### PR TITLE
sales order grid filters show in the bottom hidden

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -17,6 +17,8 @@
 
 namespace Taxjar\SalesTax\Model;
 
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+
 class Transaction
 {
     /**
@@ -178,7 +180,7 @@ class Transaction
             }
 
             $lineItem = [
-                'id' => $item->getItemId(),
+                'id' => $this->getLineItemId($item),
                 'quantity' => (int) $item->getQtyOrdered(),
                 'product_identifier' => $item->getSku(),
                 'description' => $item->getName(),
@@ -205,6 +207,25 @@ class Transaction
         }
 
         return $lineItems;
+    }
+
+    /**
+     * @param $item
+     * @return string
+     */
+    public function getLineItemId($item)
+    {
+        $id = $item->getProductId();
+
+        if ($item->getProductType() == Configurable::TYPE_CODE) {
+            $childrenItems = $item->getChildrenItems();
+            if (!empty($childrenItems)) {
+                $childItem = $childrenItems[0];
+                $id = $item->getProductId() . '_' . $childItem->getProductId();
+            }
+        }
+
+        return $id;
     }
 
     /**

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -19,4 +19,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module:etc/module.xsd">
     <!-- Database Setup Version -->
     <module name="Taxjar_SalesTax" setup_version="0.7.0"/>
+    <sequence>
+        <module name="Magento_Sales"/>
+    </sequence>
 </config>


### PR DESCRIPTION
Due to lack of priority into modules, if Magento_Sales is loaded in config.php later than taxjar module, the sales/order grid filters will be hidden under the grid, not visible before the grid.