### PR TITLE
sales order grid filters show in the bottom hidden

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -19,4 +19,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module:etc/module.xsd">
     <!-- Database Setup Version -->
     <module name="Taxjar_SalesTax" setup_version="0.7.0"/>
+    <sequence>
+        <module name="Magento_Sales"/>
+    </sequence>
 </config>


### PR DESCRIPTION
- if the sequence is not set, it could be the case to end up with this module in the config file before the Magento_Sales module, which is going to make  filter block in the adminhtml/sales/order grid invisible and move it after the grid.
