### PR TITLE
configurable product id support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "taxjar/module-taxjar",
     "description": "TaxJar Sales Tax Module for Magento 2",
     "type": "magento2-module",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "license": "OSL-3.0",
     "require": {
         "magento/framework": "^100.1.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -19,4 +19,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module:etc/module.xsd">
     <!-- Database Setup Version -->
     <module name="Taxjar_SalesTax" setup_version="0.7.0"/>
+    <sequence>
+        <module name="Magento_Sales"/>
+    </sequence>
 </config>


### PR DESCRIPTION
for the configurable products export, the id should be unique to work. In the case of a configurable product, the initial id was taken from the configurable product. So if was the case where a client will by the same configurable product with different child products, the import will fail due to having the same id on both exported items. From a previous discussion i've understand that you accept id's that are not integers, so no the exported item id is : configurableProductId_simpleProductId.