### PR TITLE
Transaction Sync Improvements

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -158,11 +158,12 @@ class Transaction
     /**
      * Build line items for SmartCalcs request
      *
+     * @param \Magento\Sales\Model\Order $order
      * @param array $items
      * @param string $type
      * @return array
      */
-    protected function buildLineItems($items, $type = 'order') {
+    protected function buildLineItems($order, $items, $type = 'order') {
         $lineItems = [];
         $parentDiscounts = $this->getParentDiscounts($items);
 
@@ -202,6 +203,15 @@ class Transaction
             }
 
             $lineItems['line_items'][] = $lineItem;
+        }
+
+        if ($order->getShippingDiscountAmount() > 0) {
+            $shippingDiscount = (float) $order->getShippingDiscountAmount();
+
+            $lineItems['line_items'][] = [
+                'description' => 'Shipping Discount',
+                'discount' => $shippingDiscount
+            ];
         }
 
         return $lineItems;

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -183,7 +183,7 @@ class Transaction
             }
 
             $lineItem = [
-                'id' => $item->getItemId(),
+                'id' => $item->getOrderItemId() ? $item->getOrderItemId() : $item->getItemId(),
                 'quantity' => (int) $item->getQtyOrdered(),
                 'product_identifier' => $item->getSku(),
                 'description' => $item->getName(),

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -166,7 +166,7 @@ class Transaction
     protected function buildLineItems($order, $items, $type = 'order') {
         $lineItems = [];
         $parentDiscounts = $this->getParentAmounts('discount', $items);
-        $parentTaxAmounts = $this->getParentAmounts('tax', $items);
+        $parentTaxes = $this->getParentAmounts('tax', $items);
 
         foreach ($items as $item) {
             if ($item->getParentItemId()) {
@@ -177,26 +177,26 @@ class Transaction
                 continue;
             }
 
-            $id = $item->getOrderItemId() ? $item->getOrderItemId() : $item->getItemId();
+            $itemId = $item->getOrderItemId() ? $item->getOrderItemId() : $item->getItemId();
             $discount = (float) $item->getDiscountAmount();
-            $taxAmount = (float) $item->getTaxAmount();
+            $tax = (float) $item->getTaxAmount();
 
-            if (isset($parentDiscounts[$id])) {
-                $discount = $parentDiscounts[$id] ?: $discount;
+            if (isset($parentDiscounts[$itemId])) {
+                $discount = $parentDiscounts[$itemId] ?: $discount;
             }
 
-            if (isset($parentTaxAmounts[$id])) {
-                $taxAmount = $parentTaxAmounts[$id] ?: $taxAmount;
+            if (isset($parentTaxes[$itemId])) {
+                $tax = $parentTaxes[$itemId] ?: $tax;
             }
 
             $lineItem = [
-                'id' => $id,
+                'id' => $itemId,
                 'quantity' => (int) $item->getQtyOrdered(),
                 'product_identifier' => $item->getSku(),
                 'description' => $item->getName(),
                 'unit_price' => (float) $item->getPrice(),
                 'discount' => $discount,
-                'sales_tax' => $taxAmount
+                'sales_tax' => $tax
             ];
 
             if ($type == 'refund') {

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -172,6 +172,10 @@ class Transaction
                 continue;
             }
 
+            if (method_exists($item, 'getOrderItem') && $item->getOrderItem()->getParentItemId()) {
+                continue;
+            }
+
             $discount = (float) $item->getDiscountAmount();
 
             if (isset($parentDiscounts[$item->getId()])) {

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -59,7 +59,7 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
             $newOrder,
             $this->buildFromAddress(),
             $this->buildToAddress($order),
-            $this->buildLineItems($order->getAllItems())
+            $this->buildLineItems($order, $order->getAllItems())
         );
 
         return $this->request;

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -67,7 +67,7 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
             $refund,
             $this->buildFromAddress(),
             $this->buildToAddress($order),
-            $this->buildLineItems($creditmemo->getAllItems(), 'refund')
+            $this->buildLineItems($order, $creditmemo->getAllItems(), 'refund')
         );
 
         return $this->request;

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -113,7 +113,21 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
                 $this->logger->log('Refund #' . $this->request['transaction_id'] . ' updated: ' . json_encode($response), 'api');
             }
 
-            $this->originalRefund->setTjSalestaxSyncDate(gmdate('Y-m-d H:i:s'))->save();
+            $originalAmountRefunded = $this->originalOrder->getAmountRefunded();
+            $originalBaseAmountRefunded = $this->originalOrder->getBaseAmountRefunded();
+            $originalBaseAmountRefundedOnline = $this->originalOrder->getBaseAmountRefundedOnline();
+
+            $this->originalRefund
+                ->setTjSalestaxSyncDate(gmdate('Y-m-d H:i:s'))
+                ->setPaymentRefundDisallowed(true)
+                ->setAutomaticallyCreated(true)
+                ->save();
+
+            $this->originalOrder
+                ->setAmountRefunded($originalAmountRefunded)
+                ->setBaseAmountRefunded($originalBaseAmountRefunded)
+                ->setBaseAmountRefundedOnline($originalBaseAmountRefundedOnline)
+                ->save();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->logger->log('Error: ' . $e->getMessage(), 'error');
             $error = json_decode($e->getMessage());

--- a/Observer/BackfillTransactions.php
+++ b/Observer/BackfillTransactions.php
@@ -193,15 +193,18 @@ class BackfillTransactions implements ObserverInterface
 
         foreach ($orders as $order) {
             $orderTransaction = $this->orderFactory->create();
-            $orderTransaction->build($order);
-            $orderTransaction->push();
 
-            $creditMemos = $order->getCreditmemosCollection();
+            if ($orderTransaction->isSyncable($order)) {
+                $orderTransaction->build($order);
+                $orderTransaction->push();
 
-            foreach ($creditMemos as $creditMemo) {
-                $refundTransaction = $this->refundFactory->create();
-                $refundTransaction->build($order, $creditMemo);
-                $refundTransaction->push();
+                $creditMemos = $order->getCreditmemosCollection();
+
+                foreach ($creditMemos as $creditMemo) {
+                    $refundTransaction = $this->refundFactory->create();
+                    $refundTransaction->build($order, $creditMemo);
+                    $refundTransaction->push();
+                }
             }
         }
 

--- a/view/adminhtml/templates/order/creditmemo/view/synced.phtml
+++ b/view/adminhtml/templates/order/creditmemo/view/synced.phtml
@@ -40,6 +40,7 @@ if ($block->getSyncedAtDate($creditmemo)) {
     );
 }
 ?>
+<?php if (!empty($orderSyncDate)): ?>
 <tr>
     <th><?php /* @escapeNotVerified */ echo __('Order Synced to TaxJar') ?></th>
     <td><?php /* @escapeNotVerified */ echo $orderSyncDate ?></td>
@@ -48,3 +49,4 @@ if ($block->getSyncedAtDate($creditmemo)) {
     <th><?php /* @escapeNotVerified */ echo __('Credit Memo Synced to TaxJar') ?></th>
     <td><?php /* @escapeNotVerified */ echo $creditmemoSyncDate ?></td>
 </tr>
+<?php endif; ?>

--- a/view/adminhtml/templates/order/view/synced.phtml
+++ b/view/adminhtml/templates/order/view/synced.phtml
@@ -30,7 +30,9 @@ if ($block->getSyncedAtDate($order)) {
     );
 }
 ?>
+<?php if (!empty($orderSyncDate)): ?>
 <tr>
     <th><?php /* @escapeNotVerified */ echo __('Synced to TaxJar') ?></th>
     <td><?php /* @escapeNotVerified */ echo $orderSyncDate ?></td>
 </tr>
+<?php endif; ?>


### PR DESCRIPTION
This PR includes the following updates for transaction sync:

- Ensure non-US, non-USD orders are filtered during backfill similar to real-time sync.

- Pass shipping discounts as a separate line item since our API doesn't support an order-level shipping discount parameter. This prevents "Order amount must be equal to the sum of line items and shipping" errors during sync for orders with coupons applied to the shipping amount.

- Fix line item `id` parameters for credit memo line items. No problems previously, but it should be populated correctly.

- Skip configurable product children when creating a credit memo.

- Only pass `discount` and `sales_tax` for base configurable / bundle product line items, not children. Magento includes the discount and sales tax by child, so we need to add up the child amounts for the parent item. Previously we were passing the child line items when creating credit memos with the correct discounts and sales tax, so this cleans up the line item list when viewing a transaction in TaxJar.

- Hide sync dates for orders and credit memos if empty. Continue to show existing sync dates even if transaction sync is disabled.

- Prevent duplicate order comments and total amount refunded when syncing a credit memo. In Magento, credit memos aren't editable. Saving the sync date on a credit memo was adding a new order comment and doubling the order total amount refunded, although just one credit memo was created. This PR fixes the display issues and re-saves the original total refund amount on the order.

- Tested on Magento 2.1 and 2.2 RC.