### PR TITLE
Bundle Product Calculation Fixes

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -331,14 +331,26 @@ class Smartcalcs
         $items = $quoteTaxDetails->getItems();
 
         if (count($items) > 0) {
+            $parentQuantities = [];
+
             foreach ($items as $item) {
                 if ($item->getType() == 'product') {
                     $id = $item->getCode();
+                    $parentId = $item->getParentCode();
                     $quantity = $item->getQuantity();
                     $unitPrice = (float) $item->getUnitPrice();
                     $discount = (float) $item->getDiscountAmount();
                     $extensionAttributes = $item->getExtensionAttributes();
                     $taxCode = '';
+
+                    if ($extensionAttributes->getProductType() == \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE) {
+                        $parentQuantities[$id] = $quantity;
+                        continue;
+                    }
+
+                    if (isset($parentQuantities[$parentId])) {
+                        $quantity *= $parentQuantities[$parentId];
+                    }
 
                     if (!$this->taxData->applyTaxAfterDiscount($store)) {
                         $discount = 0;

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -345,7 +345,10 @@ class Smartcalcs
 
                     if ($extensionAttributes->getProductType() == \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE) {
                         $parentQuantities[$id] = $quantity;
-                        continue;
+
+                        if ($extensionAttributes->getPriceType() == \Magento\Bundle\Model\Product\Price::PRICE_TYPE_DYNAMIC) {
+                            continue;
+                        }
                     }
 
                     if (isset($parentQuantities[$parentId])) {

--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -280,6 +280,7 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
         $extensionAttributes->setTaxCollectable($lineItemTax['tax_collectable']);
         $extensionAttributes->setCombinedTaxRate($lineItemTax['combined_tax_rate'] * 100);
         $extensionAttributes->setProductType($item->getProductType());
+        $extensionAttributes->setPriceType($item->getProduct()->getPriceType());
 
         $jurisdictions = ['country', 'state', 'county', 'city', 'special', 'gst', 'pst', 'qst'];
         $jurisdictionRates = [];

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -22,5 +22,6 @@
         <attribute code="combined_tax_rate" type="float" />
         <attribute code="jurisdiction_tax_rates" type="array" />
         <attribute code="product_type" type="string" />
+        <attribute code="price_type" type="string" />
     </extension_attributes>
 </config>


### PR DESCRIPTION
This PR will only pass the child items associated with the bundle product and correctly process the quantity before making a request to SmartCalcs, similar to our M1 extension.

Also fixes calculations for bundle products with fixed pricing.

**Dynamic pricing** includes the unit price for both the bundle product and its associated simple products, which would add the amount multiple times if we didn't skip the base product.

**Fixed pricing** includes the unit price for just the bundle product, so we need to make sure it's included when building out the line items. The associated products have a $0 unit price so they're not included.