### PR TITLE
Fix Refund Transaction Sync

### DIFF
--- a/Observer/SyncRefund.php
+++ b/Observer/SyncRefund.php
@@ -22,9 +22,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Registry;
-use Magento\Sales\Api\OrderRepositoryInterface;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
-use Taxjar\SalesTax\Model\Logger;
 use Taxjar\SalesTax\Model\Transaction\OrderFactory;
 use Taxjar\SalesTax\Model\Transaction\RefundFactory;
 
@@ -39,16 +37,6 @@ class SyncRefund implements ObserverInterface
      * @var \Magento\Framework\Message\ManagerInterface
      */
     protected $messageManager;
-
-    /**
-     * @var \Magento\Sales\Api\OrderRepositoryInterface
-     */
-    protected $orderRepository;
-
-    /**
-     * @var \Taxjar\SalesTax\Model\Logger
-     */
-    protected $logger;
 
     /**
      * @var \Taxjar\SalesTax\Model\Transaction\OrderFactory
@@ -68,28 +56,22 @@ class SyncRefund implements ObserverInterface
     /**
      * @param ScopeConfigInterface $scopeConfig
      * @param ManagerInterface $messageManager
-     * @param OrderRepositoryInterface $orderRepository
      * @param OrderFactory $orderFactory
      * @param RefundFactory $refundFactory
      * @param Registry $registry
-     * @param Logger $logger
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
         ManagerInterface $messageManager,
-        OrderRepositoryInterface $orderRepository,
         OrderFactory $orderFactory,
         RefundFactory $refundFactory,
-        Registry $registry,
-        Logger $logger
+        Registry $registry
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->messageManager = $messageManager;
-        $this->orderRepository = $orderRepository;
         $this->orderFactory = $orderFactory;
         $this->refundFactory = $refundFactory;
         $this->registry = $registry;
-        $this->logger = $logger;
     }
 
     /**

--- a/Observer/SyncTransaction.php
+++ b/Observer/SyncTransaction.php
@@ -24,7 +24,6 @@ use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Registry;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
-use Taxjar\SalesTax\Model\Logger;
 use Taxjar\SalesTax\Model\Transaction\OrderFactory;
 use Taxjar\SalesTax\Model\Transaction\RefundFactory;
 
@@ -44,11 +43,6 @@ class SyncTransaction implements ObserverInterface
      * @var \Magento\Sales\Api\OrderRepositoryInterface
      */
     protected $orderRepository;
-
-    /**
-     * @var \Taxjar\SalesTax\Model\Logger
-     */
-    protected $logger;
 
     /**
      * @var \Taxjar\SalesTax\Model\Transaction\OrderFactory
@@ -72,7 +66,6 @@ class SyncTransaction implements ObserverInterface
      * @param OrderFactory $orderFactory
      * @param RefundFactory $refundFactory
      * @param Registry $registry
-     * @param Logger $logger
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
@@ -80,8 +73,7 @@ class SyncTransaction implements ObserverInterface
         OrderRepositoryInterface $orderRepository,
         OrderFactory $orderFactory,
         RefundFactory $refundFactory,
-        Registry $registry,
-        Logger $logger
+        Registry $registry
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->messageManager = $messageManager;
@@ -89,7 +81,6 @@ class SyncTransaction implements ObserverInterface
         $this->orderFactory = $orderFactory;
         $this->refundFactory = $refundFactory;
         $this->registry = $registry;
-        $this->logger = $logger;
     }
 
     /**

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -20,4 +20,7 @@
     <event name="sales_order_save_after">
         <observer name="taxjar_salestax_sync_transaction" instance="Taxjar\SalesTax\Observer\SyncTransaction"/>
     </event>
+    <event name="sales_order_creditmemo_save_after">
+        <observer name="taxjar_salestax_sync_refund" instance="Taxjar\SalesTax\Observer\SyncRefund"/>
+    </event>
 </config>


### PR DESCRIPTION
When a credit memo is created in Magento, the `sales_order_save_after `event is [called before the credit memo is saved](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Sales/Model/Service/CreditmemoService.php#L180-L182). This means the credit memo won't be pushed to TaxJar as a refund until a transaction backfill is performed later.

This PR creates a new observer for the `sales_order_creditmemo_save_after` event to get the exact credit memo to sync. Once a credit memo is created for a syncable order, we'll update the order in TaxJar and push the new credit memo. Fixes #16.