### PR TITLE
Transaction Sync CLI Command

### DIFF
--- a/Console/Command/SyncTransactionsCommand.php
+++ b/Console/Command/SyncTransactionsCommand.php
@@ -84,7 +84,7 @@ class SyncTransactionsCommand extends Command
                 'to_date' => $input->getArgument(self::TO_ARGUMENT)
             ]);
         } catch (\Exception $e) {
-            $output->writeln('Failed to sync transactions: ' . $e->getMessage());
+            $output->writeln(PHP_EOL . '<error>Failed to sync transactions: ' . $e->getMessage() . '</error>');
         }
     }
 }

--- a/Console/Command/SyncTransactionsCommand.php
+++ b/Console/Command/SyncTransactionsCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Taxjar\SalesTax\Console\Command;
+
+use Magento\Framework\App\State;
+use Magento\Framework\Event\Manager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Taxjar\SalesTax\Model\Logger;
+use Taxjar\SalesTax\Model\Transaction\Backfill;
+
+class SyncTransactionsCommand extends Command
+{
+    const FROM_ARGUMENT = '<from>';
+    const TO_ARGUMENT = '<to>';
+
+    /**
+     * @var \Magento\Framework\App\State
+     */
+    protected $state;
+
+    /**
+     * @var \Magento\Framework\Event\ManagerInterface
+     */
+    protected $eventManager;
+
+    /**
+     * @var \Taxjar\SalesTax\Model\Logger
+     */
+    protected $logger;
+
+    /**
+     * @var \Taxjar\SalesTax\Model\Transaction\Backfill
+     */
+    protected $backfill;
+
+    /**
+     * @param State $state
+     * @param ManagerInterface $eventManager
+     * @param Logger $logger
+     * @param Backfill $backfill
+     */
+    public function __construct(
+        State $state,
+        Manager $eventManager,
+        Logger $logger,
+        Backfill $backfill
+    ) {
+        $this->state = $state;
+        $this->eventManager = $eventManager;
+        $this->logger = $logger;
+        $this->backfill = $backfill;
+        parent::__construct();
+    }
+
+    /**
+     * Sets config for CLI command
+     */
+    protected function configure()
+    {
+        $this->setName('taxjar:transactions:sync')
+            ->setDescription('Sync transactions from Magento to TaxJar')
+            ->addArgument(self::FROM_ARGUMENT, InputArgument::OPTIONAL)
+            ->addArgument(self::TO_ARGUMENT, InputArgument::OPTIONAL);
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return string
+     */
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output
+    ) {
+        try {
+            $this->state->setAreaCode('adminhtml');
+            $this->logger->console($output);
+            $this->backfill->start([
+                'from_date' => $input->getArgument(self::FROM_ARGUMENT),
+                'to_date' => $input->getArgument(self::TO_ARGUMENT)
+            ]);
+        } catch (\Exception $e) {
+            $output->writeln('Failed to sync transactions: ' . $e->getMessage());
+        }
+    }
+}

--- a/Model/Logger.php
+++ b/Model/Logger.php
@@ -43,6 +43,11 @@ class Logger
     protected $isRecording;
 
     /**
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected $console;
+
+    /**
      * @param \Magento\Framework\App\Filesystem\DirectoryList $directoryList
      * @param \Magento\Framework\Filesystem\Driver\File $driverFile
      */
@@ -83,6 +88,9 @@ class Logger
             if ($this->isRecording) {
                 $this->playback[] = $message;
             }
+            if ($this->console) {
+                $this->console->write($message);
+            }
         } catch (\Exception $e) {
             // @codingStandardsIgnoreStart
             throw new LocalizedException(__('Could not write to your Magento log directory under /var/log. Please make sure the directory is created and check permissions for %1.', $this->directoryList->getPath('log')));
@@ -108,5 +116,15 @@ class Logger
     public function playback()
     {
         return $this->playback;
+    }
+
+    /**
+     * Set console output interface
+     *
+     * @return void
+     */
+    public function console($output)
+    {
+        $this->console = $output;
     }
 }

--- a/Model/Transaction/Backfill.php
+++ b/Model/Transaction/Backfill.php
@@ -223,7 +223,13 @@ class Backfill
         return $this;
     }
 
-    private function orderStateFilter($state)
+    /**
+     * Filter orders to sync by order state (e.g. completed, closed)
+     *
+     * @param string $state
+     * @return \Magento\Framework\Api\Filter
+     */
+    protected function orderStateFilter($state)
     {
         return $this->filterBuilder->setField('state')->setValue($state)->create();
     }

--- a/Model/Transaction/Backfill.php
+++ b/Model/Transaction/Backfill.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxjar\SalesTax\Model\Transaction;
+
+use Magento\Framework\Api\Filter;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+use Taxjar\SalesTax\Model\Logger;
+use Taxjar\SalesTax\Model\TransactionFactory;
+use Taxjar\SalesTax\Model\Transaction\OrderFactory;
+use Taxjar\SalesTax\Model\Transaction\RefundFactory;
+
+class Backfill
+{
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @var \Magento\Framework\App\RequestInterface
+     */
+    protected $request;
+
+    /**
+     * @var \Taxjar\SalesTax\Model\TransactionFactory
+     */
+    protected $transactionFactory;
+
+    /**
+     * @var \Taxjar\SalesTax\Model\Transaction\OrderFactory
+     */
+    protected $orderFactory;
+
+    /**
+     * @var \Taxjar\SalesTax\Model\Transaction\RefundFactory
+     */
+    protected $refundFactory;
+
+    /**
+     * @var \Magento\Sales\Api\OrderRepositoryInterface
+     */
+    protected $orderRepository;
+
+    /**
+     * @var \Magento\Framework\Api\FilterBuilder
+     */
+    protected $filterBuilder;
+
+    /**
+     * @var \Magento\Framework\Api\Search\FilterGroupBuilder
+     */
+    protected $filterGroupBuilder;
+
+    /**
+     * @var \Magento\Framework\Api\SearchCriteriaBuilder
+     */
+    protected $searchCriteriaBuilder;
+
+    /**
+     * @var \Taxjar\SalesTax\Model\Logger
+     */
+    protected $logger;
+
+    /**
+     * @param ScopeConfigInterface $scopeConfig
+     * @param RequestInterface $request
+     * @param TransactionFactory $transactionFactory
+     * @param OrderFactory $orderFactory
+     * @param RefundFactory $refundFactory
+     * @param Logger $logger
+     * @param \Magento\Sales\Api\OrderRepositoryInterface $orderRepository
+     * @param \Magento\Framework\Api\FilterBuilder $filterBuilder
+     * @param \Magento\Framework\Api\Search\FilterGroupBuilder $filterGroupBuilder
+     * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        RequestInterface $request,
+        TransactionFactory $transactionFactory,
+        OrderFactory $orderFactory,
+        RefundFactory $refundFactory,
+        Logger $logger,
+        \Magento\Sales\Api\OrderRepositoryInterface $orderRepository,
+        \Magento\Framework\Api\FilterBuilder $filterBuilder,
+        \Magento\Framework\Api\Search\FilterGroupBuilder $filterGroupBuilder,
+        \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {
+        $this->scopeConfig = $scopeConfig;
+        $this->request = $request;
+        $this->transactionFactory = $transactionFactory;
+        $this->orderFactory = $orderFactory;
+        $this->refundFactory = $refundFactory;
+        $this->logger = $logger;
+        $this->orderRepository = $orderRepository;
+        $this->filterBuilder = $filterBuilder;
+        $this->filterGroupBuilder = $filterGroupBuilder;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+    }
+
+    /**
+     * Start the transaction backfill process
+     *
+     * @param array $data
+     * @return $this
+     */
+    public function start(
+        array $data = []
+    ) {
+        // @codingStandardsIgnoreEnd
+        $apiKey = trim($this->scopeConfig->getValue(TaxjarConfig::TAXJAR_APIKEY));
+
+        if (!$apiKey) {
+            throw new LocalizedException(__('Could not sync transactions with TaxJar. Please make sure you have an API key.'));
+        }
+
+        $statesToMatch = ['complete', 'closed'];
+        $fromDate = $this->request->getParam('from_date');
+        $toDate = $this->request->getParam('to_date');
+
+        if (isset($data['from_date'])) {
+            $fromDate = $data['from_date'];
+        }
+
+        if (isset($data['to_date'])) {
+            $toDate = $data['to_date'];
+        }
+
+        $this->logger->log('Initializing TaxJar transaction sync');
+
+        if (!empty($fromDate)) {
+            $fromDate = (new \DateTime($fromDate));
+        } else {
+            $fromDate = (new \DateTime())->sub(new \DateInterval('P1D'));
+        }
+
+        if (!empty($toDate)) {
+            $toDate = (new \DateTime($toDate));
+        } else {
+            $toDate = (new \DateTime());
+        }
+
+        if ($fromDate > $toDate) {
+            throw new LocalizedException(__("To date can't be earlier than from date."));
+        }
+
+        $this->logger->log('Finding ' . implode(', ', $statesToMatch) . ' transactions from ' . $fromDate->format('m/d/Y') . ' - ' . $toDate->format('m/d/Y'));
+
+        $fromDate->setTime(0, 0, 0);
+        $toDate->setTime(23, 59, 59);
+
+        $fromFilter = $this->filterBuilder->setField('updated_at')
+            ->setConditionType('gteq')
+            ->setValue($fromDate->format('Y-m-d H:i:s'))
+            ->create();
+
+        $fromFilterGroup = $this->filterGroupBuilder
+            ->setFilters([$fromFilter])
+            ->create();
+
+        $toFilter = $this->filterBuilder->setField('updated_at')
+            ->setConditionType('lteq')
+            ->setValue($toDate->format('Y-m-d H:i:s'))
+            ->create();
+
+        $toFilterGroup = $this->filterGroupBuilder
+            ->setFilters([$toFilter])
+            ->create();
+
+        $stateFilterGroup = $this->filterGroupBuilder
+            ->setFilters(array_map([$this, 'orderStateFilter'], $statesToMatch))
+            ->create();
+
+        $criteria = $this->searchCriteriaBuilder
+            ->setFilterGroups([$fromFilterGroup, $toFilterGroup, $stateFilterGroup])
+            ->create();
+
+        $orderResult = $this->orderRepository->getList($criteria);
+        $orders = $orderResult->getItems();
+
+        $this->logger->log(count($orders) . ' transaction(s) found');
+
+        // This process can take awhile
+        @set_time_limit(0);
+        @ignore_user_abort(true);
+
+        foreach ($orders as $order) {
+            $orderTransaction = $this->orderFactory->create();
+
+            if ($orderTransaction->isSyncable($order)) {
+                $orderTransaction->build($order);
+                $orderTransaction->push();
+
+                $creditMemos = $order->getCreditmemosCollection();
+
+                foreach ($creditMemos as $creditMemo) {
+                    $refundTransaction = $this->refundFactory->create();
+                    $refundTransaction->build($order, $creditMemo);
+                    $refundTransaction->push();
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    private function orderStateFilter($state)
+    {
+        return $this->filterBuilder->setField('state')->setValue($state)->create();
+    }
+}

--- a/Observer/BackfillTransactions.php
+++ b/Observer/BackfillTransactions.php
@@ -17,104 +17,24 @@
 
 namespace Taxjar\SalesTax\Observer;
 
-use Magento\Framework\Api\Filter;
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\Exception\LocalizedException;
-use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
-use Taxjar\SalesTax\Model\Logger;
-use Taxjar\SalesTax\Model\TransactionFactory;
-use Taxjar\SalesTax\Model\Transaction\OrderFactory;
-use Taxjar\SalesTax\Model\Transaction\RefundFactory;
+use Taxjar\SalesTax\Model\Transaction\Backfill;
 
 class BackfillTransactions implements ObserverInterface
 {
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var \Taxjar\SalesTax\Model\Transaction\Backfill
      */
-    protected $scopeConfig;
+    protected $backfill;
 
     /**
-     * @var \Magento\Framework\App\RequestInterface
-     */
-    protected $request;
-
-    /**
-     * @var \Taxjar\SalesTax\Model\TransactionFactory
-     */
-    protected $transactionFactory;
-
-    /**
-     * @var \Taxjar\SalesTax\Model\Transaction\OrderFactory
-     */
-    protected $orderFactory;
-
-    /**
-     * @var \Taxjar\SalesTax\Model\Transaction\RefundFactory
-     */
-    protected $refundFactory;
-
-    /**
-     * @var \Magento\Sales\Api\OrderRepositoryInterface
-     */
-    protected $orderRepository;
-
-    /**
-     * @var \Magento\Framework\Api\FilterBuilder
-     */
-    protected $filterBuilder;
-
-    /**
-     * @var \Magento\Framework\Api\Search\FilterGroupBuilder
-     */
-    protected $filterGroupBuilder;
-
-    /**
-     * @var \Magento\Framework\Api\SearchCriteriaBuilder
-     */
-    protected $searchCriteriaBuilder;
-
-    /**
-     * @var \Taxjar\SalesTax\Model\Logger
-     */
-    protected $logger;
-
-    /**
-     * @param ScopeConfigInterface $scopeConfig
-     * @param RequestInterface $request
-     * @param TransactionFactory $transactionFactory
-     * @param OrderFactory $orderFactory
-     * @param RefundFactory $refundFactory
-     * @param Logger $logger
-     * @param \Magento\Sales\Api\OrderRepositoryInterface $orderRepository
-     * @param \Magento\Framework\Api\FilterBuilder $filterBuilder
-     * @param \Magento\Framework\Api\Search\FilterGroupBuilder $filterGroupBuilder
-     * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param Backfill $backfill
      */
     public function __construct(
-        ScopeConfigInterface $scopeConfig,
-        RequestInterface $request,
-        TransactionFactory $transactionFactory,
-        OrderFactory $orderFactory,
-        RefundFactory $refundFactory,
-        Logger $logger,
-        \Magento\Sales\Api\OrderRepositoryInterface $orderRepository,
-        \Magento\Framework\Api\FilterBuilder $filterBuilder,
-        \Magento\Framework\Api\Search\FilterGroupBuilder $filterGroupBuilder,
-        \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
+        Backfill $backfill
     ) {
-        $this->scopeConfig = $scopeConfig;
-        $this->request = $request;
-        $this->transactionFactory = $transactionFactory;
-        $this->orderFactory = $orderFactory;
-        $this->refundFactory = $refundFactory;
-        $this->logger = $logger;
-        $this->orderRepository = $orderRepository;
-        $this->filterBuilder = $filterBuilder;
-        $this->filterGroupBuilder = $filterGroupBuilder;
-        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->backfill = $backfill;
     }
 
     /**
@@ -126,93 +46,7 @@ class BackfillTransactions implements ObserverInterface
     // @codingStandardsIgnoreStart
     public function execute(Observer $observer)
     {
-        // @codingStandardsIgnoreEnd
-        $apiKey = trim($this->scopeConfig->getValue(TaxjarConfig::TAXJAR_APIKEY));
-
-        if (!$apiKey) {
-            throw new LocalizedException(__('Could not sync transactions with TaxJar. Please make sure you have an API key.'));
-        }
-
-        $statesToMatch = ['complete', 'closed'];
-        $fromDate = $this->request->getParam('from_date');
-        $toDate = $this->request->getParam('to_date');
-
-        $this->logger->log('Initializing TaxJar transaction sync');
-
-        if (!empty($fromDate)) {
-            $fromDate = (new \DateTime($fromDate));
-        } else {
-            $fromDate = (new \DateTime())->sub(new \DateInterval('P1D'));
-        }
-
-        if (!empty($toDate)) {
-            $toDate = (new \DateTime($toDate));
-        } else {
-            $toDate = (new \DateTime());
-        }
-
-        if ($fromDate > $toDate) {
-            throw new LocalizedException(__("To date can't be earlier than from date."));
-        }
-
-        $this->logger->log('Finding ' . implode(', ', $statesToMatch) . ' transactions from ' . $fromDate->format('m/d/Y') . ' - ' . $toDate->format('m/d/Y'));
-
-        $fromDate->setTime(0, 0, 0);
-        $toDate->setTime(23, 59, 59);
-
-        $fromFilter = $this->filterBuilder->setField('updated_at')
-            ->setConditionType('gteq')
-            ->setValue($fromDate->format('Y-m-d H:i:s'))
-            ->create();
-
-        $fromFilterGroup = $this->filterGroupBuilder
-            ->setFilters([$fromFilter])
-            ->create();
-
-        $toFilter = $this->filterBuilder->setField('updated_at')
-            ->setConditionType('lteq')
-            ->setValue($toDate->format('Y-m-d H:i:s'))
-            ->create();
-
-        $toFilterGroup = $this->filterGroupBuilder
-            ->setFilters([$toFilter])
-            ->create();
-
-        $stateFilterGroup = $this->filterGroupBuilder
-            ->setFilters(array_map([$this, 'orderStateFilter'], $statesToMatch))
-            ->create();
-
-        $criteria = $this->searchCriteriaBuilder
-            ->setFilterGroups([$fromFilterGroup, $toFilterGroup, $stateFilterGroup])
-            ->create();
-
-        $orderResult = $this->orderRepository->getList($criteria);
-        $orders = $orderResult->getItems();
-
-        $this->logger->log(count($orders) . ' transaction(s) found');
-
-        foreach ($orders as $order) {
-            $orderTransaction = $this->orderFactory->create();
-
-            if ($orderTransaction->isSyncable($order)) {
-                $orderTransaction->build($order);
-                $orderTransaction->push();
-
-                $creditMemos = $order->getCreditmemosCollection();
-
-                foreach ($creditMemos as $creditMemo) {
-                    $refundTransaction = $this->refundFactory->create();
-                    $refundTransaction->build($order, $creditMemo);
-                    $refundTransaction->push();
-                }
-            }
-        }
-
+        $this->backfill->start();
         return $this;
-    }
-
-    private function orderStateFilter($state)
-    {
-        return $this->filterBuilder->setField('state')->setValue($state)->create();
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -21,4 +21,11 @@
     <preference for="Taxjar\SalesTax\Api\Data\Tax\NexusSearchResultsInterface" type="Magento\Framework\Api\SearchResults" />
     <preference for="Taxjar\SalesTax\Api\Data\Tax\NexusInterface" type="Taxjar\SalesTax\Model\Tax\Nexus" />
     <preference for="Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface" type="Taxjar\SalesTax\Model\Tax\Nexus\Repository" />
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="SyncTransactionsCommand" xsi:type="object">Taxjar\SalesTax\Console\Command\SyncTransactionsCommand</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
This PR addresses #14 and allows merchants to backfill transactions from Magento into TaxJar via the command line:

```
bin/magento taxjar:transactions:sync
```

This will sync transactions updated within the last 24 hours. Additionally, you can provide `from` and `to` arguments to sync a date range:

```
bin/magento taxjar:transactions:sync 12/01/2017 12/31/2017
```

For merchants with lots of transactions, this is useful to avoid in-browser AJAX timeouts. I'm also calling the following functions to prevent backend timeouts, similar to syncing backup rates:

```php
@set_time_limit(0);
@ignore_user_abort(true);
```