### PR TITLE
Multi-Store Transaction Sync

### DIFF
--- a/Model/Client.php
+++ b/Model/Client.php
@@ -131,6 +131,17 @@ class Client
     }
 
     /**
+     * Set API token for client requests
+     *
+     * @param string $key
+     * @return void
+     */
+    public function setApiKey($key)
+    {
+        $this->apiKey = $key;
+    }
+
+    /**
      * @param bool $toggle
      * @return void
      */

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -17,6 +17,8 @@
 
 namespace Taxjar\SalesTax\Model\Transaction;
 
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+
 class Order extends \Taxjar\SalesTax\Model\Transaction
 {
     /**
@@ -74,6 +76,10 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
     public function push($forceMethod = null) {
         $orderUpdatedAt = $this->originalOrder->getUpdatedAt();
         $orderSyncedAt = $this->originalOrder->getTjSalestaxSyncDate();
+        $orderApiKey = trim($this->scopeConfig->getValue(TaxjarConfig::TAXJAR_APIKEY,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $this->originalOrder->getStoreId()
+        ));
 
         if (!$this->isSynced($orderSyncedAt)) {
             $method = 'POST';
@@ -84,6 +90,10 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
                 $this->logger->log('Order #' . $this->request['transaction_id'] . ' not updated since last sync', 'skip');
                 return;
             }
+        }
+
+        if ($orderApiKey) {
+            $this->client->setApiKey($orderApiKey);
         }
 
         if ($forceMethod) {

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -17,6 +17,8 @@
 
 namespace Taxjar\SalesTax\Model\Transaction;
 
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+
 class Refund extends \Taxjar\SalesTax\Model\Transaction
 {
     /**
@@ -82,6 +84,10 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
     public function push($forceMethod = null) {
         $refundUpdatedAt = $this->originalRefund->getUpdatedAt();
         $refundSyncedAt = $this->originalRefund->getTjSalestaxSyncDate();
+        $refundApiKey = trim($this->scopeConfig->getValue(TaxjarConfig::TAXJAR_APIKEY,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $this->originalOrder->getStoreId()
+        ));
 
         if (!$this->isSynced($refundSyncedAt)) {
             $method = 'POST';
@@ -94,6 +100,10 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
                                         . ' not updated since last sync', 'skip');
                 return;
             }
+        }
+
+        if ($refundApiKey) {
+            $this->client->setApiKey($refundApiKey);
         }
 
         if ($forceMethod) {


### PR DESCRIPTION
This PR allows multi-store instances to sync transactions to multiple TaxJar accounts. If you have separate business entities across multiple stores requiring different accounts, you can set a unique TaxJar API token for each store. Transaction sync will look at a given order's store ID and use the corresponding API token to make a request to SmartCalcs.

Since the order ID is retrieved during the push process, this functionality should work for both real-time transaction sync (ship + invoice or credit memo) and backfilling.