### PR TITLE
Transaction Sync Registry Tweak

### DIFF
--- a/Observer/SyncRefund.php
+++ b/Observer/SyncRefund.php
@@ -88,18 +88,18 @@ class SyncRefund implements ObserverInterface
             return $this;
         }
 
-        if (!$this->registry->registry('taxjar_sync_' . $eventName)) {
-            $this->registry->register('taxjar_sync_' . $eventName, true);
-        } else {
-            return $this;
-        }
-
         $creditmemo = $observer->getEvent()->getCreditmemo();
         $order = $creditmemo->getOrder();
 
         $orderTransaction = $this->orderFactory->create();
 
         if ($orderTransaction->isSyncable($order)) {
+            if (!$this->registry->registry('taxjar_sync_' . $eventName)) {
+                $this->registry->register('taxjar_sync_' . $eventName, true);
+            } else {
+                return $this;
+            }
+
             try {
                 $refundTransaction = $this->refundFactory->create();
                 $refundTransaction->build($order, $creditmemo);

--- a/Observer/SyncTransaction.php
+++ b/Observer/SyncTransaction.php
@@ -97,12 +97,6 @@ class SyncTransaction implements ObserverInterface
             return $this;
         }
 
-        if (!$this->registry->registry('taxjar_sync_' . $eventName)) {
-            $this->registry->register('taxjar_sync_' . $eventName, true);
-        } else {
-            return $this;
-        }
-
         if ($observer->getData('order_id')) {
             $order = $this->orderRepository->get($observer->getData('order_id'));
         } else {
@@ -112,6 +106,12 @@ class SyncTransaction implements ObserverInterface
         $orderTransaction = $this->orderFactory->create();
 
         if ($orderTransaction->isSyncable($order)) {
+            if (!$this->registry->registry('taxjar_sync_' . $eventName)) {
+                $this->registry->register('taxjar_sync_' . $eventName, true);
+            } else {
+                return $this;
+            }
+
             try {
                 $orderTransaction->build($order);
                 $orderTransaction->push();


### PR DESCRIPTION
This PR moves some registry code to prevent an order / refund from syncing multiple times into the `isSyncable` conditional block for 3rd party extensions. Modules by Xtento import shipments and invoices in separate steps, preventing the TaxJar module from properly syncing transactions.