### PR TITLE
Tax Summary Improvements

### DIFF
--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -291,12 +291,24 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
             $rate = isset($lineItemTax[$jurisdiction . '_tax_rate']) ? $lineItemTax[$jurisdiction . '_tax_rate'] : 0;
             $amount = isset($lineItemTax[$jurisdiction . '_amount']) ? $lineItemTax[$jurisdiction . '_amount'] : 0;
 
+            // US state line item rates use `state_sales_tax_rate`
             if ($jurisdiction == 'state' && isset($lineItemTax['state_sales_tax_rate'])) {
                 $rate = $lineItemTax['state_sales_tax_rate'];
             }
 
+            // US special district tax line item amounts use `special_district_amount`
             if ($jurisdiction == 'special' && isset($lineItemTax['special_district_amount'])) {
                 $amount = $lineItemTax['special_district_amount'];
+            }
+
+            // Canada line item amounts include `gst`, `pst`, and `qst`
+            if (in_array($jurisdiction, ['gst', 'pst', 'qst']) && isset($lineItemTax[$jurisdiction])) {
+                $amount = $lineItemTax[$jurisdiction];
+            }
+
+            // Country line item amounts use `country_tax_collectable`
+            if ($jurisdiction == 'country' && isset($lineItemTax['country_tax_collectable'])) {
+                $amount = $lineItemTax['country_tax_collectable'];
             }
 
             if ($rate) {

--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -287,7 +287,7 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
         $jurisdictions = ['country', 'state', 'county', 'city', 'special', 'gst', 'pst', 'qst'];
         $jurisdictionRates = [];
 
-        foreach ($jurisdictions as $jurisdiction) {
+        foreach ($jurisdictions as $jurisdictionId => $jurisdiction) {
             $rate = isset($lineItemTax[$jurisdiction . '_tax_rate']) ? $lineItemTax[$jurisdiction . '_tax_rate'] : 0;
             $amount = isset($lineItemTax[$jurisdiction . '_amount']) ? $lineItemTax[$jurisdiction . '_amount'] : 0;
 
@@ -313,6 +313,7 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
 
             if ($rate) {
                 $jurisdictionRates[$jurisdiction] = [
+                    'id' => $jurisdictionId,
                     'rate' => $rate * 100,
                     'amount' => $amount
                 ];
@@ -344,6 +345,7 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
         $extensionAttributes->setCombinedTaxRate($shippingTax['combined_tax_rate'] * 100);
         $extensionAttributes->setJurisdictionTaxRates([
             'shipping' => [
+                'id' => 'shipping',
                 'rate' => $shippingTax['combined_tax_rate'] * 100,
                 'amount' => $shippingTax['tax_collectable']
             ]

--- a/Model/Tax/TaxCalculation.php
+++ b/Model/Tax/TaxCalculation.php
@@ -257,13 +257,13 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
 
             $rateDataObject = $this->appliedTaxRateDataObjectFactory->create()
                 ->setPercent($jurisdictionTax['rate'])
-                ->setCode($jurisdiction)
+                ->setCode($jurisdictionTax['id'])
                 ->setTitle($jurisdictionTitle);
 
             $appliedTaxDataObject = $this->appliedTaxDataObjectFactory->create();
             $appliedTaxDataObject->setAmount($jurisdictionTax['amount']);
             $appliedTaxDataObject->setPercent($jurisdictionTax['rate']);
-            $appliedTaxDataObject->setTaxRateKey($jurisdiction . '-' . $item->getCode());
+            $appliedTaxDataObject->setTaxRateKey($jurisdictionTax['id']);
             $appliedTaxDataObject->setRates([$rateDataObject]);
 
             $appliedTaxes[$appliedTaxDataObject->getTaxRateKey()] = $appliedTaxDataObject;

--- a/Model/Tax/TaxCalculation.php
+++ b/Model/Tax/TaxCalculation.php
@@ -204,10 +204,7 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
         $priceInclTax = $rowTotalInclTax / $quantity;
         $discountTaxCompensationAmount = 0;
 
-        $appliedTax = $this->getAppliedTax($item, $scope);
-        $appliedTaxes = [
-            $appliedTax->getTaxRateKey() => $appliedTax
-        ];
+        $appliedTaxes = $this->getAppliedTaxes($item, $scope);
 
         return $this->taxDetailsItemDataObjectFactory->create()
              ->setCode($item->getCode())
@@ -231,35 +228,48 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
      * @return \Magento\Tax\Api\Data\AppliedTaxInterface
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    protected function getAppliedTax(
+    protected function getAppliedTaxes(
         QuoteDetailsItemInterface $item,
         $scope
     ) {
         $extensionAttributes = $item->getExtensionAttributes();
-        $taxCollectable = $extensionAttributes ? $extensionAttributes->getTaxCollectable() : 0;
-        $taxCollectable = $this->priceCurrency->convert($taxCollectable, $scope);
-        $taxPercent = $extensionAttributes ? $extensionAttributes->getCombinedTaxRate() : 0;
         $jurisdictionTaxRates = $extensionAttributes ? $extensionAttributes->getJurisdictionTaxRates() : [];
-        $rateDataObjects = [];
+        $appliedTaxes = [];
 
-        foreach ($jurisdictionTaxRates as $jurisdiction => $jurisdictionTaxRate) {
+        foreach ($jurisdictionTaxRates as $jurisdiction => $jurisdictionTax) {
+            if ($jurisdictionTax['rate'] == 0) {
+                continue;
+            }
+
             // @codingStandardsIgnoreStart
             $jurisdictionTitle = (in_array($jurisdiction, ['gst', 'pst', 'qst'])) ? strtoupper($jurisdiction) : ucfirst($jurisdiction) . ' Tax';
             // @codingStandardsIgnoreEnd
 
-            $rateDataObjects[$jurisdiction] = $this->appliedTaxRateDataObjectFactory->create()
-                ->setPercent($jurisdictionTaxRate['rate'])
+            // Display "Special District Tax" instead of "Special Tax"
+            if ($jurisdiction == 'special') {
+                $jurisdictionTitle = 'Special District Tax';
+            }
+
+            // Display "VAT" instead of "Country Tax"
+            if ($jurisdiction == 'country') {
+                $jurisdictionTitle = 'VAT';
+            }
+
+            $rateDataObject = $this->appliedTaxRateDataObjectFactory->create()
+                ->setPercent($jurisdictionTax['rate'])
                 ->setCode($jurisdiction)
                 ->setTitle($jurisdictionTitle);
+
+            $appliedTaxDataObject = $this->appliedTaxDataObjectFactory->create();
+            $appliedTaxDataObject->setAmount($jurisdictionTax['amount']);
+            $appliedTaxDataObject->setPercent($jurisdictionTax['rate']);
+            $appliedTaxDataObject->setTaxRateKey($jurisdiction . '-' . $item->getCode());
+            $appliedTaxDataObject->setRates([$rateDataObject]);
+
+            $appliedTaxes[$appliedTaxDataObject->getTaxRateKey()] = $appliedTaxDataObject;
         }
 
-        $appliedTaxDataObject = $this->appliedTaxDataObjectFactory->create();
-        $appliedTaxDataObject->setAmount($taxCollectable);
-        $appliedTaxDataObject->setPercent($taxPercent);
-        $appliedTaxDataObject->setTaxRateKey(implode(' - ', array_keys($jurisdictionTaxRates)));
-        $appliedTaxDataObject->setRates($rateDataObjects);
-
-        return $appliedTaxDataObject;
+        return $appliedTaxes;
     }
 
     /**

--- a/Test/Integration/_files/scenarios/countries/au_calculation.php
+++ b/Test/Integration/_files/scenarios/countries/au_calculation.php
@@ -82,7 +82,7 @@ $taxCalculationData['au_calculation'] = [
                 'row_total_incl_tax' => 29.99 + 3.00,
                 'applied_taxes' => [
                     [
-                        'id' => 'country',
+                        'id' => 'country-sequence-1',
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -92,7 +92,7 @@ $taxCalculationData['au_calculation'] = [
                         'rates' => [
                             [
                                 'code' => 'country',
-                                'title' => 'Country Tax',
+                                'title' => 'VAT',
                                 'percent' => 10.0
                             ]
                         ]

--- a/Test/Integration/_files/scenarios/countries/au_calculation.php
+++ b/Test/Integration/_files/scenarios/countries/au_calculation.php
@@ -82,7 +82,7 @@ $taxCalculationData['au_calculation'] = [
                 'row_total_incl_tax' => 29.99 + 3.00,
                 'applied_taxes' => [
                     [
-                        'id' => 'country-sequence-1',
+                        'id' => 0,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -91,7 +91,7 @@ $taxCalculationData['au_calculation'] = [
                         'percent' => 10.0,
                         'rates' => [
                             [
-                                'code' => 'country',
+                                'code' => 0,
                                 'title' => 'VAT',
                                 'percent' => 10.0
                             ]

--- a/Test/Integration/_files/scenarios/countries/ca_calculation.php
+++ b/Test/Integration/_files/scenarios/countries/ca_calculation.php
@@ -87,19 +87,30 @@ $taxCalculationData['ca_calculation'] = [
                 'row_total_incl_tax' => 29.99 + 3.90,
                 'applied_taxes' => [
                     [
-                        'id' => 'gst - pst',
+                        'id' => 'gst-sequence-1',
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
-                        'amount' => 3.90,
-                        'base_amount' => 3.90,
-                        'percent' => 13.0,
+                        'amount' => 1.5,
+                        'base_amount' => 1.5,
+                        'percent' => 5,
                         'rates' => [
                             [
                                 'code' => 'gst',
                                 'title' => 'GST',
                                 'percent' => 5
-                            ],
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'pst-sequence-1',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 2.4,
+                        'base_amount' => 2.4,
+                        'percent' => 8,
+                        'rates' => [
                             [
                                 'code' => 'pst',
                                 'title' => 'PST',

--- a/Test/Integration/_files/scenarios/countries/ca_calculation.php
+++ b/Test/Integration/_files/scenarios/countries/ca_calculation.php
@@ -87,34 +87,34 @@ $taxCalculationData['ca_calculation'] = [
                 'row_total_incl_tax' => 29.99 + 3.90,
                 'applied_taxes' => [
                     [
-                        'id' => 'gst-sequence-1',
+                        'id' => 5,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
                         'amount' => 1.5,
                         'base_amount' => 1.5,
-                        'percent' => 5,
+                        'percent' => 5.0,
                         'rates' => [
                             [
-                                'code' => 'gst',
+                                'code' => 5,
                                 'title' => 'GST',
-                                'percent' => 5
+                                'percent' => 5.0
                             ]
                         ]
                     ],
                     [
-                        'id' => 'pst-sequence-1',
+                        'id' => 6,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
                         'amount' => 2.4,
                         'base_amount' => 2.4,
-                        'percent' => 8,
+                        'percent' => 8.0,
                         'rates' => [
                             [
-                                'code' => 'pst',
+                                'code' => 6,
                                 'title' => 'PST',
-                                'percent' => 8
+                                'percent' => 8.0
                             ]
                         ]
                     ]

--- a/Test/Integration/_files/scenarios/countries/eu_calculation.php
+++ b/Test/Integration/_files/scenarios/countries/eu_calculation.php
@@ -83,7 +83,7 @@ $taxCalculationData['eu_calculation'] = [
                 'row_total_incl_tax' => 29.99 + 6.00,
                 'applied_taxes' => [
                     [
-                        'id' => 'country',
+                        'id' => 'country-sequence-1',
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -93,7 +93,7 @@ $taxCalculationData['eu_calculation'] = [
                         'rates' => [
                             [
                                 'code' => 'country',
-                                'title' => 'Country Tax',
+                                'title' => 'VAT',
                                 'percent' => 20.0
                             ]
                         ]

--- a/Test/Integration/_files/scenarios/countries/eu_calculation.php
+++ b/Test/Integration/_files/scenarios/countries/eu_calculation.php
@@ -83,7 +83,7 @@ $taxCalculationData['eu_calculation'] = [
                 'row_total_incl_tax' => 29.99 + 6.00,
                 'applied_taxes' => [
                     [
-                        'id' => 'country-sequence-1',
+                        'id' => 0,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -92,7 +92,7 @@ $taxCalculationData['eu_calculation'] = [
                         'percent' => 20.0,
                         'rates' => [
                             [
-                                'code' => 'country',
+                                'code' => 0,
                                 'title' => 'VAT',
                                 'percent' => 20.0
                             ]

--- a/Test/Integration/_files/scenarios/currencies/aud_with_usd_base_currency.php
+++ b/Test/Integration/_files/scenarios/currencies/aud_with_usd_base_currency.php
@@ -93,7 +93,7 @@ $taxCalculationData['aud_with_usd_base_currency'] = [
                 'base_row_total_incl_tax' => 29.99 + 3.00,
                 'applied_taxes' => [
                     [
-                        'id' => 'country-sequence-1',
+                        'id' => 0,
                         'item_id' => '1',
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -102,7 +102,7 @@ $taxCalculationData['aud_with_usd_base_currency'] = [
                         'percent' => 10.0,
                         'rates' => [
                             [
-                                'code' => 'country',
+                                'code' => 0,
                                 'title' => 'VAT',
                                 'percent' => 10.0
                             ]

--- a/Test/Integration/_files/scenarios/currencies/aud_with_usd_base_currency.php
+++ b/Test/Integration/_files/scenarios/currencies/aud_with_usd_base_currency.php
@@ -93,17 +93,17 @@ $taxCalculationData['aud_with_usd_base_currency'] = [
                 'base_row_total_incl_tax' => 29.99 + 3.00,
                 'applied_taxes' => [
                     [
-                        'id' => 'country',
+                        'id' => 'country-sequence-1',
                         'item_id' => '1',
                         'associated_item_id' => null,
                         'item_type' => 'product',
-                        'amount' => (3.00 * 1.33),
-                        'base_amount' => (3.00 * 1.33), // Base amount remains the same
+                        'amount' => 3.0,
+                        'base_amount' => 3.0, // Base amount remains the same
                         'percent' => 10.0,
                         'rates' => [
                             [
                                 'code' => 'country',
-                                'title' => 'Country Tax',
+                                'title' => 'VAT',
                                 'percent' => 10.0
                             ]
                         ]

--- a/Test/Integration/_files/scenarios/currencies/cad_with_usd_base_currency.php
+++ b/Test/Integration/_files/scenarios/currencies/cad_with_usd_base_currency.php
@@ -98,34 +98,34 @@ $taxCalculationData['cad_with_usd_base_currency'] = [
                 'base_row_total_incl_tax' => 29.99 + 3.90,
                 'applied_taxes' => [
                     [
-                        'id' => 'gst-sequence-1',
+                        'id' => 5,
                         'item_id' => '2',
                         'associated_item_id' => null,
                         'item_type' => 'product',
                         'amount' => 1.5,
                         'base_amount' => 1.5, // Base amount remains the same
-                        'percent' => 5,
+                        'percent' => 5.0,
                         'rates' => [
                             [
-                                'code' => 'gst',
+                                'code' => 5,
                                 'title' => 'GST',
-                                'percent' => 5
+                                'percent' => 5.0
                             ]
                         ]
                     ],
                     [
-                        'id' => 'pst-sequence-1',
+                        'id' => 6,
                         'item_id' => '2',
                         'associated_item_id' => null,
                         'item_type' => 'product',
                         'amount' => 2.4,
                         'base_amount' => 2.4, // Base amount remains the same
-                        'percent' => 8,
+                        'percent' => 8.0,
                         'rates' => [
                             [
-                                'code' => 'pst',
+                                'code' => 6,
                                 'title' => 'PST',
-                                'percent' => 8
+                                'percent' => 8.0
                             ]
                         ]
                     ]

--- a/Test/Integration/_files/scenarios/currencies/cad_with_usd_base_currency.php
+++ b/Test/Integration/_files/scenarios/currencies/cad_with_usd_base_currency.php
@@ -98,19 +98,30 @@ $taxCalculationData['cad_with_usd_base_currency'] = [
                 'base_row_total_incl_tax' => 29.99 + 3.90,
                 'applied_taxes' => [
                     [
-                        'id' => 'gst - pst',
+                        'id' => 'gst-sequence-1',
                         'item_id' => '2',
                         'associated_item_id' => null,
                         'item_type' => 'product',
-                        'amount' => (3.90 * 1.28),
-                        'base_amount' => (3.90 * 1.28), // Base amount remains the same
-                        'percent' => 13.0,
+                        'amount' => 1.5,
+                        'base_amount' => 1.5, // Base amount remains the same
+                        'percent' => 5,
                         'rates' => [
                             [
                                 'code' => 'gst',
                                 'title' => 'GST',
                                 'percent' => 5
-                            ],
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'pst-sequence-1',
+                        'item_id' => '2',
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 2.4,
+                        'base_amount' => 2.4, // Base amount remains the same
+                        'percent' => 8,
+                        'rates' => [
                             [
                                 'code' => 'pst',
                                 'title' => 'PST',

--- a/Test/Integration/_files/scenarios/currencies/eur_with_usd_base_currency.php
+++ b/Test/Integration/_files/scenarios/currencies/eur_with_usd_base_currency.php
@@ -94,17 +94,17 @@ $taxCalculationData['eur_with_usd_base_currency'] = [
                 'base_row_total_incl_tax' => 29.99 + 6.00,
                 'applied_taxes' => [
                     [
-                        'id' => 'country',
+                        'id' => 'country-sequence-1',
                         'item_id' => '3',
                         'associated_item_id' => null,
                         'item_type' => 'product',
-                        'amount' => (6.00 * 0.88),
-                        'base_amount' => (6.00 * 0.88), // Base amount remains the same
+                        'amount' => 6.0,
+                        'base_amount' => 6.0, // Base amount remains the same
                         'percent' => 20.0,
                         'rates' => [
                             [
                                 'code' => 'country',
-                                'title' => 'Country Tax',
+                                'title' => 'VAT',
                                 'percent' => 20.0
                             ]
                         ]

--- a/Test/Integration/_files/scenarios/currencies/eur_with_usd_base_currency.php
+++ b/Test/Integration/_files/scenarios/currencies/eur_with_usd_base_currency.php
@@ -94,7 +94,7 @@ $taxCalculationData['eur_with_usd_base_currency'] = [
                 'base_row_total_incl_tax' => 29.99 + 6.00,
                 'applied_taxes' => [
                     [
-                        'id' => 'country-sequence-1',
+                        'id' => 0,
                         'item_id' => '3',
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -103,7 +103,7 @@ $taxCalculationData['eur_with_usd_base_currency'] = [
                         'percent' => 20.0,
                         'rates' => [
                             [
-                                'code' => 'country',
+                                'code' => 0,
                                 'title' => 'VAT',
                                 'percent' => 20.0
                             ]

--- a/Test/Integration/_files/scenarios/products/configurable_product.php
+++ b/Test/Integration/_files/scenarios/products/configurable_product.php
@@ -88,27 +88,49 @@ $taxCalculationData['configurable_product'] = [
                 'row_total_incl_tax' => 59.97 + 5.7,
                 'applied_taxes' => [
                     [
-                        'id' => 'state - county - special',
+                        'id' => 'state-sequence-1',
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
-                        'amount' => 5.70,
-                        'base_amount' => 5.70,
-                        'percent' => 9.5,
+                        'amount' => 3.75,
+                        'base_amount' => 3.75,
+                        'percent' => 6.25,
                         'rates' => [
                             [
                                 'code' => 'state',
                                 'title' => 'State Tax',
                                 'percent' => 6.25
-                            ],
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'county-sequence-1',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 0.6,
+                        'base_amount' => 0.6,
+                        'percent' => 1.0,
+                        'rates' => [
                             [
                                 'code' => 'county',
                                 'title' => 'County Tax',
-                                'percent' => 1
-                            ],
+                                'percent' => 1.0
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'special-sequence-1',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 1.35,
+                        'base_amount' => 1.35,
+                        'percent' => 2.25,
+                        'rates' => [
                             [
                                 'code' => 'special',
-                                'title' => 'Special Tax',
+                                'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]
                         ]

--- a/Test/Integration/_files/scenarios/products/configurable_product.php
+++ b/Test/Integration/_files/scenarios/products/configurable_product.php
@@ -88,7 +88,7 @@ $taxCalculationData['configurable_product'] = [
                 'row_total_incl_tax' => 59.97 + 5.7,
                 'applied_taxes' => [
                     [
-                        'id' => 'state-sequence-1',
+                        'id' => 1,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -97,14 +97,14 @@ $taxCalculationData['configurable_product'] = [
                         'percent' => 6.25,
                         'rates' => [
                             [
-                                'code' => 'state',
+                                'code' => 1,
                                 'title' => 'State Tax',
                                 'percent' => 6.25
                             ]
                         ]
                     ],
                     [
-                        'id' => 'county-sequence-1',
+                        'id' => 2,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -113,14 +113,14 @@ $taxCalculationData['configurable_product'] = [
                         'percent' => 1.0,
                         'rates' => [
                             [
-                                'code' => 'county',
+                                'code' => 2,
                                 'title' => 'County Tax',
                                 'percent' => 1.0
                             ]
                         ]
                     ],
                     [
-                        'id' => 'special-sequence-1',
+                        'id' => 4,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -129,7 +129,7 @@ $taxCalculationData['configurable_product'] = [
                         'percent' => 2.25,
                         'rates' => [
                             [
-                                'code' => 'special',
+                                'code' => 4,
                                 'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]

--- a/Test/Integration/_files/scenarios/products/simple_product.php
+++ b/Test/Integration/_files/scenarios/products/simple_product.php
@@ -76,7 +76,7 @@ $taxCalculationData['simple_product'] = [
                 'row_total_incl_tax' => 29.99 + 2.85,
                 'applied_taxes' => [
                     [
-                        'id' => 'state-sequence-1',
+                        'id' => 1,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -85,14 +85,14 @@ $taxCalculationData['simple_product'] = [
                         'percent' => 6.25,
                         'rates' => [
                             [
-                                'code' => 'state',
+                                'code' => 1,
                                 'title' => 'State Tax',
                                 'percent' => 6.25
                             ]
                         ]
                     ],
                     [
-                        'id' => 'county-sequence-1',
+                        'id' => 2,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -101,14 +101,14 @@ $taxCalculationData['simple_product'] = [
                         'percent' => 1.0,
                         'rates' => [
                             [
-                                'code' => 'county',
+                                'code' => 2,
                                 'title' => 'County Tax',
                                 'percent' => 1.0
                             ]
                         ]
                     ],
                     [
-                        'id' => 'special-sequence-1',
+                        'id' => 4,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -117,7 +117,7 @@ $taxCalculationData['simple_product'] = [
                         'percent' => 2.25,
                         'rates' => [
                             [
-                                'code' => 'special',
+                                'code' => 4,
                                 'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]
@@ -198,7 +198,7 @@ $taxCalculationData['simple_product_multiple'] = [
                 'row_total_incl_tax' => 29.99 + 2.85,
                 'applied_taxes' => [
                     [
-                        'id' => 'state-sequence-1',
+                        'id' => 1,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -207,14 +207,14 @@ $taxCalculationData['simple_product_multiple'] = [
                         'percent' => 6.25,
                         'rates' => [
                             [
-                                'code' => 'state',
+                                'code' => 1,
                                 'title' => 'State Tax',
                                 'percent' => 6.25
                             ]
                         ]
                     ],
                     [
-                        'id' => 'county-sequence-1',
+                        'id' => 2,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -223,14 +223,14 @@ $taxCalculationData['simple_product_multiple'] = [
                         'percent' => 1.0,
                         'rates' => [
                             [
-                                'code' => 'county',
+                                'code' => 2,
                                 'title' => 'County Tax',
                                 'percent' => 1.0
                             ]
                         ]
                     ],
                     [
-                        'id' => 'special-sequence-1',
+                        'id' => 4,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -239,7 +239,7 @@ $taxCalculationData['simple_product_multiple'] = [
                         'percent' => 2.25,
                         'rates' => [
                             [
-                                'code' => 'special',
+                                'code' => 4,
                                 'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]
@@ -256,7 +256,7 @@ $taxCalculationData['simple_product_multiple'] = [
                 'row_total_incl_tax' => 9.99 + 0.95,
                 'applied_taxes' => [
                     [
-                        'id' => 'state-sequence-2',
+                        'id' => 1,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -265,14 +265,14 @@ $taxCalculationData['simple_product_multiple'] = [
                         'percent' => 6.25,
                         'rates' => [
                             [
-                                'code' => 'state',
+                                'code' => 1,
                                 'title' => 'State Tax',
                                 'percent' => 6.25
                             ]
                         ]
                     ],
                     [
-                        'id' => 'county-sequence-2',
+                        'id' => 2,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -281,14 +281,14 @@ $taxCalculationData['simple_product_multiple'] = [
                         'percent' => 1.0,
                         'rates' => [
                             [
-                                'code' => 'county',
+                                'code' => 2,
                                 'title' => 'County Tax',
                                 'percent' => 1.0
                             ]
                         ]
                     ],
                     [
-                        'id' => 'special-sequence-2',
+                        'id' => 4,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -297,7 +297,7 @@ $taxCalculationData['simple_product_multiple'] = [
                         'percent' => 2.25,
                         'rates' => [
                             [
-                                'code' => 'special',
+                                'code' => 4,
                                 'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]
@@ -314,7 +314,7 @@ $taxCalculationData['simple_product_multiple'] = [
                 'row_total_incl_tax' => 59.99 + 5.7,
                 'applied_taxes' => [
                     [
-                        'id' => 'state-sequence-3',
+                        'id' => 1,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -323,14 +323,14 @@ $taxCalculationData['simple_product_multiple'] = [
                         'percent' => 6.25,
                         'rates' => [
                             [
-                                'code' => 'state',
+                                'code' => 1,
                                 'title' => 'State Tax',
                                 'percent' => 6.25
                             ]
                         ]
                     ],
                     [
-                        'id' => 'county-sequence-3',
+                        'id' => 2,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -339,14 +339,14 @@ $taxCalculationData['simple_product_multiple'] = [
                         'percent' => 1.0,
                         'rates' => [
                             [
-                                'code' => 'county',
+                                'code' => 2,
                                 'title' => 'County Tax',
                                 'percent' => 1.0
                             ]
                         ]
                     ],
                     [
-                        'id' => 'special-sequence-3',
+                        'id' => 4,
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
@@ -355,7 +355,7 @@ $taxCalculationData['simple_product_multiple'] = [
                         'percent' => 2.25,
                         'rates' => [
                             [
-                                'code' => 'special',
+                                'code' => 4,
                                 'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]

--- a/Test/Integration/_files/scenarios/products/simple_product.php
+++ b/Test/Integration/_files/scenarios/products/simple_product.php
@@ -76,27 +76,49 @@ $taxCalculationData['simple_product'] = [
                 'row_total_incl_tax' => 29.99 + 2.85,
                 'applied_taxes' => [
                     [
-                        'id' => 'state - county - special',
+                        'id' => 'state-sequence-1',
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
-                        'amount' => 2.85,
-                        'base_amount' => 2.85,
-                        'percent' => 9.5,
+                        'amount' => 1.87,
+                        'base_amount' => 1.87,
+                        'percent' => 6.25,
                         'rates' => [
                             [
                                 'code' => 'state',
                                 'title' => 'State Tax',
                                 'percent' => 6.25
-                            ],
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'county-sequence-1',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 0.3,
+                        'base_amount' => 0.3,
+                        'percent' => 1.0,
+                        'rates' => [
                             [
                                 'code' => 'county',
                                 'title' => 'County Tax',
-                                'percent' => 1
-                            ],
+                                'percent' => 1.0
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'special-sequence-1',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 0.67,
+                        'base_amount' => 0.67,
+                        'percent' => 2.25,
+                        'rates' => [
                             [
                                 'code' => 'special',
-                                'title' => 'Special Tax',
+                                'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]
                         ]
@@ -176,27 +198,49 @@ $taxCalculationData['simple_product_multiple'] = [
                 'row_total_incl_tax' => 29.99 + 2.85,
                 'applied_taxes' => [
                     [
-                        'id' => 'state - county - special',
+                        'id' => 'state-sequence-1',
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
-                        'amount' => 2.85,
-                        'base_amount' => 2.85,
-                        'percent' => 9.5,
+                        'amount' => 1.87,
+                        'base_amount' => 1.87,
+                        'percent' => 6.25,
                         'rates' => [
                             [
                                 'code' => 'state',
                                 'title' => 'State Tax',
                                 'percent' => 6.25
-                            ],
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'county-sequence-1',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 0.3,
+                        'base_amount' => 0.3,
+                        'percent' => 1.0,
+                        'rates' => [
                             [
                                 'code' => 'county',
                                 'title' => 'County Tax',
-                                'percent' => 1
-                            ],
+                                'percent' => 1.0
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'special-sequence-1',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 0.67,
+                        'base_amount' => 0.67,
+                        'percent' => 2.25,
+                        'rates' => [
                             [
                                 'code' => 'special',
-                                'title' => 'Special Tax',
+                                'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]
                         ]
@@ -212,27 +256,49 @@ $taxCalculationData['simple_product_multiple'] = [
                 'row_total_incl_tax' => 9.99 + 0.95,
                 'applied_taxes' => [
                     [
-                        'id' => 'state - county - special',
+                        'id' => 'state-sequence-2',
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
-                        'amount' => 0.95,
-                        'base_amount' => 0.95,
-                        'percent' => 9.5,
+                        'amount' => 0.62,
+                        'base_amount' => 0.62,
+                        'percent' => 6.25,
                         'rates' => [
                             [
                                 'code' => 'state',
                                 'title' => 'State Tax',
                                 'percent' => 6.25
-                            ],
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'county-sequence-2',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 0.10,
+                        'base_amount' => 0.10,
+                        'percent' => 1.0,
+                        'rates' => [
                             [
                                 'code' => 'county',
                                 'title' => 'County Tax',
-                                'percent' => 1
-                            ],
+                                'percent' => 1.0
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'special-sequence-2',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 0.22,
+                        'base_amount' => 0.22,
+                        'percent' => 2.25,
+                        'rates' => [
                             [
                                 'code' => 'special',
-                                'title' => 'Special Tax',
+                                'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]
                         ]
@@ -248,27 +314,49 @@ $taxCalculationData['simple_product_multiple'] = [
                 'row_total_incl_tax' => 59.99 + 5.7,
                 'applied_taxes' => [
                     [
-                        'id' => 'state - county - special',
+                        'id' => 'state-sequence-3',
                         'item_id' => null,
                         'associated_item_id' => null,
                         'item_type' => 'product',
-                        'amount' => 5.7,
-                        'base_amount' => 5.7,
-                        'percent' => 9.5,
+                        'amount' => 3.75,
+                        'base_amount' => 3.75,
+                        'percent' => 6.25,
                         'rates' => [
                             [
                                 'code' => 'state',
                                 'title' => 'State Tax',
                                 'percent' => 6.25
-                            ],
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'county-sequence-3',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 0.6,
+                        'base_amount' => 0.6,
+                        'percent' => 1.0,
+                        'rates' => [
                             [
                                 'code' => 'county',
                                 'title' => 'County Tax',
-                                'percent' => 1
-                            ],
+                                'percent' => 1.0
+                            ]
+                        ]
+                    ],
+                    [
+                        'id' => 'special-sequence-3',
+                        'item_id' => null,
+                        'associated_item_id' => null,
+                        'item_type' => 'product',
+                        'amount' => 1.35,
+                        'base_amount' => 1.35,
+                        'percent' => 2.25,
+                        'rates' => [
                             [
                                 'code' => 'special',
-                                'title' => 'Special Tax',
+                                'title' => 'Special District Tax',
                                 'percent' => 2.25
                             ]
                         ]


### PR DESCRIPTION
This PR fixes the display of the full tax summary (if enabled) at checkout. Jurisdiction-based rates and tax amounts are shown on each line:

<img width="303" alt="screen shot 2018-04-18 at 2 09 22 pm" src="https://user-images.githubusercontent.com/1137184/38958750-05763a32-4313-11e8-9e77-94646009e0d0.png">

Canadian GST / PST / QST breakdowns:

<img width="315" alt="screen shot 2018-04-18 at 2 10 30 pm" src="https://user-images.githubusercontent.com/1137184/38958775-1577eeb2-4313-11e8-996b-370ce9f5273d.png">

EU & Australia VAT rates:

<img width="297" alt="screen shot 2018-04-18 at 2 11 56 pm" src="https://user-images.githubusercontent.com/1137184/38958784-1eb7f350-4313-11e8-9ca6-4672a7db5563.png">
