### PR TITLE
Multi-Store Calculations

### DIFF
--- a/Api/Data/Tax/NexusInterface.php
+++ b/Api/Data/Tax/NexusInterface.php
@@ -159,6 +159,21 @@ interface NexusInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     public function setPostcode($postcode);
 
     /**
+     * Get store ID.
+     *
+     * @return int
+     */
+    public function getStoreId();
+
+    /**
+     * Set store ID.
+     *
+     * @param int $storeId
+     * @return $this
+     */
+    public function setStoreId($storeId);
+
+    /**
      * Set created at.
      *
      * @param string $createdAt

--- a/Block/Adminhtml/Tax/Nexus/Edit/Form.php
+++ b/Block/Adminhtml/Tax/Nexus/Edit/Form.php
@@ -156,21 +156,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         );
 
         $regions = $regionCollection->toOptionArray();
-        $stores = [[
-            'label' => 'All Stores',
-            'value' => 0
-        ]];
-
-        foreach ($this->storeManager->getStores() as $store) {
-            $stores[] = [
-                'label' => $store->getName(),
-                'value' => $store->getId()
-            ];
-        }
-
-        usort($stores, function ($store1, $store2) {
-            return strcmp($store1['label'], $store2['label']);
-        });
 
         $legend = $this->getShowLegend() ? __('Nexus Address Information') : '';
         $fieldset = $form->addFieldset('base_fieldset', ['legend' => $legend, 'class' => 'form-inline']);
@@ -256,11 +241,11 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             'select',
             [
                 'name' => 'store_id',
-                'label' => __('Store'),
+                'label' => __('Store View'),
                 'required' => false,
                 'value' => isset($formValues['store_id']) ? $formValues['store_id'] : '',
-                'values' => $stores,
-                'note' => __('Calculate sales tax for this nexus address in a specific Magento store. Set to "All Stores" to use this nexus address globally.')
+                'values' => $this->getStoreGroups(),
+                'note' => __('Calculate sales tax for this nexus address in a specific Magento store. Set to "All Store Views" to use this nexus address globally.')
             ]
         );
 
@@ -292,5 +277,46 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             'store_id' => $nexus->getStoreId()
         ];
         return $nexusData;
+    }
+
+    /**
+     * Retrieve list of store views
+     *
+     * @return array
+     */
+    protected function getStoreGroups()
+    {
+        $groups = [[
+            'label' => 'All Store Views',
+            'value' => 0
+        ]];
+
+        foreach ($this->storeManager->getWebsites() as $website) {
+            foreach ($website->getGroups() as $group) {
+                $stores = [];
+
+                foreach ($group->getStores() as $store) {
+                    $stores[] = [
+                        'label' => $store->getName(),
+                        'value' => $store->getId()
+                    ];
+                }
+
+                usort($stores, function ($store1, $store2) {
+                    return strcmp($store1['label'], $store2['label']);
+                });
+
+                $groups[] = [
+                    'label' => $group->getName(),
+                    'value' => $stores
+                ];
+            }
+
+            usort($groups, function ($group1, $group2) {
+                return strcmp($group1['label'], $group2['label']);
+            });
+        }
+
+        return $groups;
     }
 }

--- a/Controller/Adminhtml/Nexus.php
+++ b/Controller/Adminhtml/Nexus.php
@@ -164,6 +164,9 @@ abstract class Nexus extends \Magento\Backend\App\Action
         if (isset($postData['postcode'])) {
             $nexus->setPostcode($postData['postcode']);
         }
+        if (isset($postData['store_id'])) {
+            $nexus->setStoreId($postData['store_id']);
+        }
         return $nexus;
     }
 }

--- a/Controller/Adminhtml/Nexus/Delete.php
+++ b/Controller/Adminhtml/Nexus/Delete.php
@@ -31,9 +31,9 @@ class Delete extends \Taxjar\SalesTax\Controller\Adminhtml\Nexus
         $addressId = (int)$this->getRequest()->getParam('address');
         try {
             $nexus = $this->nexusSyncFactory->create()->load($addressId);
-            if ($nexus->getCountryId() == 'US') {
-                $nexus->syncDelete();
-            }
+            // if ($nexus->getCountryId() == 'US') {
+            //     $nexus->syncDelete();
+            // }
             $this->nexusService->deleteById($addressId);
             $this->messageManager->addSuccessMessage(__('The nexus address has been deleted.'));
             return $resultRedirect->setPath('taxjar/*/');

--- a/Controller/Adminhtml/Nexus/Save.php
+++ b/Controller/Adminhtml/Nexus/Save.php
@@ -36,10 +36,10 @@ class Save extends \Taxjar\SalesTax\Controller\Adminhtml\Nexus
             $nexus->setRegionCode($region->getCode());
 
             try {
-                if ($nexus->getCountryId() == 'US') {
-                    $nexusSync = $this->nexusSyncFactory->create(['data' => $nexus->getData()]);
-                    $nexusSync->sync();
-                }
+                // if ($nexus->getCountryId() == 'US') {
+                //     $nexusSync = $this->nexusSyncFactory->create(['data' => $nexus->getData()]);
+                //     $nexusSync->sync();
+                // }
                 $nexus = $this->nexusService->save($nexus);
 
                 $this->messageManager->addSuccessMessage(__('You saved the nexus address.'));

--- a/Model/ResourceModel/Tax/Nexus.php
+++ b/Model/ResourceModel/Tax/Nexus.php
@@ -26,20 +26,4 @@ class Nexus extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     {
         $this->_init('tax_nexus', 'id');
     }
-
-    /**
-     * Initialize unique fields
-     *
-     * @return $this
-     */
-    protected function _initUniqueFields()
-    {
-        $this->_uniqueFields = [
-            [
-                'field' => 'region_id',
-                'title' => __('Region'),
-            ],
-        ];
-        return $this;
-    }
 }

--- a/Model/ResourceModel/Tax/Nexus/Collection.php
+++ b/Model/ResourceModel/Tax/Nexus/Collection.php
@@ -111,8 +111,8 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
     {
         if (!empty($storeId)) {
             // Always include global nexus addresses
-            $storeId = array_merge([$storeId], [0]);
-            $this->addFieldToFilter('main_table.store_id', ['in' => $storeId]);
+            $storeIds = [0, $storeId];
+            $this->addFieldToFilter('main_table.store_id', ['in' => $storeIds]);
         }
         return $this;
     }

--- a/Model/ResourceModel/Tax/Nexus/Collection.php
+++ b/Model/ResourceModel/Tax/Nexus/Collection.php
@@ -100,4 +100,20 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         }
         return $this;
     }
+
+    /**
+     * Filter by store_id
+     *
+     * @param int $storeId
+     * @return $this
+     */
+    public function addStoreFilter($storeId)
+    {
+        if (!empty($storeId)) {
+            // Always include global nexus addresses
+            $storeId = array_merge([$storeId], [0]);
+            $this->addFieldToFilter('main_table.store_id', ['in' => $storeId]);
+        }
+        return $this;
+    }
 }

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -143,14 +143,29 @@ class Smartcalcs
             return;
         }
 
-        $shippingRegionId = $this->scopeConfig->getValue('shipping/origin/region_id');
+        $shippingRegionId = $this->scopeConfig->getValue('shipping/origin/region_id',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $quote->getStoreId()
+        );
 
         $fromAddress = [
-            'from_country' => $this->scopeConfig->getValue('shipping/origin/country_id'),
-            'from_zip' => $this->scopeConfig->getValue('shipping/origin/postcode'),
+            'from_country' => $this->scopeConfig->getValue('shipping/origin/country_id',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $quote->getStoreId()
+            ),
+            'from_zip' => $this->scopeConfig->getValue('shipping/origin/postcode',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $quote->getStoreId()
+            ),
             'from_state' => $this->regionFactory->create()->load($shippingRegionId)->getCode(),
-            'from_city' => $this->scopeConfig->getValue('shipping/origin/city'),
-            'from_street' => $this->scopeConfig->getValue('shipping/origin/street_line1'),
+            'from_city' => $this->scopeConfig->getValue('shipping/origin/city',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $quote->getStoreId()
+            ),
+            'from_street' => $this->scopeConfig->getValue('shipping/origin/street_line1',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $quote->getStoreId()
+            ),
         ];
 
         $toAddress = [
@@ -374,7 +389,10 @@ class Smartcalcs
 
                     if ($this->productMetadata->getEdition() == 'Enterprise') {
                         if ($extensionAttributes->getProductType() == \Magento\GiftCard\Model\Catalog\Product\Type\Giftcard::TYPE_GIFTCARD) {
-                            $giftTaxClassId = $this->scopeConfig->getValue('tax/classes/wrapping_tax_class');
+                            $giftTaxClassId = $this->scopeConfig->getValue('tax/classes/wrapping_tax_class',
+                                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                                $quote->getStoreId()
+                            );
 
                             if ($giftTaxClassId) {
                                 $giftTaxClass = $this->taxClassRepository->get($giftTaxClassId);

--- a/Model/Tax/Nexus.php
+++ b/Model/Tax/Nexus.php
@@ -32,6 +32,7 @@ class Nexus extends \Magento\Framework\Model\AbstractExtensibleModel implements
     const KEY_REGION_ID   = 'region_id';
     const KEY_REGION_CODE = 'region_code';
     const KEY_POSTCODE    = 'postcode';
+    const KEY_STORE_ID    = 'store_id';
     const KEY_CREATED_AT  = 'created_at';
     const KEY_UPDATED_AT  = 'updated_at';
     /**#@-*/
@@ -132,6 +133,16 @@ class Nexus extends \Magento\Framework\Model\AbstractExtensibleModel implements
     public function getPostcode()
     {
         return $this->getData(self::KEY_POSTCODE);
+    }
+
+    /**
+     * Get nexus store ID
+     *
+     * @return int
+     */
+    public function getStoreId()
+    {
+        return $this->getData(self::KEY_STORE_ID);
     }
 
     /**
@@ -251,6 +262,17 @@ class Nexus extends \Magento\Framework\Model\AbstractExtensibleModel implements
     public function setPostcode($postcode)
     {
         return $this->setData(self::KEY_POSTCODE, $postcode);
+    }
+
+    /**
+     * Set nexus store ID
+     *
+     * @param int $storeId
+     * @return $this
+     */
+    public function setStoreId($storeId)
+    {
+        return $this->setData(self::KEY_STORE_ID, $storeId);
     }
 
     /**

--- a/Model/Tax/Nexus/Repository.php
+++ b/Model/Tax/Nexus/Repository.php
@@ -252,13 +252,21 @@ class Repository implements \Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface
         if ($countryAddresses->getTotalCount()
         && $nexus->getCountryId() != 'US'
         && $nexus->getCountryId() != 'CA') {
-            $exception->addError(__('Only one address per country (outside of US/CA) is currently supported.'));
+            if ($nexus->getStoreId() != 0) {
+                $exception->addError(__('Only one address per country (outside of US/CA) is currently supported per store.'));
+            } else {
+                $exception->addError(__('Only one address per country (outside of US/CA) is currently supported across all stores.'));
+            }
         }
 
         if ($regionAddresses->getTotalCount()
         && ($nexus->getCountryId() == 'US'
         || $nexus->getCountryId() == 'CA')) {
-            $exception->addError(__('Only one address per region / state is currently supported.'));
+            if ($nexus->getStoreId() != 0) {
+                $exception->addError(__('Only one address per region / state is currently supported per store.'));
+            } else {
+                $exception->addError(__('Only one address per region / state is currently supported across all stores.'));
+            }
         }
 
         if ($exception->wasErrorAdded()) {

--- a/Model/Tax/NexusCollection.php
+++ b/Model/Tax/NexusCollection.php
@@ -22,6 +22,7 @@ use Magento\Framework\Api\AbstractServiceCollection;
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SortOrderBuilder;
+use Magento\Store\Model\StoreManagerInterface;
 use Taxjar\SalesTax\Api\Data\Tax\NexusInterface;
 use Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface;
 
@@ -37,21 +38,29 @@ class NexusCollection extends AbstractServiceCollection
     protected $nexusRepository;
 
     /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
      * @param EntityFactory $entityFactory
      * @param FilterBuilder $filterBuilder
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param SortOrderBuilder $sortOrderBuilder
      * @param NexusRepositoryInterface $nexusService
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         EntityFactory $entityFactory,
         FilterBuilder $filterBuilder,
         SearchCriteriaBuilder $searchCriteriaBuilder,
         SortOrderBuilder $sortOrderBuilder,
-        NexusRepositoryInterface $nexusService
+        NexusRepositoryInterface $nexusService,
+        StoreManagerInterface $storeManager
     ) {
         parent::__construct($entityFactory, $filterBuilder, $searchCriteriaBuilder, $sortOrderBuilder);
         $this->nexusRepository = $nexusService;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -84,6 +93,13 @@ class NexusCollection extends AbstractServiceCollection
         // @codingStandardsIgnoreStart
         $collectionItem = new \Magento\Framework\DataObject();
         // @codingStandardsIgnoreEnd
+
+        if ($nexus->getStoreId()) {
+            $storeName = $this->storeManager->getStore($nexus->getStoreId())->getName();
+        } else {
+            $storeName = 'All Stores';
+        }
+
         $collectionItem->setId($nexus->getId());
         $collectionItem->setApiId($nexus->getApiId());
         $collectionItem->setStreet($nexus->getStreet());
@@ -93,6 +109,7 @@ class NexusCollection extends AbstractServiceCollection
         $collectionItem->setRegionId($nexus->getRegionId());
         $collectionItem->setRegionCode($nexus->getRegionCode());
         $collectionItem->setPostcode($nexus->getPostcode());
+        $collectionItem->setStore($storeName);
 
         return $collectionItem;
     }

--- a/Model/Tax/NexusCollection.php
+++ b/Model/Tax/NexusCollection.php
@@ -97,7 +97,7 @@ class NexusCollection extends AbstractServiceCollection
         if ($nexus->getStoreId()) {
             $storeName = $this->storeManager->getStore($nexus->getStoreId())->getName();
         } else {
-            $storeName = 'All Stores';
+            $storeName = 'All Store Views';
         }
 
         $collectionItem->setId($nexus->getId());

--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -114,7 +114,10 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
             return $this;
         }
 
-        $isEnabled = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_ENABLED);
+        $isEnabled = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_ENABLED,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $quote->getStoreId()
+        );
 
         if ($isEnabled) {
             $baseQuoteTaxDetails = $this->getQuoteTaxDetailsInterface($shippingAssignment, $total, true);

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -64,5 +64,27 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
             $installer->endSetup();
         }
+
+        if (version_compare($context->getVersion(), '1.0.0') < 0) {
+            $installer = $setup;
+            $installer->startSetup();
+
+            /**
+            * Update table 'tax_nexus'
+            */
+            $installer->getConnection()->addColumn(
+                $installer->getTable('tax_nexus'),
+                'store_id',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+                    'default' => 0,
+                    'nullable' => false,
+                    'unsigned' => true,
+                    'comment' => 'Store ID'
+                ]
+            );
+
+            $installer->endSetup();
+        }
     }
 }

--- a/view/adminhtml/layout/taxjar_nexus_block.xml
+++ b/view/adminhtml/layout/taxjar_nexus_block.xml
@@ -82,6 +82,15 @@
                             <argument name="header_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="store">
+                        <arguments>
+                            <argument name="header" xsi:type="string" translate="true">Store</argument>
+                            <argument name="filter_index" xsi:type="string">store</argument>
+                            <argument name="index" xsi:type="string">store</argument>
+                            <argument name="column_css_class" xsi:type="string">col-name</argument>
+                            <argument name="header_css_class" xsi:type="string">col-name</argument>
+                        </arguments>
+                    </block>
                 </block>
             </block>
         </referenceBlock>

--- a/view/adminhtml/layout/taxjar_nexus_block.xml
+++ b/view/adminhtml/layout/taxjar_nexus_block.xml
@@ -84,7 +84,7 @@
                     </block>
                     <block class="Magento\Backend\Block\Widget\Grid\Column" as="store">
                         <arguments>
-                            <argument name="header" xsi:type="string" translate="true">Store</argument>
+                            <argument name="header" xsi:type="string" translate="true">Store View</argument>
                             <argument name="filter_index" xsi:type="string">store</argument>
                             <argument name="index" xsi:type="string">store</argument>
                             <argument name="column_css_class" xsi:type="string">col-name</argument>


### PR DESCRIPTION
This PR allows merchants to assign nexus addresses to specific stores in a single Magento instance for sales tax calculations. Additionally, multiple TaxJar API tokens can be used.

<img width="877" alt="screen shot 2018-04-19 at 5 04 47 pm" src="https://user-images.githubusercontent.com/1137184/39024157-cabd9232-43f3-11e8-8929-1898d6d7d7f3.png">

By default, all nexus addresses are globally available for "All Stores". If a nexus address is assigned to a single store, it will only be used in calculations within that store.