### PR TITLE
Discounts Applied to Shipping Amount

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -143,7 +143,8 @@ class Smartcalcs
             return;
         }
 
-        $shipping = $address->getShippingAmount() - $address->getShippingDiscountAmount();
+        $shipping = (float) $address->getShippingAmount();
+        $shippingDiscount = (float) $address->getShippingDiscountAmount();
 
         $shippingRegionId = $this->scopeConfig->getValue('shipping/origin/region_id',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
@@ -179,7 +180,7 @@ class Smartcalcs
         ];
 
         $order = array_merge($fromAddress, $toAddress, [
-            'shipping' => (float) $shipping,
+            'shipping' => $shipping - abs($shippingDiscount),
             'line_items' => $this->_getLineItems($quote, $quoteTaxDetails),
             'nexus_addresses' => $this->_getNexusAddresses($quote->getStoreId()),
             'plugin' => 'magento'

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -143,6 +143,8 @@ class Smartcalcs
             return;
         }
 
+        $shipping = $address->getShippingAmount() - $address->getShippingDiscountAmount();
+
         $shippingRegionId = $this->scopeConfig->getValue('shipping/origin/region_id',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $quote->getStoreId()
@@ -177,7 +179,7 @@ class Smartcalcs
         ];
 
         $order = array_merge($fromAddress, $toAddress, [
-            'shipping' => (float) $address->getShippingAmount(),
+            'shipping' => (float) $shipping,
             'line_items' => $this->_getLineItems($quote, $quoteTaxDetails),
             'nexus_addresses' => $this->_getNexusAddresses($quote->getStoreId()),
             'plugin' => 'magento'

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -233,15 +233,6 @@ class Transaction
             $lineItems['line_items'][] = $lineItem;
         }
 
-        if ($order->getShippingDiscountAmount() > 0) {
-            $shippingDiscount = (float) $order->getShippingDiscountAmount();
-
-            $lineItems['line_items'][] = [
-                'description' => 'Shipping Discount',
-                'discount' => $shippingDiscount
-            ];
-        }
-
         return $lineItems;
     }
 

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -42,7 +42,7 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
     ) {
         $createdAt = new \DateTime($order->getCreatedAt());
         $subtotal = (float) $order->getSubtotal();
-        $shipping = (float) $order->getShippingAmount();
+        $shipping = (float) $order->getShippingAmount() - $order->getShippingDiscountAmount();
         $discount = (float) $order->getDiscountAmount();
         $salesTax = (float) $order->getTaxAmount();
 

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -43,7 +43,7 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
         $createdAt = new \DateTime($order->getCreatedAt());
         $subtotal = (float) $order->getSubtotal();
         $shipping = (float) $order->getShippingAmount();
-        $itemDiscount = (float) $order->getDiscountAmount();
+        $discount = (float) $order->getDiscountAmount();
         $shippingDiscount = (float) $order->getShippingDiscountAmount();
         $salesTax = (float) $order->getTaxAmount();
 
@@ -53,7 +53,7 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
             'plugin' => 'magento',
             'transaction_id' => $order->getIncrementId(),
             'transaction_date' => $createdAt->format(\DateTime::ISO8601),
-            'amount' => $subtotal + $shipping - abs($itemDiscount),
+            'amount' => $subtotal + $shipping - abs($discount),
             'shipping' => $shipping - abs($shippingDiscount),
             'sales_tax' => $salesTax
         ];

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -42,8 +42,9 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
     ) {
         $createdAt = new \DateTime($order->getCreatedAt());
         $subtotal = (float) $order->getSubtotal();
-        $shipping = (float) $order->getShippingAmount() - $order->getShippingDiscountAmount();
-        $discount = (float) $order->getDiscountAmount();
+        $shipping = (float) $order->getShippingAmount();
+        $itemDiscount = (float) $order->getDiscountAmount();
+        $shippingDiscount = (float) $order->getShippingDiscountAmount();
         $salesTax = (float) $order->getTaxAmount();
 
         $this->originalOrder = $order;
@@ -52,8 +53,8 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
             'plugin' => 'magento',
             'transaction_id' => $order->getIncrementId(),
             'transaction_date' => $createdAt->format(\DateTime::ISO8601),
-            'amount' => $subtotal + $shipping - abs($discount),
-            'shipping' => $shipping,
+            'amount' => $subtotal + $shipping - abs($itemDiscount),
+            'shipping' => $shipping - abs($shippingDiscount),
             'sales_tax' => $salesTax
         ];
 

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -48,7 +48,7 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
         \Magento\Sales\Model\Order\Creditmemo $creditmemo
     ) {
         $subtotal = (float) $creditmemo->getSubtotal();
-        $shipping = (float) $creditmemo->getShippingAmount();
+        $shipping = (float) $creditmemo->getShippingAmount() - $creditmemo->getShippingDiscountAmount();
         $discount = (float) $creditmemo->getDiscountAmount();
         $salesTax = (float) $creditmemo->getTaxAmount();
 

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -49,7 +49,7 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
     ) {
         $subtotal = (float) $creditmemo->getSubtotal();
         $shipping = (float) $creditmemo->getShippingAmount();
-        $itemDiscount = (float) $creditmemo->getDiscountAmount();
+        $discount = (float) $creditmemo->getDiscountAmount();
         $shippingDiscount = (float) $creditmemo->getShippingDiscountAmount();
         $salesTax = (float) $creditmemo->getTaxAmount();
 
@@ -61,7 +61,7 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
             'transaction_id' => $creditmemo->getIncrementId() . '-refund',
             'transaction_reference_id' => $order->getIncrementId(),
             'transaction_date' => $creditmemo->getCreatedAt(),
-            'amount' => $subtotal + $shipping - abs($itemDiscount),
+            'amount' => $subtotal + $shipping - abs($discount),
             'shipping' => $shipping - abs($shippingDiscount),
             'sales_tax' => $salesTax
         ];

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -48,8 +48,9 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
         \Magento\Sales\Model\Order\Creditmemo $creditmemo
     ) {
         $subtotal = (float) $creditmemo->getSubtotal();
-        $shipping = (float) $creditmemo->getShippingAmount() - $creditmemo->getShippingDiscountAmount();
-        $discount = (float) $creditmemo->getDiscountAmount();
+        $shipping = (float) $creditmemo->getShippingAmount();
+        $itemDiscount = (float) $creditmemo->getDiscountAmount();
+        $shippingDiscount = (float) $creditmemo->getShippingDiscountAmount();
         $salesTax = (float) $creditmemo->getTaxAmount();
 
         $this->originalOrder = $order;
@@ -60,8 +61,8 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
             'transaction_id' => $creditmemo->getIncrementId() . '-refund',
             'transaction_reference_id' => $order->getIncrementId(),
             'transaction_date' => $creditmemo->getCreatedAt(),
-            'amount' => $subtotal + $shipping - abs($discount),
-            'shipping' => $shipping,
+            'amount' => $subtotal + $shipping - abs($itemDiscount),
+            'shipping' => $shipping - abs($shippingDiscount),
             'sales_tax' => $salesTax
         ];
 

--- a/Test/Integration/_files/scenarios/discounts/shopping_cart_rule_fixed.php
+++ b/Test/Integration/_files/scenarios/discounts/shopping_cart_rule_fixed.php
@@ -58,6 +58,12 @@ $taxCalculationData['shopping_cart_rule_fixed'] = [
                 'qty' => 1
             ]
         ],
+        'shipping' => [
+            'method' => 'flatrate_flatrate',
+            'description' => 'Flat Rate - Fixed',
+            'amount' => 5,
+            'base_amount' => 5,
+        ],
         'shopping_cart_rules' => [
             [
                 'discount_amount' => 20,
@@ -67,10 +73,10 @@ $taxCalculationData['shopping_cart_rule_fixed'] = [
     ],
     'expected_results' => [
         'address_data' => [
-            'tax_amount' => 0,
+            'tax_amount' => 0.44,
             'subtotal' => 19.99,
             'subtotal_incl_tax' => 19.99,
-            'grand_total' => 0
+            'grand_total' => 5 + 0.44
         ],
         'items_data' => [
             'taxjar-tshirt' => [
@@ -82,6 +88,12 @@ $taxCalculationData['shopping_cart_rule_fixed'] = [
                 'row_total_incl_tax' => 19.99,
                 'discount_amount' => 19.99
             ],
+        ],
+        'shipping' => [
+            'tax_amount' => 0.44,
+            'tax_percent' => 8.875,
+            'row_total' => 5,
+            'row_total_incl_tax' => 5 + 0.44
         ],
     ],
 ];

--- a/Test/Integration/_files/scenarios/discounts/shopping_cart_rule_fixed.php
+++ b/Test/Integration/_files/scenarios/discounts/shopping_cart_rule_fixed.php
@@ -19,34 +19,34 @@ use Magento\Tax\Model\Calculation;
 use Magento\Tax\Model\Config;
 use Taxjar\SalesTax\Test\Integration\Model\Tax\Sales\Total\Quote\SetupUtil;
 
-$taxCalculationData['shopping_cart_rule'] = [
+$taxCalculationData['shopping_cart_rule_fixed'] = [
     'config_data' => [
         SetupUtil::CONFIG_OVERRIDES => array_merge($taxjarCredentials, [
-            'shipping/origin/street_line1' => '600 Montgomery St',
-            'shipping/origin/city' => 'San Francisco',
-            'shipping/origin/region_id' => 12,
-            'shipping/origin/country_id' => 'US',
-            'shipping/origin/postcode' => '94111'
+            'shipping/origin/street_line1' => '350 5th Ave',
+            'shipping/origin/city' => 'New York',
+            'shipping/origin/region_id' => SetupUtil::REGION_NY,
+            'shipping/origin/country_id' => SetupUtil::COUNTRY_US,
+            'shipping/origin/postcode' => '10118'
         ])
     ],
     'quote_data' => [
         'billing_address' => [
-            'firstname' => 'Tony',
-            'lastname' => 'Stark',
-            'street' => '10880 Malibu Point',
-            'city' => 'Malibu',
-            'region_id' => SetupUtil::REGION_CA,
-            'postcode' => '90265',
+            'firstname' => 'George',
+            'lastname' => 'Costanza',
+            'street' => '321 W. 90th Street',
+            'city' => 'New York',
+            'region_id' => SetupUtil::REGION_NY,
+            'postcode' => '10024',
             'country_id' => SetupUtil::COUNTRY_US,
             'telephone' => '999-999-9999'
         ],
         'shipping_address' => [
-            'firstname' => 'Tony',
-            'lastname' => 'Stark',
-            'street' => '10880 Malibu Point',
-            'city' => 'Malibu',
-            'region_id' => SetupUtil::REGION_CA,
-            'postcode' => '90265',
+            'firstname' => 'George',
+            'lastname' => 'Costanza',
+            'street' => '321 W. 90th Street',
+            'city' => 'New York',
+            'region_id' => SetupUtil::REGION_NY,
+            'postcode' => '10024',
             'country_id' => SetupUtil::COUNTRY_US,
             'telephone' => '999-999-9999'
         ],
@@ -54,32 +54,33 @@ $taxCalculationData['shopping_cart_rule'] = [
             [
                 'type' => \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE,
                 'sku' => 'taxjar-tshirt',
-                'price' => 29.99,
+                'price' => 19.99,
                 'qty' => 1
             ]
         ],
         'shopping_cart_rules' => [
             [
-                'discount_amount' => 25
+                'discount_amount' => 20,
+                'simple_action' => 'cart_fixed'
             ]
         ]
     ],
     'expected_results' => [
         'address_data' => [
-            'tax_amount' => 2.14,
-            'subtotal' => 29.99,
-            'subtotal_incl_tax' => 29.99 + 2.14,
-            'grand_total' => 24.63
+            'tax_amount' => 0,
+            'subtotal' => 19.99,
+            'subtotal_incl_tax' => 19.99,
+            'grand_total' => 0
         ],
         'items_data' => [
             'taxjar-tshirt' => [
-                'tax_amount' => 2.14,
-                'tax_percent' => 9.5,
-                'price' => 29.99,
-                'price_incl_tax' => 29.99 + 2.14,
-                'row_total' => 29.99,
-                'row_total_incl_tax' => 29.99 + 2.14,
-                'discount_amount' => 7.50
+                'tax_amount' => 0,
+                'tax_percent' => 8.875,
+                'price' => 19.99,
+                'price_incl_tax' => 19.99,
+                'row_total' => 19.99,
+                'row_total_incl_tax' => 19.99,
+                'discount_amount' => 19.99
             ],
         ],
     ],

--- a/Test/Integration/_files/scenarios/discounts/shopping_cart_rule_fixed_shipping.php
+++ b/Test/Integration/_files/scenarios/discounts/shopping_cart_rule_fixed_shipping.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+use Magento\Tax\Model\Calculation;
+use Magento\Tax\Model\Config;
+use Taxjar\SalesTax\Test\Integration\Model\Tax\Sales\Total\Quote\SetupUtil;
+
+$taxCalculationData['shopping_cart_rule_fixed_shipping'] = [
+    'config_data' => [
+        SetupUtil::CONFIG_OVERRIDES => array_merge($taxjarCredentials, [
+            'shipping/origin/street_line1' => '350 5th Ave',
+            'shipping/origin/city' => 'New York',
+            'shipping/origin/region_id' => SetupUtil::REGION_NY,
+            'shipping/origin/country_id' => SetupUtil::COUNTRY_US,
+            'shipping/origin/postcode' => '10118'
+        ])
+    ],
+    'quote_data' => [
+        'billing_address' => [
+            'firstname' => 'George',
+            'lastname' => 'Costanza',
+            'street' => '321 W. 90th Street',
+            'city' => 'New York',
+            'region_id' => SetupUtil::REGION_NY,
+            'postcode' => '10024',
+            'country_id' => SetupUtil::COUNTRY_US,
+            'telephone' => '999-999-9999'
+        ],
+        'shipping_address' => [
+            'firstname' => 'George',
+            'lastname' => 'Costanza',
+            'street' => '321 W. 90th Street',
+            'city' => 'New York',
+            'region_id' => SetupUtil::REGION_NY,
+            'postcode' => '10024',
+            'country_id' => SetupUtil::COUNTRY_US,
+            'telephone' => '999-999-9999'
+        ],
+        'items' => [
+            [
+                'type' => \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE,
+                'sku' => 'taxjar-tshirt',
+                'price' => 19.99,
+                'qty' => 1
+            ]
+        ],
+        'shipping' => [
+            'method' => 'flatrate_flatrate',
+            'description' => 'Flat Rate - Fixed',
+            'amount' => 5,
+            'base_amount' => 5,
+        ],
+        'shopping_cart_rules' => [
+            [
+                'discount_amount' => 25,
+                'simple_action' => 'cart_fixed',
+                'apply_to_shipping' => true
+            ]
+        ]
+    ],
+    'expected_results' => [
+        'address_data' => [
+            'tax_amount' => 0,
+            'subtotal' => 19.99,
+            'subtotal_incl_tax' => 19.99,
+            'grand_total' => 0
+        ],
+        'items_data' => [
+            'taxjar-tshirt' => [
+                'tax_amount' => 0,
+                'tax_percent' => 8.875,
+                'price' => 19.99,
+                'price_incl_tax' => 19.99,
+                'row_total' => 19.99,
+                'row_total_incl_tax' => 19.99,
+                'discount_amount' => 19.99
+            ],
+        ],
+        'shipping' => [
+            'tax_amount' => 0,
+            'tax_percent' => 0,
+            'row_total' => 5,
+            'row_total_incl_tax' => 5
+        ],
+    ],
+];

--- a/Test/Integration/_files/scenarios/discounts/shopping_cart_rule_percent.php
+++ b/Test/Integration/_files/scenarios/discounts/shopping_cart_rule_percent.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+use Magento\Tax\Model\Calculation;
+use Magento\Tax\Model\Config;
+use Taxjar\SalesTax\Test\Integration\Model\Tax\Sales\Total\Quote\SetupUtil;
+
+$taxCalculationData['shopping_cart_rule_percent'] = [
+    'config_data' => [
+        SetupUtil::CONFIG_OVERRIDES => array_merge($taxjarCredentials, [
+            'shipping/origin/street_line1' => '600 Montgomery St',
+            'shipping/origin/city' => 'San Francisco',
+            'shipping/origin/region_id' => 12,
+            'shipping/origin/country_id' => 'US',
+            'shipping/origin/postcode' => '94111'
+        ])
+    ],
+    'quote_data' => [
+        'billing_address' => [
+            'firstname' => 'Tony',
+            'lastname' => 'Stark',
+            'street' => '10880 Malibu Point',
+            'city' => 'Malibu',
+            'region_id' => SetupUtil::REGION_CA,
+            'postcode' => '90265',
+            'country_id' => SetupUtil::COUNTRY_US,
+            'telephone' => '999-999-9999'
+        ],
+        'shipping_address' => [
+            'firstname' => 'Tony',
+            'lastname' => 'Stark',
+            'street' => '10880 Malibu Point',
+            'city' => 'Malibu',
+            'region_id' => SetupUtil::REGION_CA,
+            'postcode' => '90265',
+            'country_id' => SetupUtil::COUNTRY_US,
+            'telephone' => '999-999-9999'
+        ],
+        'items' => [
+            [
+                'type' => \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE,
+                'sku' => 'taxjar-tshirt',
+                'price' => 29.99,
+                'qty' => 1
+            ]
+        ],
+        'shopping_cart_rules' => [
+            [
+                'discount_amount' => 25
+            ]
+        ]
+    ],
+    'expected_results' => [
+        'address_data' => [
+            'tax_amount' => 2.14,
+            'subtotal' => 29.99,
+            'subtotal_incl_tax' => 29.99 + 2.14,
+            'grand_total' => 24.63
+        ],
+        'items_data' => [
+            'taxjar-tshirt' => [
+                'tax_amount' => 2.14,
+                'tax_percent' => 9.5,
+                'price' => 29.99,
+                'price_incl_tax' => 29.99 + 2.14,
+                'row_total' => 29.99,
+                'row_total_incl_tax' => 29.99 + 2.14,
+                'discount_amount' => 7.50
+            ],
+        ],
+    ],
+];

--- a/Test/Integration/_files/tax_calculation_data_aggregated.php
+++ b/Test/Integration/_files/tax_calculation_data_aggregated.php
@@ -32,6 +32,9 @@ require_once __DIR__ . '/scenarios/countries/eu_calculation.php';
 require_once __DIR__ . '/scenarios/currencies/aud_with_usd_base_currency.php';
 require_once __DIR__ . '/scenarios/currencies/cad_with_usd_base_currency.php';
 require_once __DIR__ . '/scenarios/currencies/eur_with_usd_base_currency.php';
+require_once __DIR__ . '/scenarios/discounts/shopping_cart_rule_percent.php';
+require_once __DIR__ . '/scenarios/discounts/shopping_cart_rule_fixed.php';
+require_once __DIR__ . '/scenarios/discounts/shopping_cart_rule_fixed_shipping.php';
 require_once __DIR__ . '/scenarios/exemptions/none_tax_class_exemption.php';
 require_once __DIR__ . '/scenarios/exemptions/us_ca_grocery_exemption.php';
 require_once __DIR__ . '/scenarios/exemptions/us_ny_clothing_exemption.php';
@@ -43,6 +46,5 @@ require_once __DIR__ . '/scenarios/products/configurable_product.php';
 require_once __DIR__ . '/scenarios/products/simple_product.php';
 require_once __DIR__ . '/scenarios/line_item_rounding_calculation.php';
 require_once __DIR__ . '/scenarios/shipping_tax_calculation.php';
-require_once __DIR__ . '/scenarios/shopping_cart_rule.php';
 
 // @codingStandardsIgnoreEnd


### PR DESCRIPTION
This PR fixes calculations for orders with discounted shipping amounts in states where shipping is taxable. Previously, if a discount was applied to a shipping amount we'd calculate sales tax on the full shipping amount instead.