### PR TITLE
Postcode Regex Validation

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -309,6 +309,7 @@ class Smartcalcs
 
         if (isset($postCodes[$countryId]) && is_array($postCodes[$countryId])) {
             $patterns = $postCodes[$countryId];
+
             foreach ($patterns as $pattern) {
                 preg_match('/' . $pattern['pattern'] . '/', $postcode, $matches);
 

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -65,6 +65,11 @@ class Smartcalcs
     protected $taxData;
 
     /**
+     * @var \Magento\Directory\Model\Country\Postcode\ConfigInterface
+     */
+    protected $postCodesConfig;
+
+    /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $scopeConfig;
@@ -92,7 +97,8 @@ class Smartcalcs
         ScopeConfigInterface $scopeConfig,
         ZendClientFactory $clientFactory,
         ProductMetadata $productMetadata,
-        \Magento\Tax\Helper\Data $taxData
+        \Magento\Tax\Helper\Data $taxData,
+        \Magento\Directory\Model\Country\Postcode\ConfigInterface $postCodesConfig
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->regionFactory = $regionFactory;
@@ -102,6 +108,7 @@ class Smartcalcs
         $this->scopeConfig = $scopeConfig;
         $this->clientFactory = $clientFactory;
         $this->taxData = $taxData;
+        $this->postCodesConfig = $postCodesConfig;
     }
 
     /**
@@ -128,6 +135,10 @@ class Smartcalcs
         }
 
         if (!$address->getPostcode()) {
+            return;
+        }
+
+        if (!$this->_validatePostcode($address->getPostcode(), $address->getCountry())) {
             return;
         }
 
@@ -279,6 +290,32 @@ class Smartcalcs
 
         if (isset($response['body']['tax']) && $response['status'] == 200) {
             return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Validate postcode based on country using patterns defined in
+     * app/code/Magento/Directory/etc/zip_codes.xml
+     *
+     * @param string $postcode
+     * @param string $countryId
+     * @return bool
+     */
+    private function _validatePostcode($postcode, $countryId)
+    {
+        $postCodes = $this->postCodesConfig->getPostCodes();
+
+        if (isset($postCodes[$countryId]) && is_array($postCodes[$countryId])) {
+            $patterns = $postCodes[$countryId];
+            foreach ($patterns as $pattern) {
+                preg_match('/' . $pattern['pattern'] . '/', $postcode, $matches);
+
+                if (count($matches)) {
+                    return true;
+                }
+            }
         }
 
         return false;

--- a/Test/Integration/_files/scenarios/countries/au_calculation.php
+++ b/Test/Integration/_files/scenarios/countries/au_calculation.php
@@ -25,7 +25,7 @@ $taxCalculationData['au_calculation'] = [
             'shipping/origin/street_line1' => '217 Kildare Rd',
             'shipping/origin/city' => 'Doonside',
             'shipping/origin/country_id' => 'AU',
-            'shipping/origin/postcode' => 'NSW 2767'
+            'shipping/origin/postcode' => '2767'
         ]),
         SetupUtil::NEXUS_OVERRIDES => [
             [
@@ -33,7 +33,7 @@ $taxCalculationData['au_calculation'] = [
                 'city' => 'Doonside',
                 'region' => 'New South Wales',
                 'country_id' => 'AU',
-                'postcode' => 'NSW 2767'
+                'postcode' => '2767'
             ]
         ]
     ],
@@ -43,7 +43,7 @@ $taxCalculationData['au_calculation'] = [
             'lastname' => 'Moss',
             'street' => '455 George St',
             'city' => 'Sydney',
-            'postcode' => 'NSW 2000',
+            'postcode' => '2000',
             'country_id' => 'AU',
             'telephone' => '999-999-9999'
         ],
@@ -52,7 +52,7 @@ $taxCalculationData['au_calculation'] = [
             'lastname' => 'Moss',
             'street' => '455 George St',
             'city' => 'Sydney',
-            'postcode' => 'NSW 2000',
+            'postcode' => '2000',
             'country_id' => 'AU',
             'telephone' => '999-999-9999'
         ],

--- a/Test/Integration/_files/scenarios/currencies/aud_with_usd_base_currency.php
+++ b/Test/Integration/_files/scenarios/currencies/aud_with_usd_base_currency.php
@@ -25,7 +25,7 @@ $taxCalculationData['aud_with_usd_base_currency'] = [
             'shipping/origin/street_line1' => '217 Kildare Rd',
             'shipping/origin/city' => 'Doonside',
             'shipping/origin/country_id' => 'AU',
-            'shipping/origin/postcode' => 'NSW 2767'
+            'shipping/origin/postcode' => '2767'
         ]),
         SetupUtil::NEXUS_OVERRIDES => [
             [
@@ -33,7 +33,7 @@ $taxCalculationData['aud_with_usd_base_currency'] = [
                 'city' => 'Doonside',
                 'region' => 'New South Wales',
                 'country_id' => 'AU',
-                'postcode' => 'NSW 2767'
+                'postcode' => '2767'
             ]
         ]
     ],
@@ -43,7 +43,7 @@ $taxCalculationData['aud_with_usd_base_currency'] = [
             'lastname' => 'Moss',
             'street' => '455 George St',
             'city' => 'Sydney',
-            'postcode' => 'NSW 2000',
+            'postcode' => '2000',
             'country_id' => 'AU',
             'telephone' => '999-999-9999'
         ],
@@ -52,7 +52,7 @@ $taxCalculationData['aud_with_usd_base_currency'] = [
             'lastname' => 'Moss',
             'street' => '455 George St',
             'city' => 'Sydney',
-            'postcode' => 'NSW 2000',
+            'postcode' => '2000',
             'country_id' => 'AU',
             'telephone' => '999-999-9999'
         ],


### PR DESCRIPTION
When estimating shipping and tax on the cart page, the `/estimate-shipping-methods` endpoint can be called while actively typing in a zip / postal code. This can potentially cause excessive bad requests to our API for invalid postal codes.

This PR uses Magento's native regex patterns defined in zip_codes.xml to validate postal codes by country, replicating the front-end validation while typing in a postal code on the cart page.