### PR TITLE
"None" Tax Class Line Items via Transaction Sync

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -17,6 +17,8 @@
 
 namespace Taxjar\SalesTax\Model;
 
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+
 class Transaction
 {
     /**
@@ -228,6 +230,8 @@ class Transaction
                 if ($taxClass->getTjSalestaxCode()) {
                     $lineItem['product_tax_code'] = $taxClass->getTjSalestaxCode();
                 }
+            } else {
+                $lineItem['product_tax_code'] = TaxjarConfig::TAXJAR_EXEMPT_TAX_CODE;
             }
 
             $lineItems['line_items'][] = $lineItem;


### PR DESCRIPTION
This PR ensures a TaxJar exempt tax code `99999` is provided for line items with products assigned to a "None" tax class. We have this fallback in place for calculations and M1 beta transaction sync, but not for transactions in M2 yet.