### PR TITLE
Setup Magento 2 to work with Taxjar Customer Endpoint

### DIFF
--- a/Block/Adminhtml/Tax/Taxclass/Customer/Edit/Form.php
+++ b/Block/Adminhtml/Tax/Taxclass/Customer/Edit/Form.php
@@ -152,6 +152,41 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             ]
         );
 
+        $fieldset->addField(
+            'tj_salestax_exempt_type',
+            'select',
+            [
+                'name' => 'tj_salestax_exempt_type',
+                'label' => __('TaxJar Exemption Type'),
+                'note' => __('Sets the exemption type on the customer, this will be sent to your taxjar account when customers are synced. '),
+                'values' => [
+                    'wholesale' => 'Wholesale',
+                    'government' => 'Government',
+                    'other' => 'Other'
+                ],
+                'value' => isset($formValues['tj_salestax_exempt_type']) ? $formValues['tj_salestax_exempt_type'] : ''
+            ]
+        );
+
+        $this->setChild(
+            'form_after',
+            $this->getLayout()->createBlock(
+                'Magento\Backend\Block\Widget\Form\Element\Dependence'
+            )->addFieldMap(
+                'tj_salestax_code',
+                'tj_salestax_code'
+            )->addFieldMap(
+                'tj_salestax_exempt_type',
+                'tj_salestax_exempt_type'
+            )->addFieldDependence(
+                'tj_salestax_exempt_type',
+                'tj_salestax_code',
+                '99999'
+            )
+        );
+
+
+
         $form->setAction($this->getUrl('taxjar/taxclass_customer/save'));
         $form->setUseContainer($this->getUseContainer());
         $this->setForm($form);

--- a/Block/Adminhtml/Tax/Taxclass/Customer/Edit/Form.php
+++ b/Block/Adminhtml/Tax/Taxclass/Customer/Edit/Form.php
@@ -158,7 +158,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             [
                 'name' => 'tj_salestax_exempt_type',
                 'label' => __('TaxJar Exemption Type'),
-                'note' => __('Sets the exemption type on the customer, this will be sent to your taxjar account when customers are synced. '),
+                'note' => __('If exempt from TaxJar, select an exemption type for this customer tax class.'),
                 'values' => [
                     'wholesale' => 'Wholesale',
                     'government' => 'Government',
@@ -184,8 +184,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 '99999'
             )
         );
-
-
 
         $form->setAction($this->getUrl('taxjar/taxclass_customer/save'));
         $form->setUseContainer($this->getUseContainer());

--- a/Block/Adminhtml/Tax/Taxclass/Customer/Edit/Form.php
+++ b/Block/Adminhtml/Tax/Taxclass/Customer/Edit/Form.php
@@ -205,7 +205,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         $taxClassData = [
             'class_id' => $taxClass->getClassId(),
             'class_name' => $taxClass->getClassName(),
-            'tj_salestax_code' => $taxClass->getTjSalestaxCode()
+            'tj_salestax_code' => $taxClass->getTjSalestaxCode(),
+            'tj_salestax_exempt_type' => $taxClass->getTjSalestaxExemptType()
         ];
         return $taxClassData;
     }

--- a/Controller/Adminhtml/Taxclass.php
+++ b/Controller/Adminhtml/Taxclass.php
@@ -18,6 +18,7 @@
 namespace Taxjar\SalesTax\Controller\Adminhtml;
 
 use Magento\Framework\Controller\ResultFactory;
+use TaxJar\SalesTax\Model\Configuration;
 
 abstract class Taxclass extends \Magento\Backend\App\Action
 {
@@ -119,6 +120,14 @@ abstract class Taxclass extends \Magento\Backend\App\Action
         if (isset($postData['tj_salestax_code'])) {
             $taxClass->setTjSalestaxCode($postData['tj_salestax_code']);
         }
+        if (isset($postData['tj_salestax_code']) && '99999' == $postData['tj_salestax_code'] ) {
+            if(isset($postData['tj_salestax_exempt_type'])) {
+                $taxClass->setTjSalestaxExemptType($postData['tj_salestax_exempt_type']);
+            }
+        } else {
+            $taxClass->setTjSalestaxExemptType(Configuration::TAXJAR_DEFAULT_EXEMPT_TYPE);
+        }
+
         return $taxClass;
     }
 }

--- a/Controller/Adminhtml/Taxclass.php
+++ b/Controller/Adminhtml/Taxclass.php
@@ -18,7 +18,7 @@
 namespace Taxjar\SalesTax\Controller\Adminhtml;
 
 use Magento\Framework\Controller\ResultFactory;
-use TaxJar\SalesTax\Model\Configuration;
+use TaxJar\SalesTax\Model\Configuration as TaxjarConfig;
 
 abstract class Taxclass extends \Magento\Backend\App\Action
 {
@@ -120,12 +120,12 @@ abstract class Taxclass extends \Magento\Backend\App\Action
         if (isset($postData['tj_salestax_code'])) {
             $taxClass->setTjSalestaxCode($postData['tj_salestax_code']);
         }
-        if (isset($postData['tj_salestax_code']) && '99999' == $postData['tj_salestax_code'] ) {
+        if (isset($postData['tj_salestax_code']) && '99999' == $postData['tj_salestax_code']) {
             if(isset($postData['tj_salestax_exempt_type'])) {
                 $taxClass->setTjSalestaxExemptType($postData['tj_salestax_exempt_type']);
             }
         } else {
-            $taxClass->setTjSalestaxExemptType(Configuration::TAXJAR_DEFAULT_EXEMPT_TYPE);
+            $taxClass->setTjSalestaxExemptType(TaxjarConfig::TAXJAR_DEFAULT_EXEMPT_TYPE);
         }
 
         return $taxClass;

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -39,6 +39,8 @@ class Configuration
     const TAXJAR_TRANSACTION_AUTH     = 'tax/taxjar/transaction_auth';
     const TAXJAR_TRANSACTION_SYNC     = 'tax/taxjar/transactions';
     const TAXJAR_EXEMPT_TAX_CODE      = '99999';
+    const TAXJAR_DEFAULT_EXEMPT_TYPE  = 'non_exempt';
+
 
     /**
      * @var \Magento\Config\Model\ResourceModel\Config

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -197,7 +197,9 @@ class Smartcalcs
         ]);
 
         $customer = $quote->getCustomer();
-
+        if ($customer_id = $customer->getId() and $customer->getCustomAttribute('tj_salestax_sync_date')->getValue()) {
+            $order['customer_id'] = $customer_id;
+        }
 
         if ($this->_orderChanged($order)) {
             $client = $this->clientFactory->create();

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -129,7 +129,6 @@ class Smartcalcs
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $quote->getStoreId()
         ));
-
         if (!$apiKey) {
             return;
         }
@@ -196,6 +195,9 @@ class Smartcalcs
             'nexus_addresses' => $this->_getNexusAddresses($quote->getStoreId()),
             'plugin' => 'magento'
         ]);
+
+        $customer = $quote->getCustomer();
+
 
         if ($this->_orderChanged($order)) {
             $client = $this->clientFactory->create();

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -129,6 +129,7 @@ class Smartcalcs
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $quote->getStoreId()
         ));
+
         if (!$apiKey) {
             return;
         }
@@ -197,7 +198,8 @@ class Smartcalcs
         ]);
 
         $customer = $quote->getCustomer();
-        if ($customer_id = $customer->getId() and $customer->getCustomAttribute('tj_salestax_sync_date')->getValue()) {
+        
+        if ($customer_id = $customer->getId() && $customer->getCustomAttribute('tj_salestax_sync_date')->getValue()) {
             $order['customer_id'] = $customer_id;
         }
 

--- a/Model/SyncCustomers.php
+++ b/Model/SyncCustomers.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxjar\SalesTax\Model;
+
+use Magento\Framework\HTTP\ZendClientFactory;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Tax\Api\TaxClassRepositoryInterface;
+use Taxjar\SalesTax\Model\Logger;
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+
+
+class SyncCustomers
+{
+    /**
+     * @var \Magento\Framework\HTTP\ZendClientFactory;
+     */
+    protected $_clientFactory;
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $_scopeConfig;
+
+    /**
+     * @var \Magento\Tax\Api\TaxClassRepositoryInterface
+     */
+    protected $_taxClassRepo;
+
+    /**
+     * @var \Taxjar\SalesTax\Model\Logger
+     */
+    protected $_logger;
+
+
+    public function __construct(Logger $logger,
+                                ZendClientFactory $clientFactory,
+                                ScopeConfigInterface $scopeConfig,
+                                TaxClassRepositoryInterface $taxClassRepo)
+    {
+        $this->_clientFactory = $clientFactory;
+        $this->_logger = $logger->setFilename('customers.log');
+        $this->_scopeConfig = $scopeConfig;
+        $this->_taxClassRepo = $taxClassRepo;
+    }
+
+    public function updateCustomer($customer)
+    {
+
+        // Determine if taxjar touching is necessary
+        // $customer = $this->_customer;
+        // if no sync date or sync date is older than the current time run resync
+        if((!$customer->getTjSalestaxSyncDate() or $customer->getTjSalestaxSyncDate() < time()) && !$customer->getTjProcessed()) {
+            if (!$customer->getTjSalestaxSyncDate()) {
+                $requestType = 'post';
+                $url = TaxjarConfig::TAXJAR_API_URL . '/customers';
+            } else {
+                $requestType = 'put';
+                $url = TaxjarConfig::TAXJAR_API_URL . '/customers/' . $customer->getId();
+            }
+
+
+            $taxClassId = $customer->getTaxClassId();
+            $taxClass = $this->_taxClassRepo->get($taxClassId);
+
+            $request = array(
+                'customer_id'       => $customer->getId(),
+                'exemption_type'    => $taxClass->getTjSalestaxExemptType(),
+                'name'              => $customer->getName(),
+            );
+
+            $addressToUse = $customer->getPrimaryShippingAddress();
+
+            if($addressToUse){
+                $request['exempt_regions'] = array(
+                    array(
+                        'country'       => $addressToUse->getCountry(),
+                        'state'         => $addressToUse->getRegionCode()
+                    ));
+                $request['country']     = $addressToUse->getCountry();
+                $request['state']       = $addressToUse->getRegionCode();
+                $request['zip']         = $addressToUse->getPostcode();
+                $request['city']        = $addressToUse->getCity();
+                $request['street']      = $addressToUse->getStreetFull();
+            } else {
+                // Hardcoding due to endpoint requirements
+                $request['exempt_regions'] = array(
+                    array(
+                        'country'       => 'US',
+                        'state'         => 'NY'
+                    ));
+            }
+
+            // Prepare for api call
+            $apiKey = preg_replace('/\s+/', '', $this->_scopeConfig->getValue(TaxjarConfig::TAXJAR_APIKEY,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            ));
+            $client = $this->_clientFactory->create();
+            $client->setUri($url);
+            $client->setHeaders('Authorization', 'Bearer ' . $apiKey);
+            $client->setRawData(json_encode($request), 'application/json');
+            $this->_logger->log('Syncing Customer: ' . json_encode($request), 'post');
+            try {
+                $response = $client->request(strtoupper($requestType));
+
+                if (200 <= $response->getStatus() && 300 > $response->getStatus()) {
+                    $this->_logger->log('Successful API response: ' . $response->getBody(), 'success');
+                    $customer->setTjSalestaxSyncDate(time())->setTjProcessed(true)->save();
+                } else {
+                    $errorResponse = json_decode($response->getBody());
+                    $this->_logger->log($errorResponse->status . ' ' . $errorResponse->error . ' - ' . $errorResponse->detail, 'error');
+                }
+            } catch (\Zend_Http_Client_Exception $e) {
+                // Catch API timeouts and network issues
+                $this->_logger->log('API timeout or network issue between your store and TaxJar, please try again later.', 'error');
+            }
+        }
+    }
+
+    public function deleteCustomer($customer)
+    {
+        $requestType = 'delete';
+        $url = 'https://api.taxjar.com/v2/customers/' . $customer->getId();
+
+        // Prepare for api call
+        $apiKey = preg_replace('/\s+/', '', $this->_scopeConfig->getValue(TaxjarConfig::TAXJAR_APIKEY,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        ));
+        $client = $this->_clientFactory->create();
+        $client->setUri($url);
+        $client->setHeaders('Authorization', 'Bearer ' . $apiKey);
+
+        $this->_logger->log('Deleting Customer: ' . $customer->getId(), $requestType);
+
+        try {
+            $response = $client->request(strtoupper($requestType));
+
+            if (200 <= $response->getStatus() && 300 > $response->getStatus()) {
+                $this->_logger->log('Successful API response: ' . $response->getBody(), 'success');
+                // Since we are successful we want to set the last sync time to now and save the customer
+            } else {
+                $errorResponse = json_decode($response->getBody());
+                $this->_logger->log($errorResponse->status . ' ' . $errorResponse->error . ' - ' . $errorResponse->detail, 'error');
+            }
+
+        } catch (Zend_Http_Client_Exception $e) {
+            // Catch API timeouts and network issues
+            $this->_logger->log('API timeout or network issue between your store and TaxJar, please try again later.', 'error');
+        }
+    }
+}

--- a/Model/SyncCustomers.php
+++ b/Model/SyncCustomers.php
@@ -23,7 +23,6 @@ use Magento\Tax\Api\TaxClassRepositoryInterface;
 use Taxjar\SalesTax\Model\Logger;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 
-
 class SyncCustomers
 {
     /**
@@ -56,7 +55,6 @@ class SyncCustomers
      */
     protected $_registry;
 
-
     public function __construct(Logger $logger,
                                 ZendClientFactory $clientFactory,
                                 ScopeConfigInterface $scopeConfig,
@@ -74,7 +72,7 @@ class SyncCustomers
         // Determine if taxjar touching is necessary
         // $customer = $this->_customer;
         // if no sync date or sync date is older than the current time run resync
-        if((!$customer->getTjSalestaxSyncDate() or $customer->getTjSalestaxSyncDate() < time()) && !in_array($customer->getId(), $this->_syncedCustomers)) {
+        if ((!$customer->getTjSalestaxSyncDate() || $customer->getTjSalestaxSyncDate() < time()) && !in_array($customer->getId(), $this->_syncedCustomers)) {
             if (!$customer->getTjSalestaxSyncDate()) {
                 $requestType = 'post';
                 $url = TaxjarConfig::TAXJAR_API_URL . '/customers';
@@ -82,7 +80,6 @@ class SyncCustomers
                 $requestType = 'put';
                 $url = TaxjarConfig::TAXJAR_API_URL . '/customers/' . $customer->getId();
             }
-
 
             $taxClassId = $customer->getTaxClassId();
             $taxClass = $this->_taxClassRepo->get($taxClassId);
@@ -95,12 +92,13 @@ class SyncCustomers
 
             $addressToUse = $customer->getPrimaryShippingAddress();
 
-            if($addressToUse){
+            if ($addressToUse) {
                 $request['exempt_regions'] = array(
                     array(
                         'country'       => $addressToUse->getCountry(),
                         'state'         => $addressToUse->getRegionCode()
-                    ));
+                    )
+                );
                 $request['country']     = $addressToUse->getCountry();
                 $request['state']       = $addressToUse->getRegionCode();
                 $request['zip']         = $addressToUse->getPostcode();
@@ -112,7 +110,8 @@ class SyncCustomers
                     array(
                         'country'       => 'US',
                         'state'         => 'NY'
-                    ));
+                    )
+                );
             }
 
             // Prepare for api call
@@ -123,6 +122,7 @@ class SyncCustomers
             $client->setUri($url);
             $client->setHeaders('Authorization', 'Bearer ' . $apiKey);
             $client->setRawData(json_encode($request), 'application/json');
+
             $this->_logger->log('Syncing Customer: ' . json_encode($request), 'post');
             try {
                 $response = $client->request(strtoupper($requestType));
@@ -145,7 +145,7 @@ class SyncCustomers
     public function deleteCustomer($customer)
     {
         $requestType = 'delete';
-        $url = 'https://api.taxjar.com/v2/customers/' . $customer->getId();
+        $url = TaxjarConfig::TAXJAR_API_URL . '/customers/' . $customer->getId();
 
         // Prepare for api call
         $apiKey = preg_replace('/\s+/', '', $this->_scopeConfig->getValue(TaxjarConfig::TAXJAR_APIKEY,
@@ -167,7 +167,6 @@ class SyncCustomers
                 $errorResponse = json_decode($response->getBody());
                 $this->_logger->log($errorResponse->status . ' ' . $errorResponse->error . ' - ' . $errorResponse->detail, 'error');
             }
-
         } catch (Zend_Http_Client_Exception $e) {
             // Catch API timeouts and network issues
             $this->_logger->log('API timeout or network issue between your store and TaxJar, please try again later.', 'error');

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -66,7 +66,7 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
         );
 
         $customer = $order->getCustomer();
-        if ($customer_id = $customer->getId() and $customer->getCustomAttribute('tj_salestax_sync_date')->getValue()) {
+        if ($customer_id = $customer->getId() && $customer->getCustomAttribute('tj_salestax_sync_date')->getValue()) {
             $this->request['customer_id'] = $customer_id;
         }
 

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -65,6 +65,11 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
             $this->buildLineItems($order, $order->getAllItems())
         );
 
+        $customer = $order->getCustomer();
+        if ($customer_id = $customer->getId() and $customer->getCustomAttribute('tj_salestax_sync_date')->getValue()) {
+            $this->request['customer_id'] = $customer_id;
+        }
+
         return $this->request;
     }
 

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -74,7 +74,7 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
         );
 
         $customer = $order->getCustomer();
-        if ($customer_id = $customer->getId() and $customer->getCustomAttribute('tj_salestax_sync_date')->getValue()) {
+        if ($customer_id = $customer->getId() && $customer->getCustomAttribute('tj_salestax_sync_date')->getValue()) {
             $this->request['customer_id'] = $customer_id;
         }
 

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -73,6 +73,11 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
             $this->buildLineItems($order, $creditmemo->getAllItems(), 'refund')
         );
 
+        $customer = $order->getCustomer();
+        if ($customer_id = $customer->getId() and $customer->getCustomAttribute('tj_salestax_sync_date')->getValue()) {
+            $this->request['customer_id'] = $customer_id;
+        }
+
         return $this->request;
     }
 

--- a/Plugin/AddressPlugin.php
+++ b/Plugin/AddressPlugin.php
@@ -1,0 +1,31 @@
+<?php
+namespace TaxJar\SalesTax\Plugin;
+use Taxjar\SalesTax\Model\SyncCustomers;
+use Magento\Customer\Model\Address;
+
+class AddressPlugin
+{
+    /**
+     * @var \Taxjar\SalesTax\Model\SyncCustomers
+     */
+    protected $_customerSync;
+
+    public function __construct(SyncCustomers $customerSync)
+    {
+        $this->_customerSync = $customerSync;
+    }
+
+    public function afterAfterSave($address)
+    {
+        $customer = $address->getCustomer();
+        $customer->cleanAllAddresses();
+        $this->_customerSync->updateCustomer($customer);
+    }
+
+    public function afterAfterDeleteCommit($address)
+    {
+        $customer = $address->getCustomer();
+        $customer->cleanAllAddresses();
+        $this->_customerSync->updateCustomer($customer);
+    }
+}

--- a/Plugin/AddressPlugin.php
+++ b/Plugin/AddressPlugin.php
@@ -1,5 +1,22 @@
 <?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
 namespace TaxJar\SalesTax\Plugin;
+
 use Taxjar\SalesTax\Model\SyncCustomers;
 use Magento\Customer\Model\Address;
 

--- a/Plugin/CustomerGroupPlugin.php
+++ b/Plugin/CustomerGroupPlugin.php
@@ -45,11 +45,7 @@ class CustomerGroupPlugin
 
             // Ned to do a join on group to grab the right class
             $customers = $this->customerFactory->create();
-            $customers->getSelect()->join(
-                ['customer_group'=>$customers->getResource()->getTable('customer_group')],
-                'e.group_id = customer_group.customer_group_id',
-                ['tax_class_id'])
-                ->where('tax_class_id = ? ', $customerGroup->getTaxClassId());
+            $customers->addFieldToFilter('group_id', $customerGroup->getId());
 
             // This process can take awhile
             @set_time_limit(0);

--- a/Plugin/CustomerGroupPlugin.php
+++ b/Plugin/CustomerGroupPlugin.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace TaxJar\SalesTax\Plugin;
+
+use Taxjar\SalesTax\Model\SyncCustomers;
+use \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
+
+class CustomerGroupPlugin
+{
+    /**
+     * @var \Taxjar\SalesTax\Model\SyncCustomers
+     */
+    protected $customerSync;
+
+    /**
+     * @var \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory
+     */
+    protected $customerFactory;
+
+
+    /**
+     * @var \Taxjar\SalesTax\Model\SyncCustomers
+     */
+    protected $originalTaxClassId;
+
+    public function __construct(SyncCustomers $customerSync, CollectionFactory $customerFactory)
+    {
+        $this->customerSync = $customerSync;
+        $this->customerFactory = $customerFactory;
+    }
+
+
+    public function beforeSave($customerGroupRepo, $customerGroup)
+    {
+        $customerGroup = $customerGroupRepo->getById($customerGroup->getId());
+        $this->originalTaxClassId = $customerGroup->getTaxClassId();
+    }
+
+    public function afterSave($customerGroupRepo, $customerGroup)
+    {
+        if ($customerGroup->getTaxClassId() != $this->originalTaxClassId) {
+
+            // On change we need to loop through all the affected customers and sync/resync them
+            // First verify that it's a change we care about
+
+            // Ned to do a join on group to grab the right class
+            $customers = $this->customerFactory->create();
+            $customers->getSelect()->join(
+                ['customer_group'=>$customers->getResource()->getTable('customer_group')],
+                'e.group_id = customer_group.customer_group_id',
+                ['tax_class_id'])
+                ->where('tax_class_id = ? ', $customerGroup->getTaxClassId());
+
+            // This process can take awhile
+            @set_time_limit(0);
+            @ignore_user_abort(true);
+            foreach ($customers as $customer) {
+                $this->customerSync->updateCustomer($customer);
+            }
+        }
+        return $customerGroup;
+    }
+}

--- a/Plugin/CustomerGroupPlugin.php
+++ b/Plugin/CustomerGroupPlugin.php
@@ -17,7 +17,6 @@ class CustomerGroupPlugin
      */
     protected $customerFactory;
 
-
     /**
      * @var \Taxjar\SalesTax\Model\SyncCustomers
      */
@@ -29,7 +28,6 @@ class CustomerGroupPlugin
         $this->customerFactory = $customerFactory;
     }
 
-
     public function beforeSave($customerGroupRepo, $customerGroup)
     {
         $customerGroup = $customerGroupRepo->getById($customerGroup->getId());
@@ -39,10 +37,8 @@ class CustomerGroupPlugin
     public function afterSave($customerGroupRepo, $customerGroup)
     {
         if ($customerGroup->getTaxClassId() != $this->originalTaxClassId) {
-
             // On change we need to loop through all the affected customers and sync/resync them
             // First verify that it's a change we care about
-
             // Ned to do a join on group to grab the right class
             $customers = $this->customerFactory->create();
             $customers->addFieldToFilter('group_id', $customerGroup->getId());
@@ -50,10 +46,12 @@ class CustomerGroupPlugin
             // This process can take awhile
             @set_time_limit(0);
             @ignore_user_abort(true);
+
             foreach ($customers as $customer) {
                 $this->customerSync->updateCustomer($customer);
             }
         }
+        
         return $customerGroup;
     }
 }

--- a/Plugin/CustomerGroupPlugin.php
+++ b/Plugin/CustomerGroupPlugin.php
@@ -1,4 +1,19 @@
 <?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
 
 namespace TaxJar\SalesTax\Plugin;
 
@@ -51,7 +66,7 @@ class CustomerGroupPlugin
                 $this->customerSync->updateCustomer($customer);
             }
         }
-        
+
         return $customerGroup;
     }
 }

--- a/Plugin/CustomerPlugin.php
+++ b/Plugin/CustomerPlugin.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TaxJar\SalesTax\Plugin;
+
+use Magento\Customer\Model\Customer;
+use Taxjar\SalesTax\Model\SyncCustomers;
+
+class CustomerPlugin
+{
+    /**
+     * @var \Taxjar\SalesTax\Model\SyncCustomers
+     */
+    protected $_customerSync;
+
+    public function __construct(SyncCustomers $customerSync)
+    {
+        $this->_customerSync = $customerSync;
+    }
+
+    public function afterAfterSave(Customer $customer)
+    {
+        // Will still need address plugin
+        $this->_customerSync->updateCustomer($customer);
+    }
+
+    public function afterAfterDeleteCommit(Customer $customer)
+    {
+        $this->_customerSync->deleteCustomer($customer);
+    }
+}

--- a/Plugin/CustomerPlugin.php
+++ b/Plugin/CustomerPlugin.php
@@ -1,4 +1,19 @@
 <?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
 
 namespace TaxJar\SalesTax\Plugin;
 

--- a/Plugin/TaxClassPlugin.php
+++ b/Plugin/TaxClassPlugin.php
@@ -1,4 +1,19 @@
 <?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
 
 namespace TaxJar\SalesTax\Plugin;
 
@@ -18,7 +33,6 @@ class TaxClassPlugin
      */
     protected $customerFactory;
 
-
     /**
      * @var \Taxjar\SalesTax\Model\SyncCustomers
      */
@@ -28,9 +42,7 @@ class TaxClassPlugin
     {
         $this->customerSync = $customerSync;
         $this->customerFactory = $customerFactory;
-
     }
-
 
     public function beforeSave($taxClassRepo, $taxClass)
     {
@@ -40,14 +52,12 @@ class TaxClassPlugin
     public function afterSave($taxClassRepo, $id, $taxClass)
     {
         if ('CUSTOMER' == $taxClass->getClassType()) {
-
             // On change we need to loop through all the affected customers and sync/resync them
             // First verify that it's a change we care about
-
-            // Ned to do a join on group to grab the right class
+            // Need to do a join on group to grab the right class
             $customers = $this->customerFactory->create();
             $customers->getSelect()->join(
-                ['customer_group'=>$customers->getResource()->getTable('customer_group')],
+                ['customer_group' => $customers->getResource()->getTable('customer_group')],
                 'e.group_id = customer_group.customer_group_id',
                 ['tax_class_id'])
                 ->where('tax_class_id = ? ', $taxClass->getId());
@@ -63,6 +73,7 @@ class TaxClassPlugin
             // This process can take awhile
             @set_time_limit(0);
             @ignore_user_abort(true);
+
             foreach ($customers as $customer) {
                 $this->customerSync->updateCustomer($customer);
             }

--- a/Plugin/TaxClassPlugin.php
+++ b/Plugin/TaxClassPlugin.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace TaxJar\SalesTax\Plugin;
+
+use Magento\Tax\Model\ClassModel;
+use Taxjar\SalesTax\Model\SyncCustomers;
+use \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
+
+class TaxClassPlugin
+{
+    /**
+     * @var \Taxjar\SalesTax\Model\SyncCustomers
+     */
+    protected $customerSync;
+
+    /**
+     * @var \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory
+     */
+    protected $customerFactory;
+
+
+    /**
+     * @var \Taxjar\SalesTax\Model\SyncCustomers
+     */
+    protected $originalTaxClassData;
+
+    public function __construct(SyncCustomers $customerSync, CollectionFactory $customerFactory)
+    {
+        $this->customerSync = $customerSync;
+        $this->customerFactory = $customerFactory;
+
+    }
+
+
+    public function beforeSave($taxClassRepo, $taxClass)
+    {
+        $this->originalTaxClassData = $taxClassRepo->get($taxClass->getId())->getData();
+    }
+
+    public function afterSave($taxClassRepo, $id, $taxClass)
+    {
+        if ('CUSTOMER' == $taxClass->getClassType()) {
+
+            // On change we need to loop through all the affected customers and sync/resync them
+            // First verify that it's a change we care about
+
+            // Ned to do a join on group to grab the right class
+            $customers = $this->customerFactory->create();
+            $customers->getSelect()->join(
+                ['customer_group'=>$customers->getResource()->getTable('customer_group')],
+                'e.group_id = customer_group.customer_group_id',
+                ['tax_class_id'])
+                ->where('tax_class_id = ? ', $taxClass->getId());
+
+            if ('' == $taxClass->getTjSalestaxCode() && '' == $this->originalTaxClassData['tj_salestax_code']) {
+                // * No -> No -- Don't sync
+                return;
+            } else if (('99999' == $taxClass->getTjSalestaxCode() && '99999' == $this->originalTaxClassData['tj_salestax_code']) && ($taxClass->getTjSalestaxExemptType() == $this->originalTaxClassData['tj_salestax_exempt_type'])) {
+                // * Yes -> Yes -- Sync as exemption type
+                return;
+            }
+
+            // This process can take awhile
+            @set_time_limit(0);
+            @ignore_user_abort(true);
+            foreach ($customers as $customer) {
+                $this->customerSync->updateCustomer($customer);
+            }
+        }
+    }
+}

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -1,0 +1,41 @@
+<?php
+namespace TaxJar\SalesTax\Setup;
+
+use Magento\Eav\Setup\EavSetupFactory;
+use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Customer\Model\Customer;
+
+class UpgradeData implements UpgradeDataInterface
+{
+    private $eavSetupFactory;
+
+    public function __construct(EavSetupFactory $eavSetupFactory)
+    {
+        $this->eavSetupFactory = $eavSetupFactory;
+    }
+
+    public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+
+        if (version_compare($context->getVersion(), '1.1.0', '<')) {
+            $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
+
+            $eavSetup->addAttribute(
+                Customer::ENTITY,
+                'tj_salestax_sync_date',
+                [
+                    'type' => 'static',
+                    'visible' => false,
+                    'default' => false,
+                    'system' => 0, // <-- important, to have the value be saved
+                ]
+            );
+        }
+
+        $setup->endSetup();
+
+    }
+}

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
 namespace TaxJar\SalesTax\Setup;
 
 use Magento\Eav\Setup\EavSetupFactory;
@@ -36,6 +52,5 @@ class UpgradeData implements UpgradeDataInterface
         }
 
         $setup->endSetup();
-
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -86,5 +86,42 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
             $installer->endSetup();
         }
+
+
+        if (version_compare($context->getVersion(), '1.1.0') < 0) {
+            $installer = $setup;
+            $installer->startSetup();
+
+            /**
+             * Update table 'tax_class'
+             */
+            $installer->getConnection()->addColumn(
+                $installer->getTable('tax_class'),
+                'tj_salestax_exempt_type',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'default' => 'non_exempt',
+                    'length' => 255,
+                    'nullable' => false,
+                    'comment' => 'TaxJar Sales Tax Exempt Type'
+                ]
+            );
+
+            /**
+             * Update table 'customer_entity'
+             */
+            $installer->getConnection()->addColumn(
+                $installer->getTable('customer_entity'),
+                'tj_salestax_sync_date',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
+                    'default' => '',
+                    'nullable' => true,
+                    'comment' => 'TaxJar Sales Tax Last Sync Date'
+                ]
+            );
+
+            $installer->endSetup();
+        }
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -87,7 +87,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $installer->endSetup();
         }
 
-
         if (version_compare($context->getVersion(), '1.1.0') < 0) {
             $installer = $setup;
             $installer->startSetup();

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -28,4 +28,10 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Customer\Model\Customer">
+        <plugin name="taxjar_customer_plugin_customer" type="Taxjar\SalesTax\Plugin\CustomerPlugin" sortOrder="1" />
+    </type>
+    <type name="Magento\Customer\Model\Address">
+        <plugin name="taxjar_customer_plugin_addres" type="Taxjar\SalesTax\Plugin\AddressPlugin" sortOrder="1" />
+    </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -32,6 +32,12 @@
         <plugin name="taxjar_customer_plugin_customer" type="Taxjar\SalesTax\Plugin\CustomerPlugin" sortOrder="1" />
     </type>
     <type name="Magento\Customer\Model\Address">
-        <plugin name="taxjar_customer_plugin_addres" type="Taxjar\SalesTax\Plugin\AddressPlugin" sortOrder="1" />
+        <plugin name="taxjar_customer_address_plugin" type="Taxjar\SalesTax\Plugin\AddressPlugin" sortOrder="1" />
+    </type>
+    <type name="Magento\Tax\Api\TaxClassRepositoryInterface">
+        <plugin name="taxjar_tax_class_plugin" type="Taxjar\SalesTax\Plugin\TaxClassPlugin" sortOrder="1" />
+    </type>
+    <type name="Magento\Customer\Api\GroupRepositoryInterface">
+        <plugin name="taxjar_customer_group_plugin" type="Taxjar\SalesTax\Plugin\CustomerGroupPlugin" sortOrder="1" />
     </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -18,7 +18,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module:etc/module.xsd">
     <!-- Database Setup Version -->
-    <module name="Taxjar_SalesTax" setup_version="1.0.0">
+    <module name="Taxjar_SalesTax" setup_version="1.1.0">
         <sequence>
             <module name="Magento_Enterprise"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
Sends customers to taxjar on update and create. Removes customers using the endpoint on the delete event. Watching for changes on Customer TaxClass Model as well as Customer Group and auto-backfills the affected customers to sync changes to exemption class or type. Adds two fields exemption type to the tax_class table and last sync date to the customer_entity table. 