### PR TITLE
Fix Partial Refund Transaction Sync

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -267,10 +267,10 @@ class Transaction
             if (isset($parentItemId)) {
                 switch ($attr) {
                     case 'discount':
-                        $amount = (float) ($type == 'order') ? $item->getDiscountAmount() : $item->getDiscountRefunded();
+                        $amount = (float) (($type == 'order') ? $item->getDiscountAmount() : $item->getDiscountRefunded());
                         break;
                     case 'tax':
-                        $amount = (float) ($type == 'order') ? $item->getTaxAmount() : $item->getTaxRefunded();
+                        $amount = (float) (($type == 'order') ? $item->getTaxAmount() : $item->getTaxRefunded());
                         break;
                 }
 

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -184,8 +184,8 @@ class Transaction
      */
     protected function buildLineItems($order, $items, $type = 'order') {
         $lineItems = [];
-        $parentDiscounts = $this->getParentAmounts('discount', $items);
-        $parentTaxes = $this->getParentAmounts('tax', $items);
+        $parentDiscounts = $this->getParentAmounts('discount', $items, $type);
+        $parentTaxes = $this->getParentAmounts('tax', $items, $type);
 
         foreach ($items as $item) {
             if ($item->getParentItemId()) {
@@ -218,8 +218,10 @@ class Transaction
                 'sales_tax' => $tax
             ];
 
-            if ($type == 'refund') {
-                $lineItem['quantity'] = (int) $item->getQty();
+            if ($type == 'refund' && method_exists($item, 'getOrderItem')) {
+                $orderItem = $item->getOrderItem();
+                $lineItem['quantity'] = (int) $orderItem->getQtyRefunded();
+                $lineItem['unit_price'] = $orderItem->getAmountRefunded() / $lineItem['quantity'];
             }
 
             $product = $this->productFactory->create()->load($item->getProductId());
@@ -243,11 +245,12 @@ class Transaction
     /**
      * Get parent amounts (discounts, tax, etc) for configurable / bundle products
      *
-     * @param string $type
+     * @param string $attr
      * @param array $items
+     * @param string $type
      * @return array
      */
-    protected function getParentAmounts($type, $items) {
+    protected function getParentAmounts($attr, $items, $type = 'order') {
         $parentAmounts = [];
 
         foreach ($items as $item) {
@@ -262,12 +265,12 @@ class Transaction
             }
 
             if (isset($parentItemId)) {
-                switch ($type) {
+                switch ($attr) {
                     case 'discount':
-                        $amount = (float) $item->getDiscountAmount();
+                        $amount = (float) ($type == 'order') ? $item->getDiscountAmount() : $item->getDiscountRefunded();
                         break;
                     case 'tax':
-                        $amount = (float) $item->getTaxAmount();
+                        $amount = (float) ($type == 'order') ? $item->getTaxAmount() : $item->getTaxRefunded();
                         break;
                 }
 


### PR DESCRIPTION
This PR better supports credit memos with partial refunds, either modified quantities by line item or fixed adjustments applied to the order. Shipping discounts are unavailable for credit memos, so the remainder of the total discount after subtracting line item discounts is used instead.