### PR TITLE
When rendering orders/credit memos in the admin grids, ensure the orders exist

### DIFF
--- a/Ui/Component/Listing/Column/SyncedCreditmemo.php
+++ b/Ui/Component/Listing/Column/SyncedCreditmemo.php
@@ -7,6 +7,7 @@ use \Magento\Framework\View\Element\UiComponentFactory;
 use \Magento\Ui\Component\Listing\Columns\Column;
 use \Magento\Framework\Api\SearchCriteriaBuilder;
 use \Magento\Framework\Stdlib\DateTime\Timezone;
+use \Magento\Framework\Exception\NoSuchEntityException;
 
 class SyncedCreditmemo extends Column
 {
@@ -57,8 +58,13 @@ class SyncedCreditmemo extends Column
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
-                $creditmemo = $this->creditmemoRepository->get($item['entity_id']);
                 $creditmemoSyncDate = '';
+
+                try {
+                    $creditmemo = $this->creditmemoRepository->get($item['entity_id']);
+                } catch( NoSuchEntityException $e) {
+                    $this->logger->log($e->getMessage() . ', entity id: ' . $item['entity_id']);
+                }
 
                 if ($creditmemo->getTjSalestaxSyncDate()) {
                     $creditmemoSyncDate = $this->timezone->formatDate(

--- a/Ui/Component/Listing/Column/SyncedCreditmemo.php
+++ b/Ui/Component/Listing/Column/SyncedCreditmemo.php
@@ -39,6 +39,7 @@ class SyncedCreditmemo extends Column
      * @param CreditmemoRepositoryInterface $creditmemoRepository
      * @param SearchCriteriaBuilder $criteria
      * @param Timezone $timezone
+     * @param \Taxjar\SalesTax\Model\Logger $logger
      * @param array $components
      * @param array $data
      */

--- a/Ui/Component/Listing/Column/SyncedOrder.php
+++ b/Ui/Component/Listing/Column/SyncedOrder.php
@@ -72,16 +72,16 @@ class SyncedOrder extends Column
 
                 try {
                     $order = $this->orderRepository->get($item['entity_id']);
+
+                    if ($order->getTjSalestaxSyncDate()) {
+                        $orderSyncDate = $this->timezone->formatDate(
+                            new \DateTime($order->getTjSalestaxSyncDate()),
+                            \IntlDateFormatter::MEDIUM,
+                            true
+                        );
+                    }
                 } catch (NoSuchEntityException $e) {
                     $this->logger->log($e->getMessage() . ', entity id: ' . $item['entity_id']);
-                }
-
-                if ($order->getTjSalestaxSyncDate()) {
-                    $orderSyncDate = $this->timezone->formatDate(
-                        new \DateTime($order->getTjSalestaxSyncDate()),
-                        \IntlDateFormatter::MEDIUM,
-                        true
-                    );
                 }
 
                 // $this->getData('name') returns the name of the column so in this case it would return export_status


### PR DESCRIPTION
In order to ensure the admin grids load reliably we need to confirm the orders exist.   We do this be catching a NoSuchEntityException when loading the orders and credit memos by ID.  