### PR TITLE
Magento 2.3 Composer Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "version": "1.1.0",
     "license": "OSL-3.0",
     "require": {
-        "magento/framework": "^100.1.0|^101.0.0"
+        "magento/framework": "^100.1.0|^101.0.0|^102.0.0"
     },
     "autoload": {
         "files": [ "registration.php" ],


### PR DESCRIPTION
This PR updates composer.json to support magento/framework 102.0.0.