### PR TITLE
Fix notice when iterating over empty line items

### DIFF
--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -74,7 +74,7 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
             $this->buildLineItems($order, $creditmemo->getAllItems(), 'refund')
         );
 
-        if(isset($this->request['line_items'])) {
+        if (isset($this->request['line_items'])) {
             foreach ($this->request['line_items'] as $lineItem) {
                 $itemDiscounts += $lineItem['discount'];
             }

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -74,8 +74,10 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
             $this->buildLineItems($order, $creditmemo->getAllItems(), 'refund')
         );
 
-        foreach ($this->request['line_items'] as $lineItem) {
-            $itemDiscounts += $lineItem['discount'];
+        if(isset($this->request['line_items'])) {
+            foreach ($this->request['line_items'] as $lineItem) {
+                $itemDiscounts += $lineItem['discount'];
+            }
         }
 
         if ((abs($discount) - $itemDiscounts) > 0) {


### PR DESCRIPTION
Add a check to ensure the line items array is initialized before we
attempt to iterate over it to prevent a notice from being thrown.