### PR TITLE
Rename Tax Category "None" to "Fully Taxable"

### DIFF
--- a/Model/Config/Taxclass/Source/Category.php
+++ b/Model/Config/Taxclass/Source/Category.php
@@ -54,7 +54,7 @@ class Category implements \Magento\Framework\Option\ArrayInterface
 
         $output = [
             [
-                'label' => 'None',
+                'label' => 'Fully Taxable',
                 'value' => ''
             ]
         ];


### PR DESCRIPTION
When choosing a TaxJar Category for Product Tax Classes, the "None"
category was confusing users who mistakenly assumed it meant no taxes
would be applied. Renaming it to "Fully Taxable" should help clarify
the proper use case.