### PR TITLE
Make Nexus street, city and postcode optional

### DIFF
--- a/Block/Adminhtml/Tax/Nexus/Edit/Form.php
+++ b/Block/Adminhtml/Tax/Nexus/Edit/Form.php
@@ -184,7 +184,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             [
                 'name' => 'street',
                 'label' => __('Street Address'),
-                'required' => true,
                 'value' => isset($formValues['street']) ? $formValues['street'] : ''
             ]
         );
@@ -195,7 +194,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             [
                 'name' => 'city',
                 'label' => __('City'),
-                'required' => true,
                 'value' => isset($formValues['city']) ? $formValues['city'] : ''
             ]
         );
@@ -229,7 +227,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             [
                 'name' => 'postcode',
                 'label' => __('Zip/Post Code'),
-                'required' => true,
                 'value' => isset($formValues['postcode']) ? $formValues['postcode'] : ''
             ]
         );

--- a/Controller/Adminhtml/Nexus/Index.php
+++ b/Controller/Adminhtml/Nexus/Index.php
@@ -28,7 +28,7 @@ class Index extends \Taxjar\SalesTax\Controller\Adminhtml\Nexus
         $resultPage->addBreadcrumb(__('Manage Nexus Addresses'), __('Manage Nexus Addresses'));
         $resultPage->getConfig()->getTitle()->prepend(__('Nexus Addresses'));
 
-        $this->_reviewNexusAddresses();
+//        $this->_reviewNexusAddresses();
 
         return $resultPage;
     }

--- a/Model/Tax/Nexus/Repository.php
+++ b/Model/Tax/Nexus/Repository.php
@@ -183,20 +183,8 @@ class Repository implements \Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface
         $exception = new InputException();
         // @codingStandardsIgnoreEnd
 
-        if (!\Zend_Validate::is(trim($nexus->getStreet()), 'NotEmpty')) {
-            $exception->addError(__('%fieldName is a required field.', ['fieldName' => Nexus::KEY_STREET]));
-        }
-
-        if (!\Zend_Validate::is(trim($nexus->getCity()), 'NotEmpty')) {
-            $exception->addError(__('%fieldName is a required field.', ['fieldName' => Nexus::KEY_CITY]));
-        }
-
         if (!\Zend_Validate::is(trim($nexus->getCountryId()), 'NotEmpty')) {
             $exception->addError(__('%fieldName is a required field.', ['fieldName' => Nexus::KEY_COUNTRY_ID]));
-        }
-
-        if (!\Zend_Validate::is(trim($nexus->getPostcode()), 'NotEmpty')) {
-            $exception->addError(__('%fieldName is a required field.', ['fieldName' => Nexus::KEY_POSTCODE]));
         }
 
         $countryFilter = $this->filterBuilder


### PR DESCRIPTION
Change Nexus Address street, city and postcode to be optional and
disable the warning when they are missing.