### PR TITLE
Ensure country/state is set when syncing TJ nexus

### DIFF
--- a/Model/Tax/Nexus/Repository.php
+++ b/Model/Tax/Nexus/Repository.php
@@ -187,6 +187,11 @@ class Repository implements \Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface
             $exception->addError(__('%fieldName is a required field.', ['fieldName' => Nexus::KEY_COUNTRY_ID]));
         }
 
+        if (($nexus->getCountryId() == 'US' || $nexus->getCountryId() == 'CA') &&
+            !\Zend_Validate::is($nexus->getRegionId(), 'NotEmpty')) {
+            $exception->addError(__('State can\'t be empty if country is US/Canada'));
+        }
+
         $countryFilter = $this->filterBuilder
             ->setField('country_id')
             ->setValue($nexus->getCountryId())

--- a/Model/Tax/NexusSync.php
+++ b/Model/Tax/NexusSync.php
@@ -164,6 +164,14 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
             $addresses = $nexusJson['addresses'];
 
             foreach ($addresses as $address) {
+                if (!isset($address['country']) || empty($address['country'])) {
+                    continue;
+                }
+
+                if (($address['country'] == 'US' || $address['country'] == 'CA') && (!isset($address['state']) || empty($address['state']))) {
+                    continue;
+                }
+
                 $addressRegion = $this->regionFactory->create()->loadByCode($address['state'], $address['country']);
                 $addressCountry = $this->countryFactory->create()->loadByCode($address['country']);
                 $addressCollection = $this->nexusFactory->create()->getCollection();


### PR DESCRIPTION
When syncing nexus addresses from TaxJar, ensure the country is set
before saving the address. If the country is US/Canada, ensure the
state is also set.