### PR TITLE
Create var/tmp if the directory doesn't exist

### DIFF
--- a/Observer/ImportRates.php
+++ b/Observer/ImportRates.php
@@ -242,6 +242,7 @@ class ImportRates implements ObserverInterface
 
         try {
             $dir = $this->directoryList->getPath(DirectoryList::TMP);
+
             if (!$this->driverFile->isDirectory($dir)) {
                 $this->driverFile->createDirectory($dir);
             }

--- a/Observer/ImportRates.php
+++ b/Observer/ImportRates.php
@@ -241,6 +241,11 @@ class ImportRates implements ObserverInterface
         $this->_purgeRates();
 
         try {
+            $dir = $this->directoryList->getPath(DirectoryList::TMP);
+            if (!$this->driverFile->isDirectory($dir)) {
+                $this->driverFile->createDirectory($dir);
+            }
+
             if ($this->driverFile->filePutContents($this->_getTempRatesFileName(), serialize($ratesJson)) !== false) {
                 ignore_user_abort(true);
 


### PR DESCRIPTION
Before writing to the var/tmp directory, check to see if it exists.  If
it does not, create it.