### PR TITLE
Product tax classes link causes 404 error

### DIFF
--- a/view/adminhtml/templates/enabled.phtml
+++ b/view/adminhtml/templates/enabled.phtml
@@ -32,7 +32,7 @@
 
   <p><b>Getting Started</b></p>
   <p><a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/nexus/index')) ?>'>Nexus Addresses</a><br/><span style='font-size: 0.9em'>Before enabling SmartCalcs, set up your nexus addresses so TaxJar knows where to collect sales tax.</span></p>
-  <p><a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/taxclass/index')) ?>'>Product Tax Classes</a><br/><span style='font-size: 0.9em'>If some of your products are tax-exempt, assign a TaxJar category tax code for new or existing product tax classes.</span></p>
+  <p><a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/taxclass_product')) ?>'>Product Tax Classes</a><br/><span style='font-size: 0.9em'>If some of your products are tax-exempt, assign a TaxJar category tax code for new or existing product tax classes.</span></p>
   <p><a href='http://www.taxjar.com/contact/' target='_blank'>Help & Support</a><br/><span style='font-size: 0.9em'>Need help setting up SmartCalcs? Get in touch with our Magento sales tax experts.</span></p><br/>
 
   <p><button type='button' class='scalable delete' onclick='if (window.confirm("Are you sure you want to disconnect from TaxJar? This will remove all TaxJar rates from your Magento store. If you have a paid TaxJar subscription, manage your account at https://app.taxjar.com.")) window.location="<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/disconnect')) ?>"'><span>Disconnect TaxJar</span></button>&nbsp;&nbsp;<button type='button' class='scalable' onclick='window.open("http://www.taxjar.com/guides/integrations/magento/", "_blank")'><span>Learn More</span></button></p><br/>


### PR DESCRIPTION
The Product Tax Classes link (admin > Stores > Configuration > Sales >
Tax) pointed to an incorrect URL and caused a 404 error.