### PR TITLE
Fix warning when iterating over an empty array

### DIFF
--- a/Model/Tax/TaxCalculation.php
+++ b/Model/Tax/TaxCalculation.php
@@ -236,6 +236,10 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
         $jurisdictionTaxRates = $extensionAttributes ? $extensionAttributes->getJurisdictionTaxRates() : [];
         $appliedTaxes = [];
 
+        if (empty($jurisdictionTaxRates)) {
+            return $appliedTaxes;
+        }
+
         foreach ($jurisdictionTaxRates as $jurisdiction => $jurisdictionTax) {
             if ($jurisdictionTax['rate'] == 0) {
                 continue;


### PR DESCRIPTION
The call to $extensionAttributes->getJurisdictionTaxRates() returns
array|null, which can throw a warning if iterated over.  This commit
adds a check to ensure the variable isn't null before iterating it.