### PR TITLE
Scope product tax class to relevant website

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -43,9 +43,9 @@ class Transaction
     protected $clientFactory;
 
     /**
-     * @var \Magento\Catalog\Model\ProductFactory
+     * @var \Magento\Catalog\Model\ProductRepository
      */
-    protected $productFactory;
+    protected $productRepository;
 
     /**
      * @var \Magento\Tax\Api\TaxClassRepositoryInterface
@@ -60,7 +60,7 @@ class Transaction
     /**
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Taxjar\SalesTax\Model\ClientFactory $clientFactory
-     * @param \Magento\Catalog\Model\ProductFactory $productFactory
+     * @param \Magento\Catalog\Model\ProductRepository $productRepository
      * @param \Magento\Directory\Model\RegionFactory $regionFactory
      * @param \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassRepository
      * @param \Taxjar\SalesTax\Model\Logger $logger
@@ -68,14 +68,14 @@ class Transaction
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Taxjar\SalesTax\Model\ClientFactory $clientFactory,
-        \Magento\Catalog\Model\ProductFactory $productFactory,
+        \Magento\Catalog\Model\ProductRepository $productRepository,
         \Magento\Directory\Model\RegionFactory $regionFactory,
         \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassRepository,
         \Taxjar\SalesTax\Model\Logger $logger
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->clientFactory = $clientFactory;
-        $this->productFactory = $productFactory;
+        $this->productRepository = $productRepository;
         $this->regionFactory = $regionFactory;
         $this->taxClassRepository = $taxClassRepository;
         $this->logger = $logger->setFilename(TaxjarConfig::TAXJAR_TRANSACTIONS_LOG);
@@ -238,7 +238,7 @@ class Transaction
                 $lineItem['unit_price'] = $orderItem->getAmountRefunded() / $lineItem['quantity'];
             }
 
-            $product = $this->productFactory->create()->load($item->getProductId());
+            $product = $this->productRepository->getById($item->getProductId(), false, $order->getStoreId());
 
             if ($product->getTaxClassId()) {
                 $taxClass = $this->taxClassRepository->get($product->getTaxClassId());


### PR DESCRIPTION
A bug occurred when syncing transactions to TaxJar if the product tax
class was different across websites (it would always grab the default
tax class).  Changing ProductFactory to ProductRepository allows us to
load products with the relevant website data.