### PR TITLE
Enforce rounding prices and taxes

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -85,6 +85,11 @@ class Smartcalcs
     protected $logger;
 
     /**
+     * @var \Magento\Framework\Pricing\PriceCurrencyInterface
+     */
+    protected $priceCurrency;
+
+    /**
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param RegionFactory $regionFactory
      * @param NexusFactory $nexusFactory
@@ -93,6 +98,7 @@ class Smartcalcs
      * @param ZendClientFactory $clientFactory
      * @param ProductMetadata $productMetadata
      * @param \Magento\Tax\Helper\Data $taxData
+     * @param \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency
      */
     public function __construct(
         \Magento\Checkout\Model\Session $checkoutSession,
@@ -104,7 +110,8 @@ class Smartcalcs
         ProductMetadata $productMetadata,
         \Magento\Tax\Helper\Data $taxData,
         \Magento\Directory\Model\Country\Postcode\ConfigInterface $postCodesConfig,
-        \Taxjar\SalesTax\Model\Logger $logger
+        \Taxjar\SalesTax\Model\Logger $logger,
+        \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->regionFactory = $regionFactory;
@@ -116,6 +123,7 @@ class Smartcalcs
         $this->taxData = $taxData;
         $this->postCodesConfig = $postCodesConfig;
         $this->logger = $logger->setFilename(TaxjarConfig::TAXJAR_CALCULATIONS_LOG);
+        $this->priceCurrency = $priceCurrency;
     }
 
     /**
@@ -417,7 +425,7 @@ class Smartcalcs
                     $id = $item->getCode();
                     $parentId = $item->getParentCode();
                     $quantity = $item->getQuantity();
-                    $unitPrice = (float) $item->getUnitPrice();
+                    $unitPrice = (float) round($item->getUnitPrice(), $this->priceCurrency::DEFAULT_PRECISION);
                     $discount = (float) $item->getDiscountAmount();
                     $extensionAttributes = $item->getExtensionAttributes();
                     $taxCode = '';

--- a/Model/Tax/TaxCalculation.php
+++ b/Model/Tax/TaxCalculation.php
@@ -187,21 +187,22 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
         $useBaseCurrency,
         $scope
     ) {
-        $price = $item->getUnitPrice();
+        $price = (float) round($item->getUnitPrice(), $this->priceCurrency::DEFAULT_PRECISION);
         $quantity = $this->getTotalQuantity($item);
 
         $extensionAttributes = $item->getExtensionAttributes();
-        $taxCollectable = $extensionAttributes ? $extensionAttributes->getTaxCollectable() : 0;
+        $taxCollectable = $extensionAttributes ?
+            (float) round($extensionAttributes->getTaxCollectable(), $this->priceCurrency::DEFAULT_PRECISION) : 0;
         $taxPercent = $extensionAttributes ? $extensionAttributes->getCombinedTaxRate() : 0;
 
         if (!$useBaseCurrency) {
-            $taxCollectable = $this->priceCurrency->convert($taxCollectable, $scope);
+            $taxCollectable = $this->priceCurrency->convertAndRound($taxCollectable, $scope);
         }
 
-        $rowTotal = $price * $quantity;
+        $rowTotal = (float) round($price * $quantity, $this->priceCurrency::DEFAULT_PRECISION);
         $rowTotalInclTax = $rowTotal + $taxCollectable;
 
-        $priceInclTax = $rowTotalInclTax / $quantity;
+        $priceInclTax = (float) round($rowTotalInclTax / $quantity, $this->priceCurrency::DEFAULT_PRECISION);
         $discountTaxCompensationAmount = 0;
 
         $appliedTaxes = $this->getAppliedTaxes($item, $scope);

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -58,12 +58,18 @@ class Transaction
     protected $client;
 
     /**
+     * @var \Magento\Framework\Pricing\PriceCurrencyInterface
+     */
+    protected $priceCurrency;
+
+    /**
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Taxjar\SalesTax\Model\ClientFactory $clientFactory
      * @param \Magento\Catalog\Model\ProductFactory $productFactory
      * @param \Magento\Directory\Model\RegionFactory $regionFactory
      * @param \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassRepository
      * @param \Taxjar\SalesTax\Model\Logger $logger
+     * @param \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
@@ -71,7 +77,8 @@ class Transaction
         \Magento\Catalog\Model\ProductFactory $productFactory,
         \Magento\Directory\Model\RegionFactory $regionFactory,
         \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassRepository,
-        \Taxjar\SalesTax\Model\Logger $logger
+        \Taxjar\SalesTax\Model\Logger $logger,
+        \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->clientFactory = $clientFactory;
@@ -79,6 +86,7 @@ class Transaction
         $this->regionFactory = $regionFactory;
         $this->taxClassRepository = $taxClassRepository;
         $this->logger = $logger->setFilename(TaxjarConfig::TAXJAR_TRANSACTIONS_LOG);
+        $this->priceCurrency = $priceCurrency;
 
         $this->client = $this->clientFactory->create();
         $this->client->showResponseErrors(true);
@@ -227,7 +235,7 @@ class Transaction
                 'quantity' => (int) $item->getQtyOrdered(),
                 'product_identifier' => $item->getSku(),
                 'description' => $item->getName(),
-                'unit_price' => (float) $item->getPrice(),
+                'unit_price' => (float) round($item->getPrice(), $this->priceCurrency::DEFAULT_PRECISION),
                 'discount' => $discount,
                 'sales_tax' => $tax
             ];


### PR DESCRIPTION
Tier prices have the option to apply a percent discount to an items
price which isn't limited by the typical decimal precision.  To ensure
there are no rounding errors, force rounding all prices and tax
calculations based on the default precision.