### PR TITLE
Address Validation Customer edit address bug

### DIFF
--- a/view/base/web/js/address_validation.js
+++ b/view/base/web/js/address_validation.js
@@ -24,6 +24,10 @@ define([
     'use strict';
 
     return function (addressValidation) {
+        if (!$('#tj-suggested-addresses').length) {
+            return $.mage.addressValidation;
+        }
+
         $.widget('mage.addressValidation', $.mage.addressValidation, {
             /**
              * Validation creation


### PR DESCRIPTION
When running M2 in production mode, a JS is thrown when a customer
adds/edits their address that prevents the default address validation
from running.  Returning the default validator if the suggested
address div doesn't exist fixes this.