### PR TITLE
PI-202 Fix Magento 2.2 front-end address validation when editing customers in admin panel

### DIFF
--- a/view/adminhtml/ui_component/customer_form.xml
+++ b/view/adminhtml/ui_component/customer_form.xml
@@ -24,7 +24,10 @@
                     <item name="id" xsi:type="string">validate-address-button</item>
                     <item name="title" xsi:type="string" translate="true">Validate Address</item>
                     <item name="dataType" xsi:type="string">text</item>
-                    <item name="formElement" xsi:type="string">button</item>
+                    <item name="formElement" xsi:type="string">input</item>
+                    <item name="component" xsi:type="string">Taxjar_SalesTax/js/form/element/input_button</item>
+                    <item name="template" xsi:type="string">ui/form/field</item>
+                    <item name="elementTmpl" xsi:type="string">Taxjar_SalesTax/form/element/input_button</item>
                     <item name="actions" xsi:type="array">
                         <item name="0" xsi:type="array">
                             <item name="targetName" xsi:type="string">addressValidation</item>

--- a/view/adminhtml/web/js/form/element/input_button.js
+++ b/view/adminhtml/web/js/form/element/input_button.js
@@ -1,0 +1,79 @@
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+define([
+    'Magento_Ui/js/form/element/abstract',
+    'uiRegistry',
+    'mageUtils'
+], function(Abstract, registry, utils) {
+    return Abstract.extend({
+        defaults: {
+            visible: true,
+            disabled: false,
+            title: ''
+        },
+
+        /**
+         * Initializes component, invokes initialize method of Abstract class.
+         *
+         *  @returns {Object} Chainable.
+         */
+        initialize: function () {
+            return this._super();
+        },
+
+        /**
+         * Init observables
+         *
+         * @returns {Object} Chainable.
+         */
+        initObservable: function () {
+            return this._super()
+                .observe([
+                    'visible',
+                    'disabled',
+                    'title',
+                    'childError'
+                ]);
+        },
+
+        /**
+         * Performs configured actions
+         */
+        action: function () {
+            this.actions.forEach(this.applyAction, this);
+        },
+
+        /**
+         * Apply action on target component
+         *
+         * @param {Object} action - action configuration
+         */
+        applyAction: function (action) {
+            var targetName = action.targetName,
+                params = utils.copy(action.params) || [],
+                actionName = action.actionName,
+                target;
+
+            target = registry.async(targetName);
+
+            if (target && typeof target === 'function' && actionName) {
+                params.unshift(actionName);
+                target.apply(target, params);
+            }
+        }
+    });
+});

--- a/view/adminhtml/web/template/form/element/input_button.html
+++ b/view/adminhtml/web/template/form/element/input_button.html
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+-->
+<input class="admin__control-button action-basic" click="action" type="button"
+    data-bind="
+        event: {change: userChanges},
+        value: title,
+        hasFocus: focused,
+        valueUpdate: valueUpdate,
+        attr: {
+            name: inputName,
+            placeholder: placeholder,
+            'aria-describedby': noticeId,
+            id: uid,
+            disabled: disabled,
+            maxlength: 255
+    }"/>


### PR DESCRIPTION
When address validation is enabled, this PR ensures customer addresses can be saved in the backend. Previously errors were returned for front-end validation when attempting to save a customer. By default, Magento will only invalidate standard form elements such as inputs and checkboxes.