### PR TITLE
Remove 99999s when product tax class is "none"

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -442,8 +442,6 @@ class Smartcalcs
                     if ($item->getTaxClassKey()->getValue()) {
                         $taxClass = $this->taxClassRepository->get($item->getTaxClassKey()->getValue());
                         $taxCode = $taxClass->getTjSalestaxCode();
-                    } else {
-                        $taxCode = TaxjarConfig::TAXJAR_EXEMPT_TAX_CODE;
                     }
 
                     if ($this->productMetadata->getEdition() == 'Enterprise') {

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -246,8 +246,6 @@ class Transaction
                 if ($taxClass->getTjSalestaxCode()) {
                     $lineItem['product_tax_code'] = $taxClass->getTjSalestaxCode();
                 }
-            } else {
-                $lineItem['product_tax_code'] = TaxjarConfig::TAXJAR_EXEMPT_TAX_CODE;
             }
 
             $lineItems['line_items'][] = $lineItem;

--- a/Ui/DataProvider/Product/Form/Modifier/TaxTip.php
+++ b/Ui/DataProvider/Product/Form/Modifier/TaxTip.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxjar\SalesTax\Ui\DataProvider\Product\Form\Modifier;
+
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
+
+class TaxTip extends AbstractModifier
+{
+    /**
+     * @param array $meta
+     * @return array
+     */
+    public function modifyMeta(array $meta)
+    {
+        if (isset($meta['product-details']['children']['container_tax_class_id']['children']['tax_class_id'])) {
+            $url = 'https://www.taxjar.com/guides/integrations/magento2/#product-sales-tax-exemptions';
+            $desc = 'TaxJar requires a product tax class assigned to a TaxJar category in order to exempt products from 
+                     sales tax. <a href="' . $url . '" target="_blank">Click here</a> to learn more.';
+            $meta['product-details']['children']['container_tax_class_id']['children']['tax_class_id']['arguments']
+            ['data']['config']['tooltip'] = ['description' => $desc];
+        }
+
+        return $meta;
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    public function modifyData(array $data)
+    {
+        return $data;
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool">
+    <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool" type="Magento\Ui\DataProvider\Modifier\Pool">
         <arguments>
             <argument name="modifiers" xsi:type="array">
                 <item name="TaxTip" xsi:type="array">

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool">
+        <arguments>
+            <argument name="modifiers" xsi:type="array">
+                <item name="TaxTip" xsi:type="array">
+                    <item name="class" xsi:type="string">Taxjar\SalesTax\Ui\DataProvider\Product\Form\Modifier\TaxTip</item>
+                    <item name="sortOrder" xsi:type="number">10</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
+</config>


### PR DESCRIPTION
Previously products with a tax class of "none" were assigned 99999 to
mark them as tax exempt.  This change removes that functionality and
requires users to pick a valid tax class to mark the product as exempt.
The "none" tax class now defaults to fully taxable.