### PR TITLE
AfterFiles plugin breaks when deploying production

### DIFF
--- a/Block/Adminhtml/AddressValidation.php
+++ b/Block/Adminhtml/AddressValidation.php
@@ -69,6 +69,7 @@ class AddressValidation extends Field
         if (!$this->isAuthorized()) {
             $element->setDisabled('disabled');
         }
+
         $this->_cacheElementValue($element);
 
         return parent::_getElementHtml($element) . $this->_toHtml();

--- a/Block/Adminhtml/AddressValidation.php
+++ b/Block/Adminhtml/AddressValidation.php
@@ -19,12 +19,18 @@ namespace Taxjar\SalesTax\Block\Adminhtml;
 
 use Magento\Backend\Block\Template\Context;
 use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 
 class AddressValidation extends Field
 {
+    /**
+     * @var \Magento\Framework\App\CacheInterface
+     */
+    protected $cache;
+
     /**
      * @var string
      */
@@ -38,13 +44,16 @@ class AddressValidation extends Field
     protected $scopeConfig;
 
     /**
+     * @param CacheInterface $cache
      * @param Context $context
      * @param array $data
      */
     public function __construct(
+        CacheInterface $cache,
         Context $context,
         array $data = []
     ) {
+        $this->cache = $cache;
         $this->scopeConfig = $context->getScopeConfig();
         parent::__construct($context, $data);
     }
@@ -60,8 +69,21 @@ class AddressValidation extends Field
         if (!$this->isAuthorized()) {
             $element->setDisabled('disabled');
         }
+        $this->_cacheElementValue($element);
 
         return parent::_getElementHtml($element) . $this->_toHtml();
+    }
+
+    /**
+     * Cache the element value
+     *
+     * @param AbstractElement $element
+     * @return void
+     */
+    protected function _cacheElementValue(AbstractElement $element)
+    {
+        $elementValue = (string) $element->getValue();
+        $this->cache->save($elementValue, 'taxjar_salestax_config_address_validation');
     }
 
     /**

--- a/Observer/ConfigReview.php
+++ b/Observer/ConfigReview.php
@@ -130,7 +130,7 @@ class ConfigReview implements ObserverInterface
 
         if (isset($prevEnabled) && $prevEnabled != $enabled) {
             // @codingStandardsIgnoreStart
-            $this->messageManager->addErrorMessage(__('Please redeploy production mode (bin/magento deploy:mode:set production) to ensure Address Validation works correctly.'));
+            $this->messageManager->addErrorMessage(__('Please redeploy production mode in the Magento CLI ($ bin/magento deploy:mode:set production) to ensure address validation works correctly.'));
             // @codingStandardsIgnoreEnd
         }
     }

--- a/Observer/ConfigReview.php
+++ b/Observer/ConfigReview.php
@@ -130,7 +130,7 @@ class ConfigReview implements ObserverInterface
 
         if (isset($prevEnabled) && $prevEnabled != $enabled) {
             // @codingStandardsIgnoreStart
-            $this->messageManager->addErrorMessage(__('Please redeploy production mode in the Magento CLI ($ bin/magento deploy:mode:set production) to ensure address validation works correctly.'));
+            $this->messageManager->addWarningMessage(__('Please redeploy production mode in the Magento CLI ($ bin/magento deploy:mode:set production) to ensure address validation works correctly.'));
             // @codingStandardsIgnoreEnd
         }
     }

--- a/Observer/ConfigReview.php
+++ b/Observer/ConfigReview.php
@@ -97,6 +97,7 @@ class ConfigReview implements ObserverInterface
 
             if ($enabled) {
                 $this->_reviewNexusAddresses();
+                $this->_reviewAddressValidation();
             }
         }
 
@@ -114,6 +115,22 @@ class ConfigReview implements ObserverInterface
         if (!$nexusAddresses->getSize()) {
             // @codingStandardsIgnoreStart
             $this->messageManager->addErrorMessage(__('You have no nexus addresses loaded in Magento. Go to Stores > Nexus Addresses to sync from your TaxJar account or add a new address.'));
+            // @codingStandardsIgnoreEnd
+        }
+    }
+
+    /**
+     * @return void
+     * @SuppressWarnings(Generic.Files.LineLength.TooLong)
+     */
+    private function _reviewAddressValidation()
+    {
+        $enabled = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_ADDRESS_VALIDATION);
+        $prevEnabled = $this->cache->load('taxjar_salestax_config_address_validation');
+
+        if (isset($prevEnabled) && $prevEnabled != $enabled) {
+            // @codingStandardsIgnoreStart
+            $this->messageManager->addErrorMessage(__('Please redeploy production mode (bin/magento deploy:mode:set production) to ensure Address Validation works correctly.'));
             // @codingStandardsIgnoreEnd
         }
     }

--- a/Plugin/RequireJs/AfterFiles.php
+++ b/Plugin/RequireJs/AfterFiles.php
@@ -21,6 +21,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\RequireJs\Config\File\Collector\Aggregated;
+use Magento\Theme\Model\Theme;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 
 class AfterFiles
@@ -49,27 +50,32 @@ class AfterFiles
 
     /**
      * @param Aggregated $subject
-     * @param $result
+     * @param array $result
+     * @param Theme $theme
      * @return mixed
      * @throws LocalizedException
      */
     public function afterGetFiles(
         Aggregated $subject,
-        $result
+        $result,
+        Theme $theme
     ) {
         $isEnabled = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_ADDRESS_VALIDATION);
+        $areaCode = '';
 
         try {
-            // If address validation is disabled, remove frontend RequireJs dependencies
-            if (!$isEnabled && $this->state->getAreaCode() == 'frontend') {
-                foreach ($result as $key => &$file) {
-                    if ($file->getModule() == 'Taxjar_SalesTax') {
-                        unset($result[$key]);
-                    }
-                }
-            }
+            $areaCode = $theme->getArea();
         } catch (LocalizedException $e) {
             // no-op
+        }
+
+        // If address validation is disabled, remove frontend RequireJs dependencies
+        if (!$isEnabled && $areaCode == 'frontend') {
+            foreach ($result as $key => &$file) {
+                if ($file->getModule() == 'Taxjar_SalesTax') {
+                    unset($result[$key]);
+                }
+            }
         }
 
         return $result;

--- a/Plugin/RequireJs/AfterFiles.php
+++ b/Plugin/RequireJs/AfterFiles.php
@@ -18,7 +18,6 @@
 namespace Taxjar\SalesTax\Plugin\RequireJs;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\RequireJs\Config\File\Collector\Aggregated;
 use Magento\Theme\Model\Theme;
@@ -32,20 +31,12 @@ class AfterFiles
     protected $scopeConfig;
 
     /**
-     * @var State
-     */
-    protected $state;
-
-    /**
      * @param ScopeConfigInterface $scopeConfig
-     * @param State $state
      */
     public function __construct(
-        ScopeConfigInterface $scopeConfig,
-        State $state
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->scopeConfig = $scopeConfig;
-        $this->state = $state;
     }
 
     /**

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -110,3 +110,4 @@ Region,Region
 "Debug Mode","Debug Mode"
 "API Token","API Token"
 "TaxJar Category Code","TaxJar Category Code"
+"Please redeploy production mode (bin/magento deploy:mode:set production) to ensure Address Validation works correctly.","Please redeploy production mode (bin/magento deploy:mode:set production) to ensure Address Validation works correctly."

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -110,4 +110,4 @@ Region,Region
 "Debug Mode","Debug Mode"
 "API Token","API Token"
 "TaxJar Category Code","TaxJar Category Code"
-"Please redeploy production mode (bin/magento deploy:mode:set production) to ensure Address Validation works correctly.","Please redeploy production mode (bin/magento deploy:mode:set production) to ensure Address Validation works correctly."
+"Please redeploy production mode in the Magento CLI ($ bin/magento deploy:mode:set production) to ensure address validation works correctly.","Please redeploy production mode in the Magento CLI ($ bin/magento deploy:mode:set production) to ensure address validation works correctly."


### PR DESCRIPTION
When setting the deployment mode to production, the call in AfterFiles
to $this->state->getAreaCode() always threw an exception because the
areacode is never set with CLI commands.  Getting the areacode from
$theme works around this issue.