### PR TITLE
Fail "hasNexus" check if region is empty

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -353,11 +353,11 @@ class Smartcalcs
      */
     private function _hasNexus($storeId, $regionCode, $country)
     {
-        if (empty($regionCode)) {
-            return false;
-        }
-
         if ($country == 'US') {
+            if (empty($regionCode)) {
+                return false;
+            }
+
             $nexusInRegion = $this->nexusFactory->create()->getCollection()
                 ->addStoreFilter($storeId)
                 ->addRegionCodeFilter($regionCode);

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -353,6 +353,10 @@ class Smartcalcs
      */
     private function _hasNexus($storeId, $regionCode, $country)
     {
+        if (empty($regionCode)) {
+            return false;
+        }
+
         if ($country == 'US') {
             $nexusInRegion = $this->nexusFactory->create()->getCollection()
                 ->addStoreFilter($storeId)


### PR DESCRIPTION
If no region code is provided, the nexus check was returning true even
though nexus may not exist.  Changed it to return false if no region is
provided.