### PR TITLE
Update error handling when missing address data

### DIFF
--- a/Model/AddressValidation.php
+++ b/Model/AddressValidation.php
@@ -106,11 +106,9 @@ class AddressValidation implements AddressValidationInterface
         $country = null,
         $postcode = null
     ) {
-        $errorResponse = ['error' => true, 'error_msg' => 'Unable to validate your address.'];
-
         // Ensure address validation is enabled
         if (!$this->canValidateAddress()) {
-            return $errorResponse;
+            return [];
         }
 
         // Format the address to match the endpoint's naming convention
@@ -125,7 +123,7 @@ class AddressValidation implements AddressValidationInterface
 
         // Validate address data locally
         if ($this->validateInput($addr) === false) {
-            return $errorResponse;
+            return [];
         }
 
         $results = [];
@@ -168,7 +166,7 @@ class AddressValidation implements AddressValidationInterface
         $storeScope = ScopeInterface::SCOPE_STORE;
         $validateAddress = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_ADDRESS_VALIDATION, $storeScope);
 
-        return (bool)$validateAddress;
+        return (bool) $validateAddress;
     }
 
     /**
@@ -242,7 +240,7 @@ class AddressValidation implements AddressValidationInterface
             return false;
         }
 
-        return $addr;
+        return true;
     }
 
     /**

--- a/Model/AddressValidation.php
+++ b/Model/AddressValidation.php
@@ -392,7 +392,7 @@ class AddressValidation implements AddressValidationInterface
         foreach ($simplediff as $diff) {
             if (is_array($diff)) {
                 $ret .= (!empty($diff['i']) ? '<span class="suggested-address-diff">' .
-                    implode(' ', $diff['i']) . '</span>' : '');
+                    implode(' ', $diff['i']) . '</span> ' : '');
             } else {
                 $ret .= $diff . ' ';
             }

--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -73,6 +73,10 @@ function (ko, $) {
                         // Intentionally empty to prevent the form_key from being appended to the body of the request
                     }
                 }).done(function (response) {
+                    if(response.length === 0) {
+                        return;
+                    }
+
                     self.activeAddress = formattedAddr;
                     self.updateSuggestedAddresses(response);
 

--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -73,10 +73,6 @@ function (ko, $) {
                         // Intentionally empty to prevent the form_key from being appended to the body of the request
                     }
                 }).done(function (response) {
-                    if(response.length === 0) {
-                        return;
-                    }
-
                     self.activeAddress = formattedAddr;
                     self.updateSuggestedAddresses(response);
 

--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -105,7 +105,7 @@ function (
         updateQuoteAddress: function (id) {
             var addrs = avCore.suggestedAddresses();
 
-            if (addrs !== undefined) {
+            if (addrs && addrs.length) {
                 var newAddr = $.extend({}, quote.shippingAddress(), addrs[id].address, { custom_attributes: { suggestedAddress: true } });
 
                 // Force shipping rates to recalculate


### PR DESCRIPTION
Remove the unused generic error message and return an empty array.  Add
a condition for empty suggested address arrays before attempting to
render them.  Minor code cleanup as well.