### PR TITLE
Fix performance issue when loading admin order grid

### DIFF
--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -119,6 +119,10 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
             $quote->getStoreId()
         );
 
+        if (!$isEnabled) {
+            return parent::collect($quote, $shippingAssignment, $total);
+        }
+
         if ($isEnabled) {
             $baseQuoteTaxDetails = $this->getQuoteTaxDetailsInterface($shippingAssignment, $total, true);
             $this->smartCalcs->getTaxForOrder($quote, $baseQuoteTaxDetails, $shippingAssignment);

--- a/Plugin/AddOrderSyncDateToOrderGrid.php
+++ b/Plugin/AddOrderSyncDateToOrderGrid.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Taxjar\SalesTax\Plugin;
+
+use Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory;
+use Magento\Sales\Model\ResourceModel\Order\Grid\Collection;
+
+class AddOrderSyncDateToOrderGrid
+{
+    /**
+     * @var Collection
+     */
+    private $collection;
+
+    public function __construct(
+        Collection $collection
+    ) {
+        $this->collection = $collection;
+    }
+
+    /**
+     * Join tj_salestax_sync_date in order grid
+     *
+     * @param CollectionFactory $subject
+     * @param $collection
+     * @return \Magento\Framework\Data\Collection
+     */
+    public function afterGetReport(
+        CollectionFactory $subject,
+        $collection
+    ) {
+        if ($collection instanceof Collection) {
+            $select = $collection->getSelect();
+            $select->joinLeft(
+                ['so' => 'sales_order'],
+                'main_table.entity_id = so.entity_id',
+                'tj_salestax_sync_date'
+            );
+        }
+
+        return $collection;
+    }
+}

--- a/Ui/Component/Listing/Column/SyncedOrder.php
+++ b/Ui/Component/Listing/Column/SyncedOrder.php
@@ -71,11 +71,9 @@ class SyncedOrder extends Column
                 $orderSyncDate = '';
 
                 try {
-                    $order = $this->orderRepository->get($item['entity_id']);
-
-                    if ($order->getTjSalestaxSyncDate()) {
+                    if (isset($item['tj_salestax_sync_date'])) {
                         $orderSyncDate = $this->timezone->formatDate(
-                            new \DateTime($order->getTjSalestaxSyncDate()),
+                            new \DateTime($item['tj_salestax_sync_date']),
                             \IntlDateFormatter::MEDIUM,
                             true
                         );

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -10,4 +10,8 @@
             </argument>
         </arguments>
     </virtualType>
+
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <plugin name="sales_order_additional_columns" type="Taxjar\SalesTax\Plugin\AddOrderSyncDateToOrderGrid" />
+    </type>
 </config>


### PR DESCRIPTION
When loading an admin order grid, especially with some more items than default, i.e. 200 orders, this massively slowed down loading times.
Now all the tax sync dates are retrieved in the initial collection, which increased loading time by 90% in my test case with 200 orders on a single page.