### PR TITLE
Initializing cache fails on Magento 2.1

### DIFF
--- a/Block/Adminhtml/AddressValidation.php
+++ b/Block/Adminhtml/AddressValidation.php
@@ -19,7 +19,6 @@ namespace Taxjar\SalesTax\Block\Adminhtml;
 
 use Magento\Backend\Block\Template\Context;
 use Magento\Config\Block\System\Config\Form\Field;
-use Magento\Framework\App\CacheInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
@@ -44,16 +43,15 @@ class AddressValidation extends Field
     protected $scopeConfig;
 
     /**
-     * @param CacheInterface $cache
+     * @param \Magento\Framework\App\CacheInterface $cache
      * @param Context $context
      * @param array $data
      */
     public function __construct(
-        CacheInterface $cache,
         Context $context,
         array $data = []
     ) {
-        $this->cache = $cache;
+        $this->cache = $context->getCache();
         $this->scopeConfig = $context->getScopeConfig();
         parent::__construct($context, $data);
     }


### PR DESCRIPTION
Magento 2.1 throws an error when compiling static files because the
cache can be retrieved from the Context.  Remove the cache interface
from the constructor and initialize it from the Context instead.