### PR TITLE
Don't recalculate tax on quote items when module is disabled

### DIFF
--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -119,10 +119,12 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
             $quote->getStoreId()
         );
 
-        if ($isEnabled) {
-            $baseQuoteTaxDetails = $this->getQuoteTaxDetailsInterface($shippingAssignment, $total, true);
-            $this->smartCalcs->getTaxForOrder($quote, $baseQuoteTaxDetails, $shippingAssignment);
+        if (!$isEnabled) {
+            return parent::collect($quote, $shippingAssignment, $total);
         }
+
+        $baseQuoteTaxDetails = $this->getQuoteTaxDetailsInterface($shippingAssignment, $total, true);
+        $this->smartCalcs->getTaxForOrder($quote, $baseQuoteTaxDetails, $shippingAssignment);
 
         if ($this->smartCalcs->isValidResponse()) {
             $quoteTax = $this->getQuoteTax($quote, $shippingAssignment, $total);


### PR DESCRIPTION
When creating multiple orders in the same process, the tax was recalculated for quotes which were in a store where TaxJar was disabled, because even though the `$isEnabled` check was used for getting tax, the `isValidResponse` succeeded, so the quote's tax was still recalculated.

Now when the module's disabled, just skip all and return to parent immediately.