### PR TITLE
PTC Expansion Refactor

### DIFF
--- a/Controller/Adminhtml/Config/Disconnect.php
+++ b/Controller/Adminhtml/Config/Disconnect.php
@@ -52,25 +52,33 @@ class Disconnect extends \Magento\Backend\App\AbstractAction
      */
     protected $storeManager;
 
+    /** @var
+     * \Taxjar\SalesTax\Model\ResourceModel\Tax\Category\Collection
+     */
+    protected $categories;
+
     /**
      * @param Context $context
      * @param Config $resourceConfig
      * @param ReinitableConfigInterface $reinitableConfig
      * @param NexusFactory $nexusFactory
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Taxjar\SalesTax\Model\ResourceModel\Tax\Category\Collection $categories
      */
     public function __construct(
         Context $context,
         Config $resourceConfig,
         ReinitableConfigInterface $reinitableConfig,
         NexusFactory $nexusFactory,
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Taxjar\SalesTax\Model\ResourceModel\Tax\Category\Collection $categories
     ) {
         $this->resourceConfig = $resourceConfig;
         $this->reinitableConfig = $reinitableConfig;
         $this->eventManager = $context->getEventManager();
         $this->nexusFactory = $nexusFactory;
         $this->storeManager = $storeManager;
+        $this->categories = $categories;
         parent::__construct($context);
     }
 
@@ -111,6 +119,7 @@ class Disconnect extends \Magento\Backend\App\AbstractAction
 
         $this->reinitableConfig->reinit();
         $this->_purgeNexusAddresses();
+        $this->_purgeProductTaxCategories();
 
         $this->messageManager->addSuccessMessage(__('Your TaxJar account has been disconnected.'));
 
@@ -130,5 +139,13 @@ class Disconnect extends \Magento\Backend\App\AbstractAction
             $nexusAddress->delete();
             // @codingStandardsIgnoreEnd
         }
+    }
+
+    /**
+     * Purge product tax categories on disconnect
+     */
+    private function _purgeProductTaxCategories()
+    {
+        $this->categories->walk('delete');
     }
 }

--- a/Model/Config/Taxclass/Source/Category.php
+++ b/Model/Config/Taxclass/Source/Category.php
@@ -11,14 +11,13 @@
  *
  * @category   Taxjar
  * @package    Taxjar_SalesTax
- * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
 namespace Taxjar\SalesTax\Model\Config\Taxclass\Source;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 
 class Category implements \Magento\Framework\Option\ArrayInterface
 {
@@ -32,16 +31,21 @@ class Category implements \Magento\Framework\Option\ArrayInterface
      */
     protected $helper;
 
+    /** @var \Taxjar\SalesTax\Model\ResourceModel\Tax\Category\Collection  */
+    protected $categories;
+
     /**
      * @param ScopeConfigInterface $scopeConfig
      * @param \Taxjar\SalesTax\Helper\Data $helper
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        \Taxjar\SalesTax\Helper\Data $helper
+        \Taxjar\SalesTax\Helper\Data $helper,
+        \Taxjar\SalesTax\Model\ResourceModel\Tax\Category\Collection $categories
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->helper = $helper;
+        $this->categories = $categories;
     }
 
     /**
@@ -49,9 +53,6 @@ class Category implements \Magento\Framework\Option\ArrayInterface
      */
     public function toOptionArray()
     {
-        $categories = json_decode($this->scopeConfig->getValue(TaxjarConfig::TAXJAR_CATEGORIES), true);
-        $categories = $this->helper->sortArray($categories, 'product_tax_code', SORT_ASC);
-
         $output = [
             [
                 'label' => 'Fully Taxable',
@@ -59,10 +60,10 @@ class Category implements \Magento\Framework\Option\ArrayInterface
             ]
         ];
 
-        foreach ($categories as $category) {
+        foreach ($this->categories as $category) {
             $output[] = [
-                'label' => $category['name'] . ' (' . $category['product_tax_code'] . ')',
-                'value' => $category['product_tax_code']
+                'label' => $category->getName() . ' (' . $category->getProductTaxCode() . ')',
+                'value' => $category->getProductTaxCode()
             ];
         }
 

--- a/Model/Config/Taxclass/Source/Category.php
+++ b/Model/Config/Taxclass/Source/Category.php
@@ -53,6 +53,8 @@ class Category implements \Magento\Framework\Option\ArrayInterface
      */
     public function toOptionArray()
     {
+        $this->categories->setOrder('name', 'ASC');
+
         $output = [
             [
                 'label' => 'Fully Taxable',

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -28,7 +28,6 @@ class Configuration
     const TAXJAR_ADDRESS_VALIDATION   = 'tax/taxjar/address_validation';
     const TAXJAR_APIKEY               = 'tax/taxjar/apikey';
     const TAXJAR_BACKUP               = 'tax/taxjar/backup';
-    const TAXJAR_CATEGORIES           = 'tax/taxjar/categories';
     const TAXJAR_CONNECTED            = 'tax/taxjar/connected';
     const TAXJAR_CUSTOMER_TAX_CLASSES = 'tax/taxjar/customer_tax_classes';
     const TAXJAR_DEBUG                = 'tax/taxjar/debug';

--- a/Model/ResourceModel/Tax/Category.php
+++ b/Model/ResourceModel/Tax/Category.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxjar\SalesTax\Model\ResourceModel\Tax;
+
+class Category extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+{
+    /**
+     * @return void
+     */
+    public function _construct()
+    {
+        $this->_init('tj_product_tax_categories', 'id');
+    }
+}

--- a/Model/ResourceModel/Tax/Category/Collection.php
+++ b/Model/ResourceModel/Tax/Category/Collection.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxjar\SalesTax\Model\ResourceModel\Tax\Category;
+
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+{
+    /**
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init('Taxjar\SalesTax\Model\Tax\Category', 'Taxjar\SalesTax\Model\ResourceModel\Tax\Category');
+    }
+}

--- a/Model/Tax/Category.php
+++ b/Model/Tax/Category.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *
+ * @method public Tax getIdTEST()
+ */
+
+namespace Taxjar\SalesTax\Model\Tax;
+
+class Category extends \Magento\Framework\Model\AbstractModel
+{
+    protected function _construct()
+    {
+        $this->_init('Taxjar\SalesTax\Model\ResourceModel\Tax\Category');
+    }
+}

--- a/Model/Tax/Category.php
+++ b/Model/Tax/Category.php
@@ -13,8 +13,6 @@
  * @package    Taxjar_SalesTax
  * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- *
- * @method public Tax getIdTEST()
  */
 
 namespace Taxjar\SalesTax\Model\Tax;

--- a/Observer/ImportCategories.php
+++ b/Observer/ImportCategories.php
@@ -135,6 +135,7 @@ class ImportCategories implements ObserverInterface
         foreach ($categoryJson as $categoryData) {
             $category = $this->categoryFactory->create();
 
+            // Load the category by product tax code to prevent creating duplicates
             $this->categoryResourceModel->load($category, $categoryData['product_tax_code'], 'product_tax_code');
             $category->setProductTaxCode($categoryData['product_tax_code']);
             $category->setName($categoryData['name']);

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -86,5 +86,51 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
             $installer->endSetup();
         }
+
+        if (version_compare($context->getVersion(), '1.0.3', '<')) {
+            $installer = $setup;
+            $installer->startSetup();
+
+            /**
+             * Create table 'tj_product_tax_categories'
+             */
+            $table = $installer->getConnection()
+                ->newTable($installer->getTable('tj_product_tax_categories'))
+                ->addColumn(
+                    'id',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                    null,
+                    ['identity' => true, 'unsigned' => true, 'nullable' => false, 'primary' => true],
+                    'Product Tax Code'
+                )->addColumn(
+                    'product_tax_code',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    null,
+                    ['nullable' => false, 'default' => ''],
+                    'Product Tax Code'
+                )->addColumn(
+                    'name',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    255,
+                    ['nullable' => false, 'default' => ''],
+                    'Name'
+                )->addColumn(
+                    'description',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    255,
+                    ['nullable' => false, 'default' => ''],
+                    'Description'
+                )->addColumn(
+                    'plus_only',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_BOOLEAN,
+                    null,
+                    ['nullable' => false, 'default' => false],
+                    'Plus only'
+                )->setComment("TaxJar Product Tax Codes");
+
+            $setup->getConnection()->createTable($table);
+
+            $installer->endSetup();
+        }
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -101,11 +101,11 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
                     null,
                     ['identity' => true, 'unsigned' => true, 'nullable' => false, 'primary' => true],
-                    'Product Tax Code'
+                    'ID'
                 )->addColumn(
                     'product_tax_code',
                     \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    null,
+                    32,
                     ['nullable' => false, 'default' => ''],
                     'Product Tax Code'
                 )->addColumn(
@@ -126,9 +126,12 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     null,
                     ['nullable' => false, 'default' => false],
                     'Plus only'
-                )->setComment("TaxJar Product Tax Codes");
+                )->addIndex(
+                    $installer->getIdxName('tj_product_tax_categories', 'product_tax_code'),
+                    'product_tax_code'
+                )->setComment('TaxJar Product Tax Codes');
 
-            $setup->getConnection()->createTable($table);
+            $installer->getConnection()->createTable($table);
 
             $installer->endSetup();
         }

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -26,9 +26,6 @@
     <event name="taxjar_salestax_backfill_transactions">
         <observer name="taxjar_salestax_backfill_transactions" instance="Taxjar\SalesTax\Observer\BackfillTransactions"/>
     </event>
-    <event name="taxjar_salestax_import_categories">
-        <observer name="taxjar_salestax_import_categories" instance="Taxjar\SalesTax\Observer\ImportCategories"/>
-    </event>
     <event name="taxjar_salestax_import_data">
         <observer name="taxjar_salestax_import_data" instance="Taxjar\SalesTax\Observer\ImportData"/>
     </event>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -23,4 +23,7 @@
     <event name="sales_order_creditmemo_save_after">
         <observer name="taxjar_salestax_sync_refund" instance="Taxjar\SalesTax\Observer\SyncRefund"/>
     </event>
+    <event name="taxjar_salestax_import_categories">
+        <observer name="taxjar_salestax_import_categories" instance="Taxjar\SalesTax\Observer\ImportCategories"/>
+    </event>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -18,7 +18,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module:etc/module.xsd">
     <!-- Database Setup Version -->
-    <module name="Taxjar_SalesTax" setup_version="1.0.2">
+    <module name="Taxjar_SalesTax" setup_version="1.0.3">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Enterprise"/>


### PR DESCRIPTION
Storing product tax categories as a configuration value won't scale well
as we continue to increase the total number of categories. Reworking
categories to be stored in their own table eliminates this problem and
will support significantly more categories.