### PR TITLE
Fix division by zero when issuing credit memos

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -238,8 +238,13 @@ class Transaction
             ];
 
             if ($type == 'refund' && method_exists($item, 'getOrderItem')) {
-                $orderItem = $item->getOrderItem();
+                $orderItem = $order->getItemById($item->getOrderItemId());
                 $lineItem['quantity'] = (int) $orderItem->getQtyRefunded();
+
+                if ($lineItem['quantity'] === 0) {
+                    continue;
+                }
+
                 $lineItem['unit_price'] = $orderItem->getAmountRefunded() / $lineItem['quantity'];
             }
 

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -237,7 +237,7 @@ class Transaction
                 'sales_tax' => $tax
             ];
 
-            if ($type == 'refund' && method_exists($item, 'getOrderItem')) {
+            if ($type == 'refund' && method_exists($item, 'getOrderItemId')) {
                 $orderItem = $order->getItemById($item->getOrderItemId());
                 $lineItem['quantity'] = (int) $orderItem->getQtyRefunded();
 


### PR DESCRIPTION
When issuing a credit memo for an unshipped order, credit memos weren't
correctly calculating quantity or amount refunded.  Loading the order
item from the order returns the correct item data.  Also adds a check
to skip the item if quantity is actually zero.