### PR TITLE
Changing customer save observer region code getter

### DIFF
--- a/Observer/Customer/Save.php
+++ b/Observer/Customer/Save.php
@@ -63,7 +63,7 @@ class Save extends Customer
         if ($customerAddress) {
             $data = array_merge($data, [
                 'country' => $customerAddress->getCountryId(),
-                'state' => $customerAddress->getRegion()->getRegionCode(),
+                'state' => $customerAddress->getRegionCode(),
                 'zip' => $customerAddress->getPostcode(),
                 'city' => $customerAddress->getCity(),
                 'street' => implode(", ", $customerAddress->getStreet())


### PR DESCRIPTION
$customerAddress->getRegion()->getRegionCode() stopped working in Magento 2.3.4. Using $customerAddress->getRegionCode() instead.