### PR TITLE
Fix incorrect qty with multiple credit memos

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -239,7 +239,7 @@ class Transaction
 
             if ($type == 'refund' && method_exists($item, 'getOrderItemId')) {
                 $orderItem = $order->getItemById($item->getOrderItemId());
-                $lineItem['quantity'] = (int) $orderItem->getQtyRefunded();
+                $lineItem['quantity'] = (int) $item->getQty();
 
                 if ($lineItem['quantity'] === 0) {
                     continue;

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -237,15 +237,12 @@ class Transaction
                 'sales_tax' => $tax
             ];
 
-            if ($type == 'refund' && method_exists($item, 'getOrderItemId')) {
-                $orderItem = $order->getItemById($item->getOrderItemId());
+            if ($type == 'refund') {
                 $lineItem['quantity'] = (int) $item->getQty();
 
                 if ($lineItem['quantity'] === 0) {
                     continue;
                 }
-
-                $lineItem['unit_price'] = $orderItem->getAmountRefunded() / $lineItem['quantity'];
             }
 
             $product = $this->productRepository->getById($item->getProductId(), false, $order->getStoreId());


### PR DESCRIPTION
When issuing  multiple refunds, the $lineItem['qty'] was the total of all refunds.
This caused the qty on the first refund to be correct, and each subsequent refund
was inaccurate. Getting  the qty from the credit memo, instead of the order, fixes
this issue.