### PR TITLE
Fix customer save observer without default address

### DIFF
--- a/Observer/Customer/Save.php
+++ b/Observer/Customer/Save.php
@@ -63,11 +63,17 @@ class Save extends Customer
         if ($customerAddress) {
             $data = array_merge($data, [
                 'country' => $customerAddress->getCountryId(),
-                'state' => $customerAddress->getRegion()->getRegionCode(),
+                'state' => '',
                 'zip' => $customerAddress->getPostcode(),
                 'city' => $customerAddress->getCity(),
                 'street' => implode(", ", $customerAddress->getStreet())
             ]);
+
+            if (get_class($customerAddress) == 'Magento\Customer\Model\Address') {
+                $data['state'] = $customerAddress->getRegionCode();
+            } elseif (get_class($customerAddress) == 'Magento\Customer\Model\Data\Address') {
+                $data['state'] = $customerAddress->getRegion()->getRegionCode();
+            }
         }
 
         $response = $this->updateTaxjar($customer->getTjLastSync(), $data);

--- a/Observer/Customer/Save.php
+++ b/Observer/Customer/Save.php
@@ -63,7 +63,6 @@ class Save extends Customer
         if ($customerAddress) {
             $data = array_merge($data, [
                 'country' => $customerAddress->getCountryId(),
-                'state' => '',
                 'zip' => $customerAddress->getPostcode(),
                 'city' => $customerAddress->getCity(),
                 'street' => implode(", ", $customerAddress->getStreet())


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
When saving a customer, the observer uses different address classes depending on if it's the default shipping address or not.  This change ensures we properly load the region from either class. 

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Because the function `getRegion` returns a string in `Magento\Customer\Model\Address`, it caused a fatal error when trying to load the regionCode from it.  

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This change adds a single if/ifelse statement that should have no noticeable impact on performance.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
There are two testing paths that should both be tested:

1. Create a new order in the admin and create a new customer (instead of using an existing one).  After entering the address information, ensure the "save customer address" box is checked.  After completing the order, ensure no error is thrown and the region (US state) correctly syncs to TaxJar.  

![Screen Shot 2020-02-04 at 12 24 29 PM](https://user-images.githubusercontent.com/44789510/73779719-62dca200-474a-11ea-8fd8-1c3917f0fa0e.png)


2.  Edit an existing customer with a default shipping address set.  Save the customer and ensure no error is thrown and the region correctly syncs to TaxJar.  

![Screen Shot 2020-02-04 at 12 31 03 PM](https://user-images.githubusercontent.com/44789510/73779805-90c1e680-474a-11ea-93ad-20042549f694.png)

![Screen Shot 2020-02-04 at 12 31 31 PM](https://user-images.githubusercontent.com/44789510/73779813-95869a80-474a-11ea-8e94-eca2976cc501.png)


#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
