### PR TITLE
Refresh product categories on a monthly cron job

### DIFF
--- a/Block/Adminhtml/Tax/Taxclass/Product.php
+++ b/Block/Adminhtml/Tax/Taxclass/Product.php
@@ -30,6 +30,14 @@ class Product extends \Magento\Backend\Block\Widget\Grid\Container
         $this->_controller = 'taxjar_taxclass_product';
         $this->_headerText = __('Manage Product Tax Classes');
         $this->_addButtonLabel = __('Add New Product Tax Class');
+
+        $this->addButton('sync-product-tax-class', [
+            'label' => __('Sync from TaxJar'),
+            'on_click' => 'window.location.href=\'' . $this->getUrl('taxjar/taxclass_product/sync') . '\'',
+            'class' => 'primary',
+            'level' => 1
+        ]);
+
         parent::_construct();
     }
 }

--- a/Console/Command/SyncProductCategoriesCommand.php
+++ b/Console/Command/SyncProductCategoriesCommand.php
@@ -63,8 +63,8 @@ class SyncProductCategoriesCommand extends Command
      */
     protected function configure()
     {
-        $this->setName('taxjar:product_classes:import')
-            ->setDescription('Sync Product Tax Classes from TaxJar to Magento');
+        $this->setName('taxjar:product_categories:import')
+            ->setDescription('Sync Product Tax Categories from TaxJar to Magento');
     }
 
     /**
@@ -82,10 +82,10 @@ class SyncProductCategoriesCommand extends Command
             $this->logger->console($output);
 
             $this->importCategories->execute(new \Magento\Framework\Event\Observer);
-            $output->writeln(PHP_EOL . 'Successfully imported product tax classes.');
+            $output->writeln(PHP_EOL . 'Successfully imported product tax categories.');
 
         } catch (\Exception $e) {
-            $output->writeln(PHP_EOL . '<error>Failed to import product tax classes: ' . $e->getMessage() . '</error>');
+            $output->writeln(PHP_EOL . '<error>Failed to import product tax categories: ' . $e->getMessage() . '</error>');
         }
     }
 }

--- a/Console/Command/SyncProductCategoriesCommand.php
+++ b/Console/Command/SyncProductCategoriesCommand.php
@@ -63,7 +63,7 @@ class SyncProductCategoriesCommand extends Command
      */
     protected function configure()
     {
-        $this->setName('taxjar:product_categories:import')
+        $this->setName('taxjar:product_categories:sync')
             ->setDescription('Sync Product Tax Categories from TaxJar to Magento');
     }
 
@@ -82,10 +82,10 @@ class SyncProductCategoriesCommand extends Command
             $this->logger->console($output);
 
             $this->importCategories->execute(new \Magento\Framework\Event\Observer);
-            $output->writeln(PHP_EOL . 'Successfully imported product tax categories.');
+            $output->writeln(PHP_EOL . 'Successfully synced product tax categories.');
 
         } catch (\Exception $e) {
-            $output->writeln(PHP_EOL . '<error>Failed to import product tax categories: ' . $e->getMessage() . '</error>');
+            $output->writeln(PHP_EOL . '<error>Failed to sync product tax categories: ' . $e->getMessage() . '</error>');
         }
     }
 }

--- a/Console/Command/SyncProductCategoriesCommand.php
+++ b/Console/Command/SyncProductCategoriesCommand.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2020 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxjar\SalesTax\Console\Command;
+
+use Magento\Framework\App\State;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Taxjar\SalesTax\Model\Logger;
+use Taxjar\Salestax\Observer\ImportCategories;
+
+class SyncProductCategoriesCommand extends Command
+{
+    /**
+     * @var State
+     */
+    protected $state;
+
+    /**
+     * @var Logger
+     */
+    protected $logger;
+
+    /**
+     * @var ImportCategories
+     */
+    protected $importCategories;
+
+    /**
+     * @param State $state
+     * @param Logger $logger
+     * @param ImportCategories $importCategories
+     */
+    public function __construct(
+        State $state,
+        Logger $logger,
+        ImportCategories $importCategories
+    ) {
+        $this->state = $state;
+        $this->logger = $logger;
+        $this->importCategories = $importCategories;
+
+        parent::__construct();
+    }
+
+    /**
+     * Sets config for CLI command
+     */
+    protected function configure()
+    {
+        $this->setName('taxjar:product_classes:import')
+            ->setDescription('Sync Product Tax Classes from TaxJar to Magento');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return string
+     */
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output
+    ) {
+        try {
+            $this->state->setAreaCode('adminhtml');
+            $this->logger->console($output);
+
+            $this->importCategories->execute(new \Magento\Framework\Event\Observer);
+            $output->writeln(PHP_EOL . 'Successfully imported product tax classes.');
+
+        } catch (\Exception $e) {
+            $output->writeln(PHP_EOL . '<error>Failed to import product tax classes: ' . $e->getMessage() . '</error>');
+        }
+    }
+}

--- a/Controller/Adminhtml/Taxclass/Product/Sync.php
+++ b/Controller/Adminhtml/Taxclass/Product/Sync.php
@@ -26,7 +26,7 @@ class Sync extends \Taxjar\SalesTax\Controller\Adminhtml\Taxclass\Product
     {
         try {
             $this->_eventManager->dispatch('taxjar_salestax_import_categories');
-            $this->messageManager->addSuccessMessage(__('Product tax classes have been synced from TaxJar.'));
+            $this->messageManager->addSuccessMessage(__('Product tax categories have been synced from TaxJar.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
         }

--- a/Controller/Adminhtml/Taxclass/Product/Sync.php
+++ b/Controller/Adminhtml/Taxclass/Product/Sync.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2020 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxjar\SalesTax\Controller\Adminhtml\Taxclass\Product;
+
+class Sync extends \Taxjar\SalesTax\Controller\Adminhtml\Taxclass\Product
+{
+    /**
+     * @return \Magento\Backend\Model\View\Result\Page
+     */
+    public function execute()
+    {
+        try {
+            $this->_eventManager->dispatch('taxjar_salestax_import_categories');
+            $this->messageManager->addSuccessMessage(__('Product tax classes have been synced from TaxJar.'));
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
+        }
+
+        $this->_redirect('*/*/');
+    }
+}

--- a/Observer/ImportCategories.php
+++ b/Observer/ImportCategories.php
@@ -113,6 +113,16 @@ class ImportCategories implements ObserverInterface
     }
 
     /**
+     * Execute observer action during cron job
+     *
+     * @return void
+     */
+    public function cron()
+    {
+        $this->execute(new Observer);
+    }
+
+    /**
      * Get TaxJar product categories
      *
      * @return array

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -17,9 +17,12 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
-    <group id="default">
+    <group id="taxjar_crongroup">
         <job name="taxjar_backup_rates" instance="Taxjar\SalesTax\Observer\ImportRates" method="cron">
             <schedule>0 8 1 * *</schedule>
+        </job>
+        <job name="taxjar_product_categories" instance="Taxjar\SalesTax\Observer\ImportCategories" method="cron">
+            <schedule>30 8 1 * *</schedule>
         </job>
     </group>
 </config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -18,9 +18,11 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="taxjar_crongroup">
+        <!-- Update TaxJar backup rates on the first of each month -->
         <job name="taxjar_backup_rates" instance="Taxjar\SalesTax\Observer\ImportRates" method="cron">
             <schedule>0 8 1 * *</schedule>
         </job>
+        <!-- Update TaxJar product tax categories on the first of each month -->
         <job name="taxjar_product_categories" instance="Taxjar\SalesTax\Observer\ImportCategories" method="cron">
             <schedule>30 8 1 * *</schedule>
         </job>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -26,6 +26,7 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="SyncTransactionsCommand" xsi:type="object">Taxjar\SalesTax\Console\Command\SyncTransactionsCommand</item>
+                <item name="SyncProductCategoriesCommand" xsi:type="object">Taxjar\SalesTax\Console\Command\SyncProductCategoriesCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
To ensure that the latest product tax categories are available, we've added a new cron method to sync tax categories each month.  We've also added a button to the Product Tax Classes admin page and a new CLI command to allow users to manually sync the latest tax categories.  

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR adds three changes:
- A new cron process to automatically update the product tax categories each month
- A new command line option to run the product tax sync (screenshot below)
- A new "Sync from TaxJar" button on the Product Tax Classes page (screenshot below)

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This PR adds an additional cronjob that runs on the first of each month.  It typically completes in around 3 seconds.  The other new commands are all initiated by the user and have similar run times.  

![Screen Shot 2020-02-10 at 10 56 53 AM](https://user-images.githubusercontent.com/44789510/74176016-1da9eb80-4bf4-11ea-8a60-ef2fd196c829.png)


### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1.  To test the cron job:  
  - Ensure cron jobs are running correctly
  - Either wait until 8:30am on the first of the month OR change the cron schedule in crontab.xml
  - Confirm the cronjob runs successfully

2. To test the new cli command
  - Open a cli window and navigate to the magento installation
  - Run the command "bin/magento taxjar:product_classes:import"
  - Confirm that the success message is displayed
![Screen Shot 2020-02-10 at 10 59 58 AM](https://user-images.githubusercontent.com/44789510/74176231-81341900-4bf4-11ea-9eb7-048a10a7dfef.png)
  
3. To test the new "Sync to TaxJar button"
  - Login to the Magento admin and navigate to the Product Tax Classes page (admin/taxjar/taxclass_product/)
  - Click "Sync to TaxJar"
  - Confirm that the success message is displayed
![Screen Shot 2020-02-10 at 11 01 34 AM](https://user-images.githubusercontent.com/44789510/74176338-b80a2f00-4bf4-11ea-9355-ec4336157d49.png)


#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
