### PR TITLE
Update the gift card product tax code

### DIFF
--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -45,6 +45,7 @@ class Configuration
     const TAXJAR_ADDRVALIDATION_LOG   = 'address_validation.log';
     const TAXJAR_CUSTOMER_LOG         = 'customers.log';
     const TAXJAR_EXEMPT_TAX_CODE      = '99999';
+    const TAXJAR_GIFT_CARD_TAX_CODE   = '14111803A0001';
 
     /**
      * @var \Magento\Config\Model\ResourceModel\Config

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -464,7 +464,7 @@ class Smartcalcs
                                 $giftTaxClassCode = $giftTaxClass->getTjSalestaxCode();
                                 $taxCode = $giftTaxClassCode;
                             } else {
-                                $taxCode = TaxjarConfig::TAXJAR_EXEMPT_TAX_CODE;
+                                $taxCode = TaxjarConfig::TAXJAR_GIFT_CARD_TAX_CODE;
                             }
                         }
                     }


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Updates the default gift card tax code from '99999' to '14111803A0001' for improved accuracy.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Gift cards used as part of Magento Commerce previously used '99999' to mark them exempt.  Using '14111803A0001' is more accurate.  

![Screen Shot 2020-02-10 at 5 12 51 PM](https://user-images.githubusercontent.com/44789510/74202060-a2166180-4c28-11ea-8aab-a4137b031310.png)

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This change should have no affect on performance, as we're only changing the tax code that is sent to the API.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1.  Add a gift card to Magento's shopping cart (note: gift cards are only available in Commerce and B2B editions of Magento)
2. Visit the shopping cart page and enter a city and zip code to estimate taxes.
3. Confirm that no taxes were calculated for the gift card.


![Screen Shot 2020-02-10 at 5 04 38 PM](https://user-images.githubusercontent.com/44789510/74202195-fe798100-4c28-11ea-880b-a1f6fd0f35cb.png)


#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
