### PR TITLE
Fix sorting nexus addresses by "Store View"

### DIFF
--- a/view/adminhtml/layout/taxjar_nexus_block.xml
+++ b/view/adminhtml/layout/taxjar_nexus_block.xml
@@ -85,7 +85,7 @@
                     <block class="Magento\Backend\Block\Widget\Grid\Column" as="store">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store View</argument>
-                            <argument name="filter_index" xsi:type="string">store</argument>
+                            <argument name="filter_index" xsi:type="string">store_id</argument>
                             <argument name="index" xsi:type="string">store</argument>
                             <argument name="column_css_class" xsi:type="string">col-name</argument>
                             <argument name="header_css_class" xsi:type="string">col-name</argument>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
When viewing the nexus address page in Magento's admin (admin/taxjar/nexus/index/), trying to sort the addresses by "Store View" causes a fatal error.  

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Changes the filter index to store_id so it matches the column in the table.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Because this is a bug fix, it has no affect on performance.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1.  Log into the admin and click on Stores > Nexus Addresses
2. Ensure at least 1 address is present
3. Click on "Store View" to sort the addresses
4. Ensure the addresses are correctly sorted

![Screen Shot 2020-02-06 at 10 26 48 AM](https://user-images.githubusercontent.com/44789510/73965199-e922f080-48d0-11ea-87e0-8a81056fc740.png)


#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
