### PR TITLE
Fix Class Taxjar\Salestax\Observer\ImportCategories does not exist

### DIFF
--- a/Console/Command/SyncProductCategoriesCommand.php
+++ b/Console/Command/SyncProductCategoriesCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Taxjar\SalesTax\Model\Logger;
-use Taxjar\Salestax\Observer\ImportCategories;
+use Taxjar\SalesTax\Observer\ImportCategories;
 
 class SyncProductCategoriesCommand extends Command
 {


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Reference to Import Categories Observer is wrong so can't install v1.4.8
Errors:
In ClassReader.php line 35:                                                            
Class Taxjar\Salestax\Observer\ImportCategories does not exist  
                                                                  
In ClassReader.php line 29:                                                       
Class Taxjar\Salestax\Observer\ImportCategories does not exist  

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
 - na

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. changed class reference
2. run composer require taxjar/module-taxjar
3. run setup successfully

#### Versions
<!-- What version(s) did you test this change on? -->
- [ ] Magento 2.4
- [x] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [ ] Magento Open Source (CE)
- [x] Magento Commerce (EE)
- [x] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [x ] PHP 7.2.26
