### PR TITLE
Sort by sync date broken in order grid

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -145,7 +145,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
              */
             $installer->getConnection()->addColumn(
                 $installer->getTable('sales_order_grid'),
-                'tj_salestax_sync_date',
+                'synced',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
                     'nullable' => true,

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -135,5 +135,25 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
             $installer->endSetup();
         }
+
+        if (version_compare($context->getVersion(), '1.0.4', '<')) {
+            $installer = $setup;
+            $installer->startSetup();
+
+            /**
+             * Add synced date to sales_order_grid column
+             */
+            $installer->getConnection()->addColumn(
+                $installer->getTable('sales_order_grid'),
+                'tj_salestax_sync_date',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
+                    'nullable' => true,
+                    'comment' => 'Order sync date for TaxJar'
+                ]
+            );
+
+            $installer->endSetup();
+        }
     }
 }

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -10,4 +10,12 @@
             </argument>
         </arguments>
     </virtualType>
+    <virtualType name="Magento\Sales\Model\ResourceModel\Order\Grid"
+                 type="Magento\Sales\Model\ResourceModel\Grid">
+        <arguments>
+            <argument name="columns" xsi:type="array">
+                <item name="tj_salestax_sync_date" xsi:type="string">sales_order.tj_salestax_sync_date</item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -10,12 +10,4 @@
             </argument>
         </arguments>
     </virtualType>
-    <virtualType name="Magento\Sales\Model\ResourceModel\Order\Grid"
-                 type="Magento\Sales\Model\ResourceModel\Grid">
-        <arguments>
-            <argument name="columns" xsi:type="array">
-                <item name="synced" xsi:type="string">sales_order.tj_salestax_sync_date</item>
-            </argument>
-        </arguments>
-    </virtualType>
 </config>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -14,7 +14,7 @@
                  type="Magento\Sales\Model\ResourceModel\Grid">
         <arguments>
             <argument name="columns" xsi:type="array">
-                <item name="tj_salestax_sync_date" xsi:type="string">sales_order.tj_salestax_sync_date</item>
+                <item name="synced" xsi:type="string">sales_order.tj_salestax_sync_date</item>
             </argument>
         </arguments>
     </virtualType>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -33,4 +33,12 @@
     <type name="Magento\Framework\RequireJs\Config\File\Collector\Aggregated">
         <plugin name="manage_address_validation_mixins" type="Taxjar\SalesTax\Plugin\RequireJs\AfterFiles" sortOrder="100"/>
     </type>
+    <virtualType name="Magento\Sales\Model\ResourceModel\Order\Grid"
+                 type="Magento\Sales\Model\ResourceModel\Grid">
+        <arguments>
+            <argument name="columns" xsi:type="array">
+                <item name="synced" xsi:type="string">sales_order.tj_salestax_sync_date</item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -18,7 +18,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module:etc/module.xsd">
     <!-- Database Setup Version -->
-    <module name="Taxjar_SalesTax" setup_version="1.0.3">
+    <module name="Taxjar_SalesTax" setup_version="1.0.4">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Enterprise"/>


### PR DESCRIPTION
### Context
An exception is thrown when sorting by sync date in the order grid. The error thrown is the following:
`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'synced' in 'order clause', query was: SELECT `main_table`.* FROM `sales_order_grid` AS `main_table` ORDER BY synced ASC`

The sync column is missing from the order grid table and does not have any way of sorting by this column.

### Expected Results
When the sync column is visible, the sorting feature should sort by the sync date correctly.

### Description
The fix adds a column to the sales_order_grid table and maps the values from the order table to the order grid table. In order to have the data populated into the grid correctly after sorting, the sales_order_grid table needs to be truncated and regenerated. The table will be regenerated through the cron process `sales_grid_order_async_insert`. This can be updated either through cron or with a magerun command `n98-magerun2 sys:cron:run sales_grid_order_async_insert`. Note, asynchronous indexing needs to be enabled to regenerate the order grid table. The config is under Stores -> Configuration -> Advanced -> Developer -> Grid Settings -> Asynchronous Indexing

### Testing
1. Go to the order table in the admin panel.
2. Make column "Synced to Taxjar" visible in the order grid if it is not visible.
3. Sort by synced to taxjar and verify that the grid correctly sorts the orders.

#### Versions
Taxjar 1.4.9
Magento Open Source 2.3.2
PHP 7.2
