### PR TITLE
Max discount amount ignores item quantity

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -455,8 +455,8 @@ class Smartcalcs
                         $discount = 0;
                     }
 
-                    if ($discount > $unitPrice) {
-                        $discount = $unitPrice;
+                    if ($discount > ($unitPrice * $quantity)) {
+                        $discount = ($unitPrice * $quantity);
                     }
 
                     if ($item->getTaxClassKey()->getValue()) {

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -200,6 +200,15 @@ class Transaction
             $itemType = $item->getProductType();
             $parentItem = $item->getParentItem();
             $unitPrice = (float) $item->getPrice();
+            $quantity = (int) $item->getQtyOrdered();
+
+            if ($type == 'refund') {
+                $quantity = (int) $item->getQty();
+
+                if ($quantity === 0) {
+                    continue;
+                }
+            }
 
             if (($itemType == 'simple' || $itemType == 'virtual') && $item->getParentItemId()) {
                 if (!empty($parentItem) && $parentItem->getProductType() == 'bundle') {
@@ -227,8 +236,8 @@ class Transaction
                 $discount = $parentDiscounts[$itemId] ?: $discount;
             }
 
-            if ($discount > $unitPrice) {
-                $discount = $unitPrice;
+            if ($discount > ($unitPrice * $quantity)) {
+                $discount = ($unitPrice * $quantity);
             }
 
             if (isset($parentTaxes[$itemId])) {
@@ -237,21 +246,13 @@ class Transaction
 
             $lineItem = [
                 'id' => $itemId,
-                'quantity' => (int) $item->getQtyOrdered(),
+                'quantity' => $quantity,
                 'product_identifier' => $item->getSku(),
                 'description' => $item->getName(),
                 'unit_price' => $unitPrice,
                 'discount' => $discount,
                 'sales_tax' => $tax
             ];
-
-            if ($type == 'refund') {
-                $lineItem['quantity'] = (int) $item->getQty();
-
-                if ($lineItem['quantity'] === 0) {
-                    continue;
-                }
-            }
 
             $product = $this->productRepository->getById($item->getProductId(), false, $order->getStoreId());
 


### PR DESCRIPTION
### Context
Currently if an item's discounts exceed the price of an individual item, the discount is maxed at the price of that item.  This ignores the quantity of the items being ordered and incorrectly calculates the discount.  Ex:

12 items ordered at $10 each with a 10% discount.   The subtotal is $120 with a discount of $12.  Because $12 > $10, the discount will be incorrectly calculated as $10.

### Description
When enforcing the maximum discount amount, the unit price should
also consider the quantity of the items being ordered.

### Performance
This change has a negligible impact on performance.

### Testing
1. Add 11 (or more) taxable items to Magento's cart
2. Apply a 10% (or greater) discount 
3. Ensure that the discount amount is greater than the price of an individual item

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1

<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud

<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
