### PR TITLE
Fix for credit memo adjustments

### DIFF
--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -77,8 +77,25 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
         );
 
         if (isset($this->request['line_items'])) {
-            foreach ($this->request['line_items'] as $lineItem) {
+            $adjustmentFee = $creditmemo->getAdjustmentNegative();
+            $adjustmentRefund = $creditmemo->getAdjustmentPositive();
+
+            foreach ($this->request['line_items'] as $k => $lineItem) {
+                $lineItemSubtotal = $lineItem['unit_price'] * $lineItem['quantity'];
+                $this->request['line_items'][$k]['discount'] += ($adjustmentFee * ($lineItemSubtotal / $creditmemo->getSubtotal()));
                 $itemDiscounts += $lineItem['discount'];
+            }
+
+            if ($adjustmentRefund) {
+                $this->request['line_items'][] = [
+                    'id' => 'adjustment-refund',
+                    'quantity' => 1,
+                    'product_identifier' => 'adjustment-refund',
+                    'description' => 'Adjustment Refund',
+                    'unit_price' => $adjustmentRefund,
+                    'discount' => 0,
+                    'sales_tax' => 0
+                ];
             }
         }
 

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -80,9 +80,10 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
             $adjustmentFee = $creditmemo->getAdjustmentNegative();
             $adjustmentRefund = $creditmemo->getAdjustmentPositive();
 
+            // Discounts on credit memos act as fees and shouldn't be included in $itemDiscounts
             foreach ($this->request['line_items'] as $k => $lineItem) {
                 $lineItemSubtotal = $lineItem['unit_price'] * $lineItem['quantity'];
-                $this->request['line_items'][$k]['discount'] += ($adjustmentFee * ($lineItemSubtotal / $creditmemo->getSubtotal()));
+                $this->request['line_items'][$k]['discount'] += ($adjustmentFee * ($lineItemSubtotal / $subtotal));
                 $itemDiscounts += $lineItem['discount'];
             }
 


### PR DESCRIPTION
### Context
Adding an adjustment fee or adjustment refund to a credit memo was causing a mismatch between the sum of the line items and the calculated subtotal.  

### Description
This PR distributes the adjustment fee proportionally across the line item discounts, and adds a new line item for the adjustment refund.

### Performance
This change has a negligible impact or performance.  

### Testing
1. Create a new order in Magento
2. Issue a credit memo with an adjustment refund and/or adjustment fee
![Screen Shot 2020-04-01 at 6 37 00 PM](https://user-images.githubusercontent.com/44789510/78268982-3634d480-74c6-11ea-8864-21c9aedd58e6.png)
3. Ensure that any adjustment fees were distributed across the item discounts and any adjustment refund was added as a new line item. 
![Screen Shot 2020-04-02 at 9 43 50 AM](https://user-images.githubusercontent.com/44789510/78269184-7ac07000-74c6-11ea-9404-adbf548a8759.png)


#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
