### PR TITLE
Fix checkout AV for logged in customers

### DIFF
--- a/Model/AddressValidation.php
+++ b/Model/AddressValidation.php
@@ -106,9 +106,19 @@ class AddressValidation implements AddressValidationInterface
         $country = null,
         $postcode = null
     ) {
+        $original = [
+            'street' => [$street0],
+            'city' => $city,
+            'regionCode' => $this->getRegionById($region)->getCode(),
+            'regionId' => $region,
+            'countryId' => $country,
+            'postcode' => $postcode
+        ];
+        $results = [['id' => 0, 'address' => $original, 'changes' => $original]];
+
         // Ensure address validation is enabled
         if (!$this->canValidateAddress()) {
-            return [];
+            return $results;
         }
 
         // Format the address to match the endpoint's naming convention
@@ -123,20 +133,8 @@ class AddressValidation implements AddressValidationInterface
 
         // Validate address data locally
         if ($this->validateInput($addr) === false) {
-            return [];
+            return $results;
         }
-
-        $results = [];
-        $original = [
-            'street' => [$street0],
-            'city' => $city,
-            'regionCode' => $this->getRegionById($region)->getCode(),
-            'regionId' => $region,
-            'countryId' => $country,
-            'postcode' => $postcode
-        ];
-
-        $results[] = ['id' => 0, 'address' => $original, 'changes' => $original];
 
         // Send address to Taxjar for validation
         $response = $this->validateWithTaxjar($addr);

--- a/Model/AddressValidation.php
+++ b/Model/AddressValidation.php
@@ -106,19 +106,9 @@ class AddressValidation implements AddressValidationInterface
         $country = null,
         $postcode = null
     ) {
-        $original = [
-            'street' => [$street0],
-            'city' => $city,
-            'regionCode' => $this->getRegionById($region)->getCode(),
-            'regionId' => $region,
-            'countryId' => $country,
-            'postcode' => $postcode
-        ];
-        $results = [['id' => 0, 'address' => $original, 'changes' => $original]];
-
         // Ensure address validation is enabled
         if (!$this->canValidateAddress()) {
-            return $results;
+            return [];
         }
 
         // Format the address to match the endpoint's naming convention
@@ -133,8 +123,20 @@ class AddressValidation implements AddressValidationInterface
 
         // Validate address data locally
         if ($this->validateInput($addr) === false) {
-            return $results;
+            return [];
         }
+
+        $results = [];
+        $original = [
+            'street' => [$street0],
+            'city' => $city,
+            'regionCode' => $this->getRegionById($region)->getCode(),
+            'regionId' => $region,
+            'countryId' => $country,
+            'postcode' => $postcode
+        ];
+
+        $results[] = ['id' => 0, 'address' => $original, 'changes' => $original];
 
         // Send address to Taxjar for validation
         $response = $this->validateWithTaxjar($addr);

--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -34,6 +34,8 @@ function (ko, $) {
 
             // Skip if non-US shipping address
             if (addr && addr.countryId !== 'US') {
+                self.updateSuggestedAddresses([]);
+
                 if (typeof onFail === 'function') {
                     onFail('NON_US_SHIPPING_ADDRESS');
                 }

--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -32,14 +32,6 @@ function (ko, $) {
         getSuggestedAddresses: function (addr, onDone, onFail) {
             var self = this;
 
-            // Skip if non-US shipping address
-            if (addr && addr.countryId !== 'US') {
-                if (typeof onFail === 'function') {
-                    onFail('NON_US_SHIPPING_ADDRESS');
-                }
-                return;
-            }
-
             if (addr && addr.street && addr.city && addr.regionId) {
                 var formattedAddr = {
                     'street0': addr.street[0],

--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -32,6 +32,14 @@ function (ko, $) {
         getSuggestedAddresses: function (addr, onDone, onFail) {
             var self = this;
 
+            // Skip if non-US shipping address
+            if (addr && addr.countryId !== 'US') {
+                if (typeof onFail === 'function') {
+                    onFail('NON_US_SHIPPING_ADDRESS');
+                }
+                return;
+            }
+
             if (addr && addr.street && addr.city && addr.regionId) {
                 var formattedAddr = {
                     'street0': addr.street[0],


### PR DESCRIPTION
### Context
When a logged in customer with a saved address adds an international address, the previous suggested addresses aren't cleared from the checkout screen.

### Description
This PR removes the front-end country validation, allowing AV to use the server-side validation instead.  It also changes the server-side error handling to always return the original address.

### Performance
This PR slightly increases latency during the checkout process, as it requires an additional POST request to the local server for international addresses during checkout.  Because this request will not pass local validation, it will not have to wait for the address to be validated.  During my testing, I did not notice the increased latency.  

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Ensure address validation is enabled in the admin
2. Log into Magento as a user with a saved address
3. Add a product to the cart and continue to checkout
4. Enter a new international address during checkout
![Screen Shot 2020-04-08 at 1 30 07 PM](https://user-images.githubusercontent.com/44789510/79003206-59d3cc80-7b0f-11ea-9aed-f3080b460d1a.png)
5. Change back and forth between both addresses with the "Ship Here" button.  Confirm that suggestions appear for US addresses and are hidden for international addresses.
![Screen Shot 2020-04-08 at 1 30 27 PM](https://user-images.githubusercontent.com/44789510/79003294-8687e400-7b0f-11ea-97d1-b43a0a68d585.png)
6. Place the order using the international address and confirm that the shipping address is correct.
![Screen Shot 2020-04-08 at 1 32 24 PM](https://user-images.githubusercontent.com/44789510/79003323-98698700-7b0f-11ea-99c5-b27bdb328ca7.png)

7.  Open the customer's account by clicking "My Account" from the top right dropdown
8. Load the address book by clicking "Address Book" from the left menu
9. Confirm that international addresses save properly
![Screen Shot 2020-04-10 at 11 55 12 AM](https://user-images.githubusercontent.com/44789510/79011838-2babb800-7b22-11ea-8c07-b3cc77d50c52.png)



#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
