### PR TITLE
Remove "plus_only" flag and uses of /plus endpoint

### DIFF
--- a/Block/Adminhtml/AddressValidation.php
+++ b/Block/Adminhtml/AddressValidation.php
@@ -86,19 +86,13 @@ class AddressValidation extends Field
     }
 
     /**
-     * TaxJar Plus authorization check
+     * TaxJar address validation authorization check
      *
      * @return bool
      */
     public function isAuthorized()
     {
-        $isAuthorized = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_PLUS);
-
-        if ($isAuthorized) {
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
     /**

--- a/Block/Adminhtml/AddressValidation.php
+++ b/Block/Adminhtml/AddressValidation.php
@@ -92,7 +92,13 @@ class AddressValidation extends Field
      */
     public function isAuthorized()
     {
-        return true;
+        $isAuthorized = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_PLUS);
+
+        if ($isAuthorized) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/Controller/Adminhtml/Config/Connect.php
+++ b/Controller/Adminhtml/Config/Connect.php
@@ -133,6 +133,10 @@ class Connect extends AbstractAction
             $response = $this->client->postResource('verify', ['token' => $apiKey]);
 
             if ($response['enabled'] && $response['valid']) {
+                if ($response['plus']) {
+                    $this->resourceConfig->saveConfig(TaxjarConfig::TAXJAR_PLUS, true, 'default', 0);
+                }
+
                 return true;
             }
         } catch (Exception $e) {

--- a/Controller/Adminhtml/Config/Connect.php
+++ b/Controller/Adminhtml/Config/Connect.php
@@ -119,7 +119,7 @@ class Connect extends AbstractAction
     }
 
     /**
-     * Verify if user is subscribed to Plus
+     * Verify if user has a valid subscription
      *
      * @param string $apiKey
      * @return bool
@@ -133,10 +133,6 @@ class Connect extends AbstractAction
             $response = $this->client->postResource('verify', ['token' => $apiKey]);
 
             if ($response['enabled'] && $response['valid']) {
-                if ($response['plus']) {
-                    $this->resourceConfig->saveConfig(TaxjarConfig::TAXJAR_PLUS, true, 'default', 0);
-                }
-
                 return true;
             }
         } catch (Exception $e) {

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -35,6 +35,7 @@ class Configuration
     const TAXJAR_ENABLED              = 'tax/taxjar/enabled';
     const TAXJAR_FREIGHT_TAXABLE      = 'tax/taxjar/freight_taxable';
     const TAXJAR_LAST_UPDATE          = 'tax/taxjar/last_update';
+    const TAXJAR_PLUS                 = 'tax/taxjar/plus';
     const TAXJAR_PRODUCT_TAX_CLASSES  = 'tax/taxjar/product_tax_classes';
     const TAXJAR_STATES               = 'tax/taxjar/states';
     const TAXJAR_TRANSACTION_SYNC     = 'tax/taxjar/transactions';

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -35,7 +35,6 @@ class Configuration
     const TAXJAR_ENABLED              = 'tax/taxjar/enabled';
     const TAXJAR_FREIGHT_TAXABLE      = 'tax/taxjar/freight_taxable';
     const TAXJAR_LAST_UPDATE          = 'tax/taxjar/last_update';
-    const TAXJAR_PLUS                 = 'tax/taxjar/plus';
     const TAXJAR_PRODUCT_TAX_CLASSES  = 'tax/taxjar/product_tax_classes';
     const TAXJAR_STATES               = 'tax/taxjar/states';
     const TAXJAR_TRANSACTION_SYNC     = 'tax/taxjar/transactions';

--- a/Observer/ImportCategories.php
+++ b/Observer/ImportCategories.php
@@ -150,7 +150,6 @@ class ImportCategories implements ObserverInterface
             $category->setProductTaxCode($categoryData['product_tax_code']);
             $category->setName($categoryData['name']);
             $category->setDescription($categoryData['description']);
-            $category->setPlusOnly((strpos($categoryData['description'], '*(PLUS ONLY)*') !== false));
             $this->categoryResourceModel->save($category);
         }
     }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -135,5 +135,20 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
             $installer->endSetup();
         }
+
+        if (version_compare($context->getVersion(), '1.0.4', '<')) {
+            $installer = $setup;
+            $installer->startSetup();
+
+            /**
+             * Update table 'tj_product_tax_categories'
+             */
+            $installer->getConnection()->dropColumn(
+                $installer->getTable('tj_product_tax_categories'),
+                'plus_only'
+            );
+
+            $installer->endSetup();
+        }
     }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -18,7 +18,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module:etc/module.xsd">
     <!-- Database Setup Version -->
-    <module name="Taxjar_SalesTax" setup_version="1.0.3">
+    <module name="Taxjar_SalesTax" setup_version="1.0.4">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Enterprise"/>
@@ -27,3 +27,4 @@
         </sequence>
     </module>
 </config>
+


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
This PR removes the "plus_only" flag from the tj_product_tax_categories table.  It also removes the use of the /plus endpoint and references to "plus" in the /verify endpoint.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR removes the "plus_only" flag from the tj_product_tax_categories table.  It also removes the use of the /plus endpoint and references to "plus" in the /verify endpoint.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This PR has a negligible impact on performance.  

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Ensure address validation is enabled in the admin configuration
![Screen Shot 2020-04-21 at 9 12 04 PM](https://user-images.githubusercontent.com/44789510/79936467-d1a9cd00-8414-11ea-9664-cdd4112b013e.png)

2. Ensure address validation works correctly during checkout
![Screen Shot 2020-04-21 at 8 59 57 PM](https://user-images.githubusercontent.com/44789510/79936473-d4a4bd80-8414-11ea-9e9e-492da9c19134.png)

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
