### PR TITLE
Update the default customer_id in Smartcalcs

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -209,7 +209,7 @@ class Smartcalcs
             'shipping' => $shipping - abs($shippingDiscount),
             'line_items' => $this->_getLineItems($quote, $quoteTaxDetails),
             'nexus_addresses' => $this->_getNexusAddresses($quote->getStoreId()),
-            'customer_id' => $quote->getCustomerId() ? $quote->getCustomerId() : 0,
+            'customer_id' => $quote->getCustomerId() ? $quote->getCustomerId() : '',
             'plugin' => 'magento'
         ]);
 


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Zero is an invalid customer_id, and shouldn't ever be passed.  Updating the default value to an empty string fixes this.  

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR changes the default customer_id in Smartcalcs from 0 to ''

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This change has no impact on performance.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Add a product to Magento's cart and navigate to the cart page.

2. Estimate taxes in a zipcode with nexus
<img width="1139" alt="Screen Shot 2020-04-23 at 5 54 56 PM" src="https://user-images.githubusercontent.com/44789510/80160748-9a116100-858b-11ea-90e5-31c8a8556219.png">

3. Confirm no internal error logs are generated

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
