### PR TITLE
Cleanup exception handling during connection

### DIFF
--- a/Controller/Adminhtml/Config/Connect.php
+++ b/Controller/Adminhtml/Config/Connect.php
@@ -131,9 +131,12 @@ class Connect extends AbstractAction
             $this->client->setApiKey($apiKey);
 
             $response = $this->client->postResource('verify', ['token' => $apiKey]);
+            $valid = isset($response['valid']) ? $response['valid'] : false;
+            $enabled = isset($response['enabled']) ? $response['enabled'] : false;
+            $plus = isset($response['plus']) ? $response['plus'] : false;
 
-            if ($response['enabled'] && $response['valid']) {
-                if ($response['plus']) {
+            if ($valid && $enabled) {
+                if ($plus) {
                     $this->resourceConfig->saveConfig(TaxjarConfig::TAXJAR_PLUS, true, 'default', 0);
                 }
 


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Trying to connect with an invalid API key fills the logs with irrelevant notices.  

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR checks the array keys before trying to access them to prevent notices from being generated.  

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This PR as a negligible impact on performance.  

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Ensure that no TaxJar account is currently connected inside the Magento admin
2. Attempt to connect an account with invalid permissions
3. Confirm that no notices were logged during the process

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [X] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
