### PR TITLE
Fix for deploying production mode in PHP 5.6

### DIFF
--- a/Model/Import/Rate.php
+++ b/Model/Import/Rate.php
@@ -23,7 +23,6 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Tax\Api\TaxRateRepositoryInterface;
-use Magento\Tax\Model\Calculation\Rule;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 
 class Rate
@@ -77,7 +76,7 @@ class Rate
      * @param RegionFactory $regionFactory
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param FilterBuilder $filterBuilder
-     * @param Rule $rule
+     * @param \Magento\Tax\Model\Calculation\Rule $rule
      */
     public function __construct(
         CacheInterface $cache,
@@ -88,7 +87,7 @@ class Rate
         RegionFactory $regionFactory,
         SearchCriteriaBuilder $searchCriteriaBuilder,
         FilterBuilder $filterBuilder,
-        Rule $rule
+        \Magento\Tax\Model\Calculation\Rule $rule
     ) {
         $this->cache = $cache;
         $this->scopeConfig = $scopeConfig;


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Our latest release prevents enabling production mode in Magento 2.1 running PHP 5.6.  

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This error is thrown when trying to enable production mode:

`PHP Fatal error:  Cannot use Magento\Tax\Model\Calculation\Rule as Rule because the name is already in use in /var/www/magento2/app/code/Taxjar/SalesTax/Model/Import/Rate.php on line 26`

In order to remain backwards compatible, this PR explicitly references the Rule class.  

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This PR has no impact on performance.  

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Setup version 2.1.x of Magento with PHP 5.6.x
2. Ensure the command `bin/magento deploy:mode:set production` completes successfully

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.3
- [ ] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [X] PHP 5.x
