### PR TITLE
 Change to/from streets to only use the first street value

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -202,7 +202,7 @@ class Smartcalcs
             'to_zip' => $address->getPostcode(),
             'to_state' => $address->getRegionCode(),
             'to_city' => $address->getCity(),
-            'to_street' => $address->getData('street'),
+            'to_street' => $address->getStreetLine(1)
         ];
 
         $order = array_merge($fromAddress, $toAddress, [

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -162,7 +162,7 @@ class Transaction
             'from_zip' => $fromPostcode,
             'from_state' => $fromState,
             'from_city' => $fromCity,
-            'from_street' => $fromStreet1 . $fromStreet2
+            'from_street' => $fromStreet1 . ', ' . $fromStreet2
         ];
     }
 

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -148,11 +148,7 @@ class Transaction
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $order->getStoreId()
         );
-        $fromStreet1 = $this->scopeConfig->getValue('shipping/origin/street_line1',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-            $order->getStoreId()
-        );
-        $fromStreet2 = $this->scopeConfig->getValue('shipping/origin/street_line2',
+        $fromStreet = $this->scopeConfig->getValue('shipping/origin/street_line1',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $order->getStoreId()
         );
@@ -162,7 +158,7 @@ class Transaction
             'from_zip' => $fromPostcode,
             'from_state' => $fromState,
             'from_city' => $fromCity,
-            'from_street' => $fromStreet1 . (!empty($fromStreet2) ? ', ' . $fromStreet2 : '')
+            'from_street' => $fromStreet
         ];
     }
 
@@ -186,7 +182,7 @@ class Transaction
             'to_zip' => $address->getPostcode(),
             'to_state' => $address->getRegionCode(),
             'to_city' => $address->getCity(),
-            'to_street' => $address->getData('street')
+            'to_street' => $address->getStreetLine(1)
         ];
 
         return $toAddress;

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -162,7 +162,7 @@ class Transaction
             'from_zip' => $fromPostcode,
             'from_state' => $fromState,
             'from_city' => $fromCity,
-            'from_street' => $fromStreet1 . ', ' . $fromStreet2
+            'from_street' => $fromStreet1 . (!empty($fromStreet2) ? ', ' . $fromStreet2 : '')
         ];
     }
 


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
The "from_street" address was created by concatenating the first and second street inputs.  This caused addresses with a second line to be improperly formatted.   

![Screen Shot 2020-06-19 at 5 16 43 PM](https://user-images.githubusercontent.com/44789510/85185367-ed80f200-b250-11ea-9791-48e5e7cf7b0a.png)

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR forces all to and from street addresses to only use the first input of the street, formatting the address like this:  
    **10 W 14th Ave Parkway**

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This PR has no impact on performance.  

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Configure the shipping origin address with a value in the second street input.
2. Sync a transaction to TaxJar
3. Confirm via API logs that the from_street value is correctly formatted. 

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.3
- [X] Magento 2.2
- [X] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
