### PR TITLE
Fix bug with missing prefixes in table name

### DIFF
--- a/Plugin/AddTjSyncDateToGrid.php
+++ b/Plugin/AddTjSyncDateToGrid.php
@@ -17,12 +17,27 @@
 
 namespace Taxjar\SalesTax\Plugin;
 
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory;
 use Magento\Sales\Model\ResourceModel\Order\Grid\Collection as OrderGridCollection;
 use Magento\Sales\Model\ResourceModel\Order\Creditmemo\Grid\Collection as CreditmemoGridCollection;
 
 class AddTjSyncDateToGrid
 {
+    /**
+     * @var ResourceConnection
+     */
+    protected $resource;
+
+    /**
+     * @param ResourceConnection $resource
+     */
+    public function __construct(
+        ResourceConnection $resource
+    ) {
+        $this->resource = $resource;
+    }
+
     /**
      * Join tj_salestax_sync_date in the order and creditmemo admin grids
      *
@@ -36,16 +51,16 @@ class AddTjSyncDateToGrid
     ) {
         if ($collection instanceof OrderGridCollection) {
             $collection->getSelect()->joinLeft(
-                'sales_order',
-                'main_table.entity_id = sales_order.entity_id',
+                ['orders' => $this->resource->getTableName('sales_order')],
+                'main_table.entity_id = orders.entity_id',
                 'tj_salestax_sync_date'
             );
         }
 
         if ($collection instanceof CreditmemoGridCollection) {
             $collection->getSelect()->joinLeft(
-                'sales_creditmemo',
-                'main_table.entity_id = sales_creditmemo.entity_id',
+                ['creditmemos' => $this->resource->getTableName('sales_creditmemo')],
+                'main_table.entity_id = creditmemos.entity_id',
                 'tj_salestax_sync_date'
             );
         }


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
The afterGetReport plugin refers to hard-coded table names.  This causes an error if table prefixes are being used.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR dynamically loads the table name to include the prefix.  

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
n/a

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Install Magento w/ a prefix for all tables
2. Configure the order grid to display the TaxJar salestax sync date
3. Confirm that the grid loads and is sortable 

![Screen Shot 2020-08-03 at 6 02 10 PM](https://user-images.githubusercontent.com/44789510/89238560-c0479380-d5b3-11ea-8e9c-d4433d833cc5.png)


#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
