### PR TITLE
Move API key initialization outside the constructor

### DIFF
--- a/Model/Transaction/Backfill.php
+++ b/Model/Transaction/Backfill.php
@@ -132,7 +132,6 @@ class Backfill
         $this->filterGroupBuilder = $filterGroupBuilder;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->taxjarConfig = $taxjarConfig;
-        $this->apiKey = $this->taxjarConfig->getApiKey();
     }
 
     /**
@@ -145,6 +144,8 @@ class Backfill
         array $data = []
     ) {
         // @codingStandardsIgnoreEnd
+
+        $this->apiKey = $this->taxjarConfig->getApiKey();
 
         if (!$this->apiKey) {
             throw new LocalizedException(__('Could not sync transactions with TaxJar. Please make sure you have an API key.'));

--- a/Observer/ImportCategories.php
+++ b/Observer/ImportCategories.php
@@ -99,7 +99,6 @@ class ImportCategories implements ObserverInterface
         $this->categoryFactory = $categoryFactory;
         $this->categoryResourceModel = $categoryResourceModel;
         $this->taxjarConfig = $taxjarConfig;
-        $this->apiKey = $this->taxjarConfig->getApiKey();
     }
 
     /**
@@ -110,6 +109,8 @@ class ImportCategories implements ObserverInterface
     // @codingStandardsIgnoreStart
     public function execute(Observer $observer)
     {
+        $this->apiKey = $this->taxjarConfig->getApiKey();
+
         // @codingStandardsIgnoreEnd
         if ($this->apiKey) {
             $this->client = $this->clientFactory->create();


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Because the API key utilizes the store scope during retrieval, doing so in the constructor fails if Magento hasn't been installed yet.  This prevents installing TaxJar at the same time as Magento.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR moves retrieving the API key outside the constructor for classes used during installation.  

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
n/a

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Download a copy of Magento 2 (ex:  composer create-project --repository=https://repo.magento.com/ magento/project-community-edition)
2. Require TaxJar via this specific commit (ex:  composer require taxjar/module-taxjar:dev-master#7b6391476a8388cd05cb28e185389f607d842414)
3. Finish installing Magento 2 (ex:  bin/magento setup:install)

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
