### PR TITLE
Magento 2.4 - Check array indexes before using them

### DIFF
--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -282,10 +282,13 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
             ? $itemDataObject->getExtensionAttributes()
             : $this->extensionFactory->create();
 
-        $taxCollectable = $lineItemTax['taxable_amount'] * $lineItemTax['combined_tax_rate'];
+        if (is_array($lineItemTax)) {
+            $taxCollectable = $lineItemTax['taxable_amount'] * $lineItemTax['combined_tax_rate'];
 
-        $extensionAttributes->setTaxCollectable($taxCollectable);
-        $extensionAttributes->setCombinedTaxRate($lineItemTax['combined_tax_rate'] * 100);
+            $extensionAttributes->setTaxCollectable($taxCollectable);
+            $extensionAttributes->setCombinedTaxRate($lineItemTax['combined_tax_rate'] * 100);
+        }
+
         $extensionAttributes->setProductType($item->getProductType());
         $extensionAttributes->setPriceType($item->getProduct()->getPriceType());
 
@@ -346,16 +349,19 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
 
         $shippingTax = $this->smartCalcs->getResponseShipping();
 
-        $extensionAttributes->setTaxCollectable($shippingTax['tax_collectable']);
-        $extensionAttributes->setCombinedTaxRate($shippingTax['combined_tax_rate'] * 100);
-        $extensionAttributes->setJurisdictionTaxRates([
-            'shipping' => [
-                'id' => 'shipping',
-                'rate' => $shippingTax['combined_tax_rate'] * 100,
-                'amount' => $shippingTax['tax_collectable']
-            ]
-        ]);
-        $shippingDataObject->setExtensionAttributes($extensionAttributes);
+        if (is_array($shippingTax)) {
+            $extensionAttributes->setTaxCollectable($shippingTax['tax_collectable']);
+            $extensionAttributes->setCombinedTaxRate($shippingTax['combined_tax_rate'] * 100);
+            $extensionAttributes->setJurisdictionTaxRates([
+                'shipping' => [
+                    'id' => 'shipping',
+                    'rate' => $shippingTax['combined_tax_rate'] * 100,
+                    'amount' => $shippingTax['tax_collectable']
+                ]
+            ]);
+
+            $shippingDataObject->setExtensionAttributes($extensionAttributes);
+        }
 
         return $shippingDataObject;
     }


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
When adding certain products to the cart in Magento 2.4, with the TaxJar extension installed (but not necessarily enabled), an error may occur and the product won't be added to the cart.

![Screen Shot 2020-08-18 at 1 12 27 PM](https://user-images.githubusercontent.com/44789510/90555798-25bf8680-e155-11ea-91b5-e63bd1139c89.png)

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This change ensures that certain array indexes exist before utilizing them.  

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
n/a

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Create a new Magento 2.4 installation and install the TaxJar extension
2. Confirm that products can be successfully added to the cart.  
3. Confirm that the rest of the checkout process 

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
