### PR TITLE
Fix mismatched tax class for configurable products

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -464,6 +464,7 @@ class Smartcalcs
                         $discount = ($unitPrice * $quantity);
                     }
 
+                    // This TaxClass may have been overwritten in the TaxjarCommonTaxCollector plugin
                     if ($item->getTaxClassKey()->getValue()) {
                         $taxClass = $this->taxClassRepository->get($item->getTaxClassKey()->getValue());
                         $taxCode = $taxClass->getTjSalestaxCode();

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -468,8 +468,7 @@ class Smartcalcs
                     if ($extensionAttributes->getTjPtc()) {
                         $taxCode = $extensionAttributes->getTjPtc();
                     } elseif ($item->getTaxClassKey()->getValue()) {
-                    // This TaxClass may have been overwritten in the TaxjarCommonTaxCollector plugin
-                    if ($item->getTaxClassKey()->getValue()) {
+                        // This TaxClass may have been overwritten in the TaxjarCommonTaxCollector plugin
                         $taxClass = $this->taxClassRepository->get($item->getTaxClassKey()->getValue());
                         $taxCode = $taxClass->getTjSalestaxCode();
                     }

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -274,14 +274,18 @@ class Transaction
                 'sales_tax' => $tax
             ];
 
+            // Load the tax class from the product.  For configurable products, check the child first
             $product = $this->productRepository->getById($item->getProductId(), false, $order->getStoreId());
+            $children = $item->getChildrenItems();
 
-            if ($product->getTaxClassId()) {
+            if (!empty($children) && $children[0]->getProduct()->getTaxClassId()) {
+                $taxClass = $this->taxClassRepository->get($children[0]->getProduct()->getTaxClassId());
+            } elseif ($product->getTaxClassId()) {
                 $taxClass = $this->taxClassRepository->get($product->getTaxClassId());
+            }
 
-                if ($taxClass->getTjSalestaxCode()) {
-                    $lineItem['product_tax_code'] = $taxClass->getTjSalestaxCode();
-                }
+            if ($taxClass && $taxClass->getTjSalestaxCode()) {
+                $lineItem['product_tax_code'] = $taxClass->getTjSalestaxCode();
             }
 
             $lineItems['line_items'][] = $lineItem;

--- a/Plugin/Tax/Model/Sales/Total/Quote/TaxjarCommonTaxCollector.php
+++ b/Plugin/Tax/Model/Sales/Total/Quote/TaxjarCommonTaxCollector.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2020 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxjar\SalesTax\Plugin\Tax\Model\Sales\Total\Quote;
+
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Quote\Model\Quote\Item\AbstractItem;
+use Magento\Tax\Api\Data\QuoteDetailsItemInterface;
+use Magento\Tax\Api\Data\QuoteDetailsItemInterfaceFactory;
+
+/**
+ * Plugin for CommonTaxCollector to apply Tax Class ID from child item for configurable product
+ */
+class TaxjarCommonTaxCollector
+{
+    /**
+     * Apply Tax Class ID from child item for configurable product
+     *
+     * @param \Magento\Tax\Model\Sales\Total\Quote\CommonTaxCollector $subject
+     * @param QuoteDetailsItemInterface $result
+     * @param QuoteDetailsItemInterfaceFactory $itemDataObjectFactory
+     * @param AbstractItem $item
+     * @return QuoteDetailsItemInterface
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function afterMapItem(
+        \Magento\Tax\Model\Sales\Total\Quote\CommonTaxCollector $subject,
+        QuoteDetailsItemInterface $result,
+        QuoteDetailsItemInterfaceFactory $itemDataObjectFactory,
+        AbstractItem $item
+    ) {
+        if ($item->getProduct()->getTypeId() === Configurable::TYPE_CODE) {
+            $taxClass = (int) $result->getTaxClassKey()->getValue();
+
+            // If a configurable product has no tax class, attempt to load it from the product
+            // This allows a simple product to inherit the tax class of it's configurable parent
+            if ($taxClass === 0) {
+                $result->getTaxClassKey()->setValue($item->getProduct()->getTaxClassId());
+            }
+        }
+
+        return $result;
+    }
+}

--- a/Plugin/Tax/Model/Sales/Total/Quote/TaxjarCommonTaxCollector.php
+++ b/Plugin/Tax/Model/Sales/Total/Quote/TaxjarCommonTaxCollector.php
@@ -49,6 +49,7 @@ class TaxjarCommonTaxCollector
 
             // If a configurable product has no tax class, attempt to load it from the product
             // This allows a simple product to inherit the tax class of it's configurable parent
+            // This tax class is used when calculating tax rates in SmartCalcs
             if ($taxClass === 0) {
                 $result->getTaxClassKey()->setValue($item->getProduct()->getTaxClassId());
             }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -33,4 +33,7 @@
     <type name="Magento\Framework\RequireJs\Config\File\Collector\Aggregated">
         <plugin name="manage_address_validation_mixins" type="Taxjar\SalesTax\Plugin\RequireJs\AfterFiles" sortOrder="100"/>
     </type>
+    <type name="Magento\Tax\Model\Sales\Total\Quote\CommonTaxCollector">
+        <plugin name="taxjar_apply_tax_class" type="Taxjar\SalesTax\Plugin\Tax\Model\Sales\Total\Quote\TaxjarCommonTaxCollector" />
+    </type>
 </config>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
When calculating taxes for configurable products, the tax class of the simple product was used during calculations but the tax class of the parent was used when reporting transactions.  

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR standardizes tax classes to always use the tax class assigned to the simple product first, and if no tax class is set to fall back to the parent.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
n/a

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
0.  Ensure logging is enabled.
1. Setup a configurable product with one tax class and a simple product with a different tax class.
2. Add the simple product to the cart and complete the checkout process.  Invoice and ship the order.
3. Review the logs to confirm the correct PTCs were used for calculations and transactions. 

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
