### PR TITLE
Persist PTCs on OrderItems

### DIFF
--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -49,6 +49,7 @@ class Configuration
     const TAXJAR_TRANSACTIONS_LOG     = 'transactions.log';
     const TAXJAR_ADDRVALIDATION_LOG   = 'address_validation.log';
     const TAXJAR_CUSTOMER_LOG         = 'customers.log';
+    const TAXJAR_TAXABLE_TAX_CODE     = '11111';
     const TAXJAR_EXEMPT_TAX_CODE      = '99999';
     const TAXJAR_GIFT_CARD_TAX_CODE   = '14111803A0001';
     const TAXJAR_BACKUP_RATE_CODE     = 'TaxJar Backup Rates';

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -375,7 +375,8 @@ class Transaction
     {
         // Check for a PTC saved to the Item
         if ($item->getTjPtc()) {
-            return $item->getTjPtc();
+            // Return the PTC, or an empty string if the TAXABLE_TAX_CODE is present
+            return $item->getTjPtc() != $this->taxjarConfig::TAXJAR_TAXABLE_TAX_CODE ?: '';
         }
 
         // If no PTC is saved on the Item, attempt to load it from the product or tax class

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -374,9 +374,15 @@ class Transaction
     protected function getProductTaxCode($item, $order)
     {
         // Check for a PTC saved to the Item
+        // For configurable products, load the PTC of the child
+        if ($item->getHasChildren() && $item->getProductType() == 'configurable') {
+            $child = $item->getChildrenItems()[0];
+            return $child->getTjPtc() != $this->taxjarConfig::TAXJAR_TAXABLE_TAX_CODE ? $child->getTjPtc() : '';
+        }
+
         if ($item->getTjPtc()) {
             // Return the PTC, or an empty string if the TAXABLE_TAX_CODE is present
-            return $item->getTjPtc() != $this->taxjarConfig::TAXJAR_TAXABLE_TAX_CODE ?: '';
+            return $item->getTjPtc() != $this->taxjarConfig::TAXJAR_TAXABLE_TAX_CODE ? $item->getTjPtc() : '';
         }
 
         // If no PTC is saved on the Item, attempt to load it from the product or tax class

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -373,6 +373,12 @@ class Transaction
      */
     protected function getProductTaxCode($item, $order)
     {
+        // Check for a PTC saved to the Item
+        if ($item->getTjPtc()) {
+            return $item->getTjPtc();
+        }
+
+        // If no PTC is saved on the Item, attempt to load it from the product or tax class
         try {
             $product = $this->productRepository->getById($item->getProductId(), false, $order->getStoreId());
 

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -376,8 +376,12 @@ class Transaction
         // Check for a PTC saved to the Item
         // For configurable products, load the PTC of the child
         if ($item->getHasChildren() && $item->getProductType() == 'configurable') {
-            $child = $item->getChildrenItems()[0];
-            return $child->getTjPtc() != $this->taxjarConfig::TAXJAR_TAXABLE_TAX_CODE ? $child->getTjPtc() : '';
+            $children = $item->getChildrenItems();
+
+            if (!empty($children) && is_array($children)) {
+                $child = reset($children);
+                return $child->getTjPtc() != $this->taxjarConfig::TAXJAR_TAXABLE_TAX_CODE ? $child->getTjPtc() : '';
+            }
         }
 
         if ($item->getTjPtc()) {

--- a/Plugin/Sales/Model/Order/ItemRepository.php
+++ b/Plugin/Sales/Model/Order/ItemRepository.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2020 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxjar\SalesTax\Plugin\Sales\Model\Order;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+
+class ItemRepository
+{
+    /**
+     * @var ProductRepositoryInterface
+     */
+    protected $productRepository;
+
+    public function __construct(
+        ProductRepositoryInterface $productRepository
+    ) {
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * Include the TaxJar product tax code when creating an order item
+     *
+     * @param \Magento\Sales\Model\Order\ItemRepository $subject
+     * @param \Magento\Sales\Api\Data\OrderItemInterface $item
+     */
+    public function beforeSave(
+        \Magento\Sales\Model\Order\ItemRepository $subject,
+        \Magento\Sales\Api\Data\OrderItemInterface $item
+    ) {
+        // Only set the product tax code when first creating the OrderItem
+        if ($item->getItemId() === null) {
+            $product = $this->productRepository->getById($item->getProductId());
+            $item->setTjPtc($product->getTjPtc());
+        }
+
+        return null;
+    }
+}

--- a/Plugin/Sales/Model/Order/ItemRepository.php
+++ b/Plugin/Sales/Model/Order/ItemRepository.php
@@ -19,6 +19,7 @@ namespace Taxjar\SalesTax\Plugin\Sales\Model\Order;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 use Taxjar\SalesTax\Model\Logger;
 
 class ItemRepository
@@ -59,7 +60,8 @@ class ItemRepository
         if ($item->getItemId() === null) {
             try {
                 $product = $this->productRepository->getById($item->getProductId());
-                $item->setTjPtc($product->getTjPtc());
+                $ptc = $product->getTjPtc() ?: TaxjarConfig::TAXJAR_TAXABLE_TAX_CODE;
+                $item->setTjPtc($ptc);
             } catch (NoSuchEntityException $e) {
                 $msg = 'Product #' . $item->getProductId() . ' does not exist.  Order #' . $item->getOrderId() . ' possibly missing PTCs on OrderItems.';
                 $this->logger->log($msg, 'error');

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -163,7 +163,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'tj_ptc',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    'length' => 255,
+                    'length' => 32,
                     'nullable' => true,
                     'default' => null,
                     'comment' => 'TaxJar Product Tax Code'

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -150,5 +150,27 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
             $installer->endSetup();
         }
+
+        if (version_compare($context->getVersion(), '1.0.6', '<')) {
+            $installer = $setup;
+            $installer->startSetup();
+
+            /**
+             * Update table 'sales_order_item'
+             */
+            $installer->getConnection()->addColumn(
+                $installer->getTable('sales_order_item'),
+                'tj_ptc',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 255,
+                    'nullable' => true,
+                    'default' => null,
+                    'comment' => 'TaxJar Product Tax Code'
+                ]
+            );
+
+            $installer->endSetup();
+        }
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -36,4 +36,7 @@
     <type name="Magento\Tax\Model\Sales\Total\Quote\CommonTaxCollector">
         <plugin name="taxjar_apply_tax_class" type="Taxjar\SalesTax\Plugin\Tax\Model\Sales\Total\Quote\TaxjarCommonTaxCollector" />
     </type>
+    <type name="Magento\Sales\Model\Order\ItemRepository">
+        <plugin name="taxjar_sales_order_itemrepository" type="Taxjar\SalesTax\Plugin\Sales\Model\Order\ItemRepository" />
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -18,7 +18,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module:etc/module.xsd">
     <!-- Database Setup Version -->
-    <module name="Taxjar_SalesTax" setup_version="1.0.5">
+    <module name="Taxjar_SalesTax" setup_version="1.0.6">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Enterprise"/>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
This PR adds an extra column (tj_ptc) to the sales_order_item table.  It saves the PTC for each OrderItem during creation via the ItemRepository beforeSave plugin.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Product tax codes can change between an order being placed and the order being synced to TaxJar.  By saving the PTC on the sales_order_item table, we can ensure the correct code is synced.  

![Screen Shot 2020-10-26 at 7 42 28 PM](https://user-images.githubusercontent.com/44789510/97246635-683fb800-17c3-11eb-83d8-81f3320930ea.png)


### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Before methods in plugins have a negligible impact on performance.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Obtain this PR and install it by running `bin/magento setup:upgrade`
2. Confirm that the "tj_ptc" column is added to the table `sales_order_item`
3. Place an order with product(s) with PTCs assigned
4. Confirm that the new order items contain the appropriate PTCs
5. Change the PTC on one of the products ordered
6. Invoice and Ship the order
7. Confirm that the correct PTC(s) were synced to TaxJar

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [] Magento 2.2
- [] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
