### PR TITLE
Fix array lookup for configurable product PTCs

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -386,8 +386,12 @@ class Transaction
                 $children = $item->getChildrenItems();
             }
 
-            if (!empty($children) && $children[0]->getProduct()->getTaxClassId()) {
-                $taxClass = $this->taxClassRepository->get($children[0]->getProduct()->getTaxClassId());
+            if (!empty($children) && is_array($children)) {
+                $child = array_first($children);
+
+                if ($child->getProduct()->getTaxClassId()) {
+                    $taxClass = $this->taxClassRepository->get($child->getProduct()->getTaxClassId());
+                }
             } elseif ($product->getTaxClassId()) {
                 $taxClass = $this->taxClassRepository->get($product->getTaxClassId());
             }

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -387,7 +387,7 @@ class Transaction
             }
 
             if (!empty($children) && is_array($children)) {
-                $child = array_first($children);
+                $child = reset($children);
 
                 if ($child->getProduct()->getTaxClassId()) {
                     $taxClass = $this->taxClassRepository->get($child->getProduct()->getTaxClassId());


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Some users are still experiencing fatal errors when trying to load the PTC from the children of configurable products.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Some extensions change the array keys of the children of configurable products.  This PR uses `array_first` to get the first element in the array.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This PR has a negligible impact on performance.  

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Assign a PTC to a parent configurable product, and a different PTC to the child.  
2. Checkout with the product in the cart, and invoice/ship the order.
3. Confirm that the correct PTC synced to TaxJar

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
