### PR TITLE
Fix JS Object Comparison

### DIFF
--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -52,7 +52,7 @@ function (ko, $) {
                 };
 
                 // Skip if already suggested
-                if (formattedAddr == this.activeAddress) {
+                if (JSON.stringify(formattedAddr) === JSON.stringify(this.activeAddress)) {
                     if (typeof onFail === 'function') {
                         onFail('ADDRESS_ALREADY_VALIDATED');
                     }


### PR DESCRIPTION
### Context
Use `JSON.stringify` for JS Object comparison, and `==` can not compare JS object

### Description
Just for correct original logic, and avoid updating when entering the suggested address

### Testing
1. Enter an address that needs to be suggested
2. Update for suggest address

#### Versions
<!-- What version(s) did you test this change on? -->
- [ ] Magento 2.4
- [x] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [ ] Magento Open Source (CE)
- [x] Magento Commerce (EE)
- [ ] Magento B2B
- [x] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [x] PHP 7.x
- [ ] PHP 5.x

**I also use `Aheadwork OneStepCheckout` extension.**