### PR TITLE
Fix issues with Credit Memo Grid filters

### DIFF
--- a/Plugin/AddTjSyncDateToGrid.php
+++ b/Plugin/AddTjSyncDateToGrid.php
@@ -63,6 +63,11 @@ class AddTjSyncDateToGrid
                 'main_table.entity_id = creditmemos.entity_id',
                 'tj_salestax_sync_date'
             );
+            $collection->addFilterToMap('created_at', 'main_table.created_at');
+            $collection->addFilterToMap('base_grand_total', 'main_table.base_grand_total');
+            $collection->addFilterToMap('increment_id', 'main_table.increment_id');
+            $collection->addFilterToMap('state', 'main_table.state');
+            $collection->addFilterToMap('store_id', 'main_table.store_id');
         }
 
         return $collection;


### PR DESCRIPTION
### Context
Errors are occurring on the credit memo grid when using some of the filters. See #161.

### Description
This PR resolves the issue by using addFilterToMap method on the credit memo grid collection to resolve the ambiguity in the query. 

### Testing
1. Navigate to the credit memo grid. (Sales -> Credit Memos).
2. Add created date filter to the view. 
3. No error message should appear and the grid should be filtered as expected.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3

<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)

<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x

