### PR TITLE
Double Inventory Restock Fix

### DIFF
--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -156,21 +156,9 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
                 $this->logger->log('Refund #' . $this->request['transaction_id'] . ' updated: ' . json_encode($response), 'api');
             }
 
-            $originalAmountRefunded = $this->originalOrder->getAmountRefunded();
-            $originalBaseAmountRefunded = $this->originalOrder->getBaseAmountRefunded();
-            $originalBaseAmountRefundedOnline = $this->originalOrder->getBaseAmountRefundedOnline();
+            $this->originalRefund->setTjSalestaxSyncDate(gmdate('Y-m-d H:i:s'));
+            $this->originalRefund->getResource()->saveAttribute($this->originalRefund, 'tj_salestax_sync_date');
 
-            $this->originalRefund
-                ->setTjSalestaxSyncDate(gmdate('Y-m-d H:i:s'))
-                ->setPaymentRefundDisallowed(true)
-                ->setAutomaticallyCreated(true)
-                ->save();
-
-            $this->originalOrder
-                ->setAmountRefunded($originalAmountRefunded)
-                ->setBaseAmountRefunded($originalBaseAmountRefunded)
-                ->setBaseAmountRefundedOnline($originalBaseAmountRefundedOnline)
-                ->save();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->logger->log('Error: ' . $e->getMessage(), 'error');
             $error = json_decode($e->getMessage());


### PR DESCRIPTION
### Context
When a credit memo is created and saved it triggers the sales_order_creditmemo_save_after event. We have an observer tied to this event (SyncRefund) that triggers the refund data to be built and sent to TaxJar. As part of that process we add a sync timestamp to the credit memo and save it. This is where the issue is created. When we save the credit memo in our observer, it triggers the event (sales_order_creditmemo_save_after) again.

Magento also has an observer (RefundOrderInventoryObserver) that runs on that event. This observer is responsible for restocking the inventory from the refund. Since we cause the observer to be run twice we double the inventory that is restocked.

### Description
This PR fixes the issue by removing the save method call on the credit memo, and instead only saving the sync timestamp attribute through the use of the $dataobject->getResource()->saveAttribute() method.

As part of the fix I also remove some code that I believe is no longer necessary. The code was originally added here:

https://github.com/taxjar/taxjar-magento2-extension/commit/7fc15fb2be7b30e27e68bf7c5c50122ef0d98d0e

Its intent was to fix an issue where the refund amounts on the original order where altered and comments were duplicated. I believe this issue was also caused by the extension triggering the sales_order_creditmemo_save_after a second time. After performing the fix in this PR and removing the now unnecessary code, no issues with duplicate comments or incorrect refund totals were found.

### Performance
As observers are a synchronous process performance is pretty critical. This will improve performance as each observer tied to the mentioned event will only run the single time as intended. This also brings our extension inline with best practices for using observers.

### Testing
1. Take note of the quantity of a particular product.
2. Place and ship an order containing 1 of the particular product.
3. Take note of the quantity again (it will reduce by 1).
4. Create a credit memo for the order and restock the item.
5. Check the quantity of the product. It will be 2 greater than the last check (after shipping the item on the test order) and 1 greater than the original quantity. In effect, 1 extra quantity was created.

After applying the PR in the last quantity check the values will be what is expected (same as the original quantity).

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
