### PR TITLE
Fix sniff failures regarding getting config constant

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -19,7 +19,7 @@ use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\Request\Http;
-use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Framework\Pricing\PriceCurrencyInterface as PriceCurrencyInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
@@ -134,7 +134,7 @@ class Data extends AbstractHelper
         $curl = !in_array('curl_version', $disabledFunctions) ? 'cURL ' . curl_version()['version'] : '';
         $openSSL = defined('OPENSSL_VERSION_TEXT') ? OPENSSL_VERSION_TEXT : '';
         $magento = 'Magento ' . $this->productMetadata->getEdition() . ' ' . $this->productMetadata->getVersion();
-        $precision = 'Precision ' . $this->priceCurrency::DEFAULT_PRECISION;
+        $precision = 'Precision ' . PriceCurrencyInterface::DEFAULT_PRECISION;
         $taxjar = 'Taxjar_SalesTax/' . TaxjarConfig::TAXJAR_VERSION;
 
         return "TaxJar/Magento ($os; $php; $curl; $openSSL; $precision; $magento) $taxjar";

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -380,13 +380,13 @@ class Transaction
 
             if (!empty($children) && is_array($children)) {
                 $child = reset($children);
-                return $child->getTjPtc() != $this->taxjarConfig::TAXJAR_TAXABLE_TAX_CODE ? $child->getTjPtc() : '';
+                return $child->getTjPtc() != TaxjarConfig::TAXJAR_TAXABLE_TAX_CODE ? $child->getTjPtc() : '';
             }
         }
 
         if ($item->getTjPtc()) {
             // Return the PTC, or an empty string if the TAXABLE_TAX_CODE is present
-            return $item->getTjPtc() != $this->taxjarConfig::TAXJAR_TAXABLE_TAX_CODE ? $item->getTjPtc() : '';
+            return $item->getTjPtc() != TaxjarConfig::TAXJAR_TAXABLE_TAX_CODE ? $item->getTjPtc() : '';
         }
 
         // If no PTC is saved on the Item, attempt to load it from the product or tax class


### PR DESCRIPTION
This PR cleans up a sniffing failure with how we were accessing constants in two locations.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1

