### PR TITLE
Fix altered line subtotal due to lack of rounding

### DIFF
--- a/Model/Tax/TaxCalculation.php
+++ b/Model/Tax/TaxCalculation.php
@@ -187,7 +187,7 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
         $useBaseCurrency,
         $scope
     ) {
-        $price = $item->getUnitPrice();
+        $price = $this->priceCurrency->round($item->getUnitPrice());
         $quantity = $this->getTotalQuantity($item);
 
         $extensionAttributes = $item->getExtensionAttributes();
@@ -201,7 +201,7 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
         $rowTotal = $price * $quantity;
         $rowTotalInclTax = $rowTotal + $taxCollectable;
 
-        $priceInclTax = $rowTotalInclTax / $quantity;
+        $priceInclTax = $this->priceCurrency->round($rowTotalInclTax / $quantity);
         $discountTaxCompensationAmount = 0;
 
         $appliedTaxes = $this->getAppliedTaxes($item, $scope);


### PR DESCRIPTION
### Context
This issue describes the issue and replicating it in detail: https://github.com/taxjar/taxjar-magento2-extension/issues/173

### Description
This PR resolves the issue by applying rounding to mirror what Magento does natively.

### Performance
No impact.

### Testing
Reproducing the issue is described in detail in this issue: https://github.com/taxjar/taxjar-magento2-extension/issues/173. After applying the PR the subtotal will match what Magento calculated before the TaxJar extension performed its calculations.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4

