### PR TITLE
Address Validation Javascript Fix

### DIFF
--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -128,8 +128,6 @@ function (ko, $) {
         },
 
         addressMatches: function (address, addressToCompare) {
-            console.log(JSON.stringify(address));
-            console.log(JSON.stringify(addressToCompare));
             return JSON.stringify(address) === JSON.stringify(addressToCompare);
         }
     };

--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -106,25 +106,23 @@ function (ko, $) {
         },
 
         formatAddress: function (address) {
-            var formattedAddress = {
+            return {
                 'street0': address.street[0],
                 'city': address.city,
                 'region': address.region_id,
                 'country': address.country_id,
                 'postcode': address.postcode
             };
-            return formattedAddress;
         },
 
         formatSuggestedAddress: function (suggestedAddress) {
-            var formattedAddress = {
+            return {
                 'street0': suggestedAddress.street[0],
                 'city': suggestedAddress.city,
                 'region': suggestedAddress.regionId,
                 'country': suggestedAddress.countryId,
                 'postcode': suggestedAddress.postcode
             };
-            return formattedAddress;
         },
 
         addressMatches: function (address, addressToCompare) {


### PR DESCRIPTION
### Context
The address validation javascript is currently broken on Magento 2.4.

### Description
This PR fixes the issue by the checkout provider registry instead of the quote.

### Performance
N/A

### Testing
1. Ensure Address Validation is enabled in the TaxJar settings.
2. Add a product to the cart and proceed to checkout.
3. Enter an address, and then choose the selected address.
4. Proceed to the next step, and you will see that the selected suggested address was not applied to the cart.

After applying this PR, the selected address will apply to the cart.

#### Versions
- [X] Magento 2.4.2
- [X] Magento 2.3.6
