### PR TITLE
Ignore suggestion address for saved address

### DIFF
--- a/view/adminhtml/web/js/suggested_addresses_admin.js
+++ b/view/adminhtml/web/js/suggested_addresses_admin.js
@@ -73,8 +73,8 @@ define([
                                 forms[x].find('input[name*="[street][0]"]').val(selectedAddress.street);
                                 forms[x].find('input[name*="[city]"]').val(selectedAddress.city);
                                 forms[x].find('select[name*="[region_id]"]').val(selectedAddress.regionId);
-                                forms[x].find('input[name*="[postcode]"]').val(selectedAddress.postcode);
                                 forms[x].find('select[name*="[country_id]"]').val(selectedAddress.countryId);
+                                forms[x].find('input[name*="[postcode]"]').val(selectedAddress.postcode);
                             }
 
                             if (uiRegistry.get(formScope)) {
@@ -147,16 +147,16 @@ define([
                 addr = {
                     street: [uiRegistry.get(formScope + '.street.street_0').value()],
                     city: uiRegistry.get(formScope + '.city').value(),
-                    regionId: uiRegistry.get(formScope + '.region_id').value(),
-                    countryId: uiRegistry.get(formScope + '.country_id').value(),
+                    region_id: uiRegistry.get(formScope + '.region_id').value(),
+                    country_id: uiRegistry.get(formScope + '.country_id').value(),
                     postcode: uiRegistry.get(formScope + '.postcode').value()
                 };
             } else {
                 addr = {
                     street: [this.getAddressFormValue(formValues, '[street][0]')],
                     city: this.getAddressFormValue(formValues, '[city]'),
-                    regionId: this.getAddressFormValue(formValues, '[region_id]'),
-                    countryId: this.getAddressFormValue(formValues, '[country_id]'),
+                    region_id: this.getAddressFormValue(formValues, '[region_id]'),
+                    country_id: this.getAddressFormValue(formValues, '[country_id]'),
                     postcode: this.getAddressFormValue(formValues, '[postcode]')
                 };
             }

--- a/view/base/web/js/address_validation.js
+++ b/view/base/web/js/address_validation.js
@@ -56,8 +56,8 @@ define([
                                 this.data.form.street_1.value = selectedAddress.street;
                                 this.data.form.city.value = selectedAddress.city;
                                 this.data.form.region_id.value = selectedAddress.regionId;
-                                this.data.form.postcode.value = selectedAddress.postcode;
                                 this.data.form.country_id.value = selectedAddress.countryId;
+                                this.data.form.postcode.value = selectedAddress.postcode;
                                 this.data.form.submit();
                             }
                         }
@@ -73,8 +73,8 @@ define([
                         var addr = {
                             street: [form.street_1.value],
                             city: form.city.value,
-                            regionId: form.region_id.value,
-                            countryId: form.country_id.value,
+                            region_id: form.region_id.value,
+                            country_id: form.country_id.value,
                             postcode: form.postcode.value
                         };
 

--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -31,11 +31,25 @@ function (ko, $) {
             return '/rest/V1/Taxjar/address_validation/';
         },
 
+        /**
+         * Fetch suggested address by shipping address
+         * @param {Object} addr - Shipping Address
+         * @param {Array} addr.street - [Street 1, Street 2]
+         * @param {String} addr.region_id
+         * @param {String} addr.country_id
+         * @param {String} addr.postcode
+         * @param {Number} addr.save_in_address_book - Optional, 1 means that saved in address book
+         */
         getSuggestedAddresses: function (addr, onDone, onFail) {
             var self = this;
 
+            if (this.isSavedAddress(addr)) {
+                self.updateSuggestedAddresses([]);
+                return;
+            }
+
             // Skip if non-US shipping address
-            if (addr && addr.country_id !== 'US') {
+            if (!this.isUnitedStatesAddress(addr)) {
                 self.updateSuggestedAddresses([]);
 
                 if (typeof onFail === 'function') {
@@ -106,13 +120,21 @@ function (ko, $) {
             this.suggestedAddresses(addr);
         },
 
+        isSavedAddress: function (addr) {
+            return !!addr && addr.save_in_address_book === 1;
+        },
+
+        isUnitedStatesAddress: function (addr) {
+            return !!addr && addr.country_id === 'US';
+        },
+
         isValidAddress: function (address) {
             return !!(
                 address &&
-                address.country_id &&
                 address.street[0] &&
                 address.city &&
                 address.region_id &&
+                address.country_id &&
                 address.postcode
             );
         },

--- a/view/frontend/web/js/view/shipping.js
+++ b/view/frontend/web/js/view/shipping.js
@@ -40,8 +40,8 @@ define([
                     street: [self.source.get('shippingAddress.street.0')],
                     city: self.source.get('shippingAddress.city'),
                     region_id: self.source.get('shippingAddress.region_id'),
-                    postcode: self.source.get('shippingAddress.postcode'),
-                    country_id: self.source.get('shippingAddress.country_id')
+                    country_id: self.source.get('shippingAddress.country_id'),
+                    postcode: self.source.get('shippingAddress.postcode')
                 });
             });
         },

--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -117,14 +117,13 @@ function (
                 var checkoutProvider = registry.get('checkoutProvider');
                 var originalAddress = $.extend({}, checkoutProvider.get('shippingAddress'));
 
+                addrs[id].address.street.forEach(function(item, index) {
+                    originalAddress.street[index] = item;
+                });
                 originalAddress.city = addrs[id].address.city;
                 originalAddress.country_id = addrs[id].address.countryId;
-                originalAddress.postcode = addrs[id].address.postcode;
                 originalAddress.region_id = addrs[id].address.regionId;
-
-                addrs[id].address.street.forEach(function(item, index) {
-                   originalAddress.street[index] = item;
-                });
+                originalAddress.postcode = addrs[id].address.postcode;
 
                 if (id !== 0) {
                     originalAddress.taxjar_attributes = {


### PR DESCRIPTION
### Context & Description
1. Fixed #183 (Address Validation is not work for saved address of login customers in checkout page)
For saved address should not allow to trigger suggestion address
It's triggered from `view/frontend/web/js/view/suggested_address_checkout_step.js` with `save_in_address_book = 1`
![image](https://user-images.githubusercontent.com/3338473/122469680-d91a2700-cf82-11eb-9384-b0e7ce67e5e7.png)

2. Fixed `Save Address` button in Address Book page for Edit Address (customer/address/edit/id/*) and Add New Address (/customer/address/new/).
It's triggered from `view/base/web/js/address_validation.js`
![image](https://user-images.githubusercontent.com/3338473/122470674-f4d1fd00-cf83-11eb-8acd-7f194ddaa0a7.png)

3. Fixed `Validate Address` button in create order (/admin/sales/order_create/index/) page
It's triggered from `view/adminhtml/web/js/suggested_addresses_admin.js`
![image](https://user-images.githubusercontent.com/3338473/122471186-90fc0400-cf84-11eb-85a0-77d266a851fb.png)

![image](https://user-images.githubusercontent.com/3338473/122471154-83df1500-cf84-11eb-9423-ba80a1f79f52.png)

4. Add comment for `addr` of `getSuggestedAddresses` function
```JavaScript
/**
 * Fetch suggested address by shipping address
 * @param {Object} addr - Shipping Address
 * @param {Array} addr.street - [Street 1, Street 2]
 * @param {String} addr.region_id
 * @param {String} addr.country_id
 * @param {String} addr.postcode
 * @param {Number} addr.save_in_address_book - Optional, 1 means that saved in address book
 */
getSuggestedAddresses: function (addr, onDone, onFail) {
...
```

5. Reorder the address fields
street, city, region, country, and postcode

### Performance
none

### Testing
1. When guest in checkout page, suggestion address is available.
2. When login user without any saved address, suggestion address is available.
3. When login user `new address` in checkout page, suggestion address is unavailable. (No show any suggestion address, it is not work for saved address)
4. When login user 'save address' in Address book page for Edit Address (customer/address/edit/id/*) and Add New Address (/customer/address/new/), suggestion address is available.
5. When admin in create order page (/admin/sales/order_create/index/), suggestion address is available by click `Validate Address` button 

#### Versions
<!-- What version(s) did you test this change on? -->
- [x] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [ ] Magento Open Source (CE)
- [x] Magento Commerce (EE)
- [x] Magento B2B
- [x] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [x] PHP 7.x
- [ ] PHP 5.x
