### PR TITLE
Fix issue with ambiguous query during credit memo export

### DIFF
--- a/Plugin/AddTjSyncDateToGrid.php
+++ b/Plugin/AddTjSyncDateToGrid.php
@@ -68,6 +68,7 @@ class AddTjSyncDateToGrid
             $collection->addFilterToMap('increment_id', 'main_table.increment_id');
             $collection->addFilterToMap('state', 'main_table.state');
             $collection->addFilterToMap('store_id', 'main_table.store_id');
+            $collection->addFilterToMap('entity_id', 'main_table.entity_id');
         }
 
         return $collection;


### PR DESCRIPTION
### Description
The extension has a bug where exporting credit memos will cause a SQL error.  Specifically:

SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'entity_id' in where clause is ambiguous, query was: SELECT COUNT() FROM `sales_creditmemo_grid` AS `main_table`LEFT JOIN `sales_creditmemo` AS `creditmemos` ON main_table.entity_id = creditmemos.entity_id WHERE (`entity_id` IN('6113', '6249'))

This PR resolves the issue.

### Performance
No impact.

### Testing
1. Go the the credit memo grid.
2. Select a few credit memos.
3. Export the credit memos.
4. An error will be thrown and logged.

After applying the PR, the selected credit memos are exported correctly.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3

