### PR TITLE
Fix various address validation issues

### DIFF
--- a/view/adminhtml/web/js/suggested_addresses_admin.js
+++ b/view/adminhtml/web/js/suggested_addresses_admin.js
@@ -43,20 +43,46 @@ define([
 
         initialize: function (config) {
             this._super();
-
             var self = this;
+            this.addressModal = this.buildModal();
 
-            this.addressModal = $('#tj-suggested-addresses').modal({
+            if (config.controller === 'order_create') {
+                this.appendButtonToOrder();
+
+                if ('MutationObserver' in window) {
+                    var orderObserver = new MutationObserver(function (mutations) {
+                        var addressObserver = new MutationObserver(function (mutations) {
+                            self.appendButtonToOrder();
+                            orderObserver.disconnect();
+                        });
+
+                        self.appendButtonToOrder();
+
+                        if ($('.order-billing-address, .order-shipping-address').length) {
+                            addressObserver.observe($('.order-billing-address').get(0), {childList: true});
+                            addressObserver.observe($('.order-shipping-address').get(0), {childList: true});
+                        }
+                    });
+
+                    orderObserver.observe($('#order-data').get(0), {childList: true});
+                }
+            }
+
+            return this;
+        },
+
+        buildModal: function() {
+            return $('#tj-suggested-addresses').modal({
                 buttons: [
                     {
-                        text: $.mage.__('Edit Address'),
+                        text: $.mage.__('Cancel'),
                         class: '',
                         click: function () {
                             this.closeModal();
                         }
                     },
                     {
-                        text: $.mage.__('Save Address'),
+                        text: $.mage.__('Save'),
                         class: 'action primary',
                         click: function () {
                             var addrs = avCore.suggestedAddresses();
@@ -90,30 +116,6 @@ define([
                     }
                 ]
             });
-
-            if (config.controller === 'order_create') {
-                this.appendButtonToOrder();
-
-                if ('MutationObserver' in window) {
-                    var orderObserver = new MutationObserver(function (mutations) {
-                        var addressObserver = new MutationObserver(function (mutations) {
-                            self.appendButtonToOrder();
-                            orderObserver.disconnect();
-                        });
-
-                        self.appendButtonToOrder();
-
-                        if ($('.order-billing-address, .order-shipping-address').length) {
-                            addressObserver.observe($('.order-billing-address').get(0), {childList: true});
-                            addressObserver.observe($('.order-shipping-address').get(0), {childList: true});
-                        }
-                    });
-
-                    orderObserver.observe($('#order-data').get(0), {childList: true});
-                }
-            }
-
-            return this;
         },
 
         appendButtonToOrder: function () {
@@ -147,16 +149,16 @@ define([
                 addr = {
                     street: [uiRegistry.get(formScope + '.street.street_0').value()],
                     city: uiRegistry.get(formScope + '.city').value(),
-                    regionId: uiRegistry.get(formScope + '.region_id').value(),
-                    countryId: uiRegistry.get(formScope + '.country_id').value(),
+                    region_id: uiRegistry.get(formScope + '.region_id').value(),
+                    country_id: uiRegistry.get(formScope + '.country_id').value(),
                     postcode: uiRegistry.get(formScope + '.postcode').value()
                 };
             } else {
                 addr = {
                     street: [this.getAddressFormValue(formValues, '[street][0]')],
                     city: this.getAddressFormValue(formValues, '[city]'),
-                    regionId: this.getAddressFormValue(formValues, '[region_id]'),
-                    countryId: this.getAddressFormValue(formValues, '[country_id]'),
+                    region_id: this.getAddressFormValue(formValues, '[region_id]'),
+                    country_id: this.getAddressFormValue(formValues, '[country_id]'),
                     postcode: this.getAddressFormValue(formValues, '[postcode]')
                 };
             }

--- a/view/adminhtml/web/js/suggested_addresses_admin.js
+++ b/view/adminhtml/web/js/suggested_addresses_admin.js
@@ -58,8 +58,11 @@ define([
 
                         self.appendButtonToOrder();
 
-                        if ($('.order-billing-address, .order-shipping-address').length) {
+                        if ($('.order-billing-address').length) {
                             addressObserver.observe($('.order-billing-address').get(0), {childList: true});
+                        }
+
+                        if ($('.order-shipping-address').length) {
                             addressObserver.observe($('.order-shipping-address').get(0), {childList: true});
                         }
                     });

--- a/view/base/web/js/address_validation.js
+++ b/view/base/web/js/address_validation.js
@@ -39,14 +39,14 @@ define([
                 var addressModal = $('#tj-suggested-addresses').modal({
                     buttons: [
                         {
-                            text: $.mage.__('Edit Address'),
+                            text: $.mage.__('Cancel'),
                             class: '',
                             click: function () {
                                 this.closeModal();
                             }
                         },
                         {
-                            text: $.mage.__('Save Address'),
+                            text: $.mage.__('Save'),
                             class: 'action primary',
                             click: function () {
                                 var addrs = avCore.suggestedAddresses();
@@ -73,8 +73,8 @@ define([
                         var addr = {
                             street: [form.street_1.value],
                             city: form.city.value,
-                            regionId: form.region_id.value,
-                            countryId: form.country_id.value,
+                            region_id: form.region_id.value,
+                            country_id: form.country_id.value,
                             postcode: form.postcode.value
                         };
 

--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -46,7 +46,11 @@ function (
         },
 
         isVisible: function () {
-            return !quote.isVirtual() && this.checkStepNavigator() && this.suggestedAddresses().length && this.validatedAddresses().length !== this.suggestedAddresses().length;
+            var virtual = !quote.isVirtual();
+            var checkoutStepNav = this.checkStepNavigator();
+            var suggestedAddress = this.suggestedAddresses().length;
+            var validatedAddresss = this.validatedAddresses().length !== this.suggestedAddresses().length;
+            return !quote.isVirtual() && this.checkStepNavigator() && this.suggestedAddresses().length;
         },
 
         isOneStepCheckout: function () {
@@ -70,7 +74,16 @@ function (
 
             quote.shippingAddress.subscribe(function (address) {
                 var checkoutProvider = registry.get('checkoutProvider');
-                var address = $.extend({}, checkoutProvider.get('shippingAddress'));
+                //var address = $.extend({}, checkoutProvider.get('shippingAddress'));
+                var quote_address = quote.shippingAddress();
+                var address = {
+                    country_id: quote_address.countryId,
+                    region_id: quote_address.regionId,
+                    postcode: quote_address.postcode,
+                    city: quote_address.city,
+                    street: quote_address.street
+                };
+
                 avCore.getSuggestedAddresses(address);
             });
 
@@ -104,10 +117,6 @@ function (
             this.suggestedAddressRadio.subscribe(function (id) {
                 self.updateQuoteAddress(id);
             });
-        },
-
-        getSuggestedAddressTemplate: function () {
-            return this.suggestedAddressTemplate;
         },
 
         updateQuoteAddress: function (id) {

--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -46,10 +46,6 @@ function (
         },
 
         isVisible: function () {
-            var virtual = !quote.isVirtual();
-            var checkoutStepNav = this.checkStepNavigator();
-            var suggestedAddress = this.suggestedAddresses().length;
-            var validatedAddresss = this.validatedAddresses().length !== this.suggestedAddresses().length;
             return !quote.isVirtual() && this.checkStepNavigator() && this.suggestedAddresses().length;
         },
 
@@ -73,8 +69,6 @@ function (
             this.subscribeToSuggestedAddressRadio();
 
             quote.shippingAddress.subscribe(function (address) {
-                var checkoutProvider = registry.get('checkoutProvider');
-                //var address = $.extend({}, checkoutProvider.get('shippingAddress'));
                 var quote_address = quote.shippingAddress();
                 var address = {
                     country_id: quote_address.countryId,


### PR DESCRIPTION
### Context
Address validation should be able to be used at multiple locations in Magento. These locations are: during guest checkout, during checkout by a logged in user (for both new addresses and saved addresses), in the address book (in account) for a logged in customer) and during order creation in the admin interface.

### Description
There are multiple issues with address validation:

1. While creating an order in admin, it is incorrectly displaying that it can't validate a non US address, even when the country is set to US.
2. When a logged in user checks out, saved addresses are not being validated.
3. When a logged in user checks out, after adding a new address (which is validated) and then switching to a saved address, the suggested addresses are not updated when the saved address is selected.
4. Buttons in the modals that are displayed when validating addresses don't give a clear idea of what they do.
5. Address validation is not working in the address book for logged in customers.

### Performance
No effect.

### Testing

1. Create an order in admin using a US address. Address validation should work correctly.
2. Add an item to the cart with a logged in customer. Address validation should work for both saved and new addresses.
3. Change addresses using the address book for a logged in customer, address validation should work properly.


#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3


