### PR TITLE
Asynchronous Backup Rates Import

### DIFF
--- a/Model/Import/Consumer.php
+++ b/Model/Import/Consumer.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Model\Import;
+
+use Magento\Framework\Bulk\OperationInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\EntityManager\EntityManager;
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+use Taxjar\SalesTax\Model\Import\RateFactory;
+use Taxjar\SalesTax\Model\Import\RuleFactory;
+
+class Consumer
+{
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @var EntityManager $entityManager
+     */
+    protected $entityManager;
+
+    /**
+     * @var TaxjarConfig
+     */
+    private $taxjarConfig;
+
+    /**
+     * @var RateFactory
+     */
+    protected $rateFactory;
+
+    /**
+     * @var RuleFactory
+     */
+    protected $ruleFactory;
+
+    /**
+     * @var \Magento\AsynchronousOperations\Api\Data\OperationInterface
+     */
+    private $operation;
+
+    /**
+     * @var array
+     */
+    private $rates;
+
+    /**
+     * @var array
+     */
+    private $newRates;
+
+    /**
+     * @var array
+     */
+    private $newShippingRates;
+
+    /**
+     * @var array
+     */
+    private $productTaxClasses;
+
+    /**
+     * @var array
+     */
+    private $customerTaxClasses;
+
+    /**
+     * @var integer
+     */
+    private $shippingClass;
+
+    /**
+     * @param SerializerInterface $serializer
+     * @param ScopeConfigInterface $scopeConfig
+     * @param EntityManager $entityManager
+     * @param TaxjarConfig $taxjarConfig
+     * @param RateFactory $rateFactory
+     * @param RuleFactory $ruleFactory
+     */
+    public function __construct(
+        SerializerInterface $serializer,
+        ScopeConfigInterface $scopeConfig,
+        EntityManager $entityManager,
+        TaxjarConfig $taxjarConfig,
+        RateFactory $rateFactory,
+        RuleFactory $ruleFactory
+    )
+    {
+        $this->serializer = $serializer;
+        $this->scopeConfig = $scopeConfig;
+        $this->entityManager = $entityManager;
+        $this->taxjarConfig = $taxjarConfig;
+        $this->rateFactory = $rateFactory;
+        $this->ruleFactory = $ruleFactory;
+    }
+
+    /**
+     * Process asynchronous bulk operation
+     *
+     * @param \Magento\AsynchronousOperations\Api\Data\OperationInterface $operation
+     * @throws \Exception
+     */
+    public function process(\Magento\AsynchronousOperations\Api\Data\OperationInterface $operation)
+    {
+        $this->operation = $operation;
+        $this->reset();
+
+        try {
+            $this->processOperation();
+        } catch (LocalizedException $e) {
+            $this->fail($e, $e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail(
+                $e,
+                __('Sorry, something went wrong during product attributes update. Please see log for details.')
+            );
+        }
+
+        $this->success();
+        $this->entityManager->save($this->operation);
+    }
+
+    /**
+     * Reset member variables as class is not reinstantiated between operations
+     */
+    private function reset()
+    {
+        $this->newRates = [];
+        $this->newShippingRates = [];
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function processOperation()
+    {
+        $this->validate();
+        $this->setData();
+        $this->createRatesAndRules();
+    }
+
+    /**
+     * Validate that backup rates should be imported
+     *
+     * @throws LocalizedException
+     */
+    private function validate()
+    {
+        $this->validateBackupRatesAreEnabled();
+        $this->validateAPIKeyIsSet();
+    }
+
+    /**
+     * Validate that settings are configured to allow backup rates
+     *
+     * @throws LocalizedException
+     */
+    private function validateBackupRatesAreEnabled()
+    {
+        if (!$this->scopeConfig->getValue(TaxjarConfig::TAXJAR_BACKUP)) {
+            throw new LocalizedException(__('Backup rates are not enabled.'));
+        }
+    }
+
+    /**
+     * Validate API key is set
+     *
+     * @throws LocalizedException
+     */
+    private function validateAPIKeyIsSet()
+    {
+        if (!$this->taxjarConfig->getApiKey()) {
+            throw new LocalizedException(__('TaxJar account is not linked or API Token is invalid.'));
+        }
+    }
+
+    /**
+     * Set member variables from operation
+     */
+    private function setData()
+    {
+        $serializedData = $this->operation->getSerializedData();
+        $data = $this->serializer->unserialize($serializedData);
+        $this->setRates($data['rates']);
+        $this->productTaxClasses = $data['product_tax_classes'];
+        $this->customerTaxClasses = $data['customer_tax_classes'];
+        $this->shippingClass = $data['shipping_class'];
+    }
+
+    /**
+     * Set rates
+     *
+     * @param array $rates
+     */
+    private function setRates(array $rates)
+    {
+        $this->rates = $rates;
+    }
+
+    /**
+     * Create tax rates and rules
+     *
+     * @throws \Exception
+     */
+    private function createRatesAndRules()
+    {
+        $this->createRates();
+        $this->createRules();
+    }
+
+    /**
+     * Create new tax rates
+     *
+     * @return void
+     */
+    private function createRates()
+    {
+        $rate = $this->rateFactory->create();
+
+        foreach ($this->rates as $newRate) {
+            $rateIdWithShippingId = $rate->create($newRate);
+
+            if ($rateIdWithShippingId[0]) {
+                $this->newRates[] = $rateIdWithShippingId[0];
+            }
+
+            if ($rateIdWithShippingId[1]) {
+                $this->newShippingRates[] = $rateIdWithShippingId[1];
+            }
+        }
+    }
+
+    /**
+     * Create or update existing tax rules with new rates
+     *
+     * @throws \Exception
+     * @return void
+     */
+    private function createRules()
+    {
+        $rule = $this->ruleFactory->create();
+
+        $rule->create(
+            TaxjarConfig::TAXJAR_BACKUP_RATE_CODE,
+            $this->customerTaxClasses,
+            $this->productTaxClasses,
+            1,
+            $this->newRates
+        );
+
+        if ($this->shippingClass) {
+            $rule->create(
+                TaxjarConfig::TAXJAR_BACKUP_RATE_CODE . ' (Shipping)',
+                $this->customerTaxClasses,
+                [$this->shippingClass],
+                2,
+                $this->newShippingRates
+            );
+        }
+    }
+
+    /**
+     * Log and handled operation failures
+     *
+     * @param \Exception $e
+     * @param $message
+     */
+    private function fail(\Exception $e, $message)
+    {
+        $this->logger->critical($e->getMessage());
+        $this->operation->setStatus(OperationInterface::STATUS_TYPE_NOT_RETRIABLY_FAILED);
+        $this->operation->setErrorCode($e->getCode());
+        $this->operation->setResultMessage($message);
+    }
+
+    /**
+     * Set operation status to completed
+     */
+    private function success()
+    {
+        $this->operation->setStatus(OperationInterface::STATUS_TYPE_COMPLETE);
+        $this->operation->setErrorCode(null);
+        $this->operation->setResultMessage(null);
+    }
+}

--- a/Model/Import/RuleModel.php
+++ b/Model/Import/RuleModel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Taxjar\SalesTax\Model\Import;
+
+use Magento\Tax\Model\Calculation\Rule;
+use Magento\Framework\Model\AbstractExtensibleModel;
+
+class RuleModel extends Rule
+{
+
+    /**
+     * Triggers after save events
+     * Re-declared to prevent saveCalculationData from running after saving
+     * saveCalculationData causes all rates to be re-associated with the rule in the database
+     * Associating new rates already occurs in Taxjar\SalesTax\Model\Import\Rule::saveCalculationData
+     * Only associating new rates greatly increases performance during large imports
+     *
+     * @return $this
+     */
+    public function afterSave()
+    {
+        AbstractExtensibleModel::afterSave();
+        $this->_eventManager->dispatch('tax_settings_change_after');
+        return $this;
+    }
+
+}

--- a/etc/communication.xml
+++ b/etc/communication.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
+    <topic name="taxjar.create_backup_rates" request="Magento\AsynchronousOperations\Api\Data\OperationInterface">
+        <handler name="taxjar.create_backup_rates" type="Taxjar\SalesTax\Model\Import\Consumer" method="process" />
+    </topic>
+</config>

--- a/etc/queue_consumer.xml
+++ b/etc/queue_consumer.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
+    <consumer name="taxjar.create_backup_rates" queue="taxjar.create_backup_rates" connection="db" maxMessages="5000" consumerInstance="Magento\Framework\MessageQueue\Consumer" handler="Taxjar\SalesTax\Model\Import\Consumer::process" />
+</config>

--- a/etc/queue_publisher.xml
+++ b/etc/queue_publisher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/publisher.xsd">
+    <publisher topic="taxjar.create_backup_rates">
+        <connection name="db" exchange="taxjar" />
+    </publisher>
+</config>

--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
+    <exchange name="taxjar" type="topic" connection="db">
+        <binding id="backupRatesBinding" topic="taxjar.create_backup_rates" destinationType="queue" destination="taxjar.create_backup_rates"/>
+    </exchange>
+</config>


### PR DESCRIPTION
### Context
Importing backup rates is an intensive process. For a store with nexus in all 50 states there can be over 20000 backup rates that need imported. This process was previously done synchronously and would often fail due to timeouts. 

### Description
This PR changes the backup rate import from a synchronous process to an asynchronous one. It also splits the import into batches. This is the first step in rebuilding the backup rate process to be fully asynchronous. Additional changes will be made in the Backup-Rates-Rebuild branch and will all be released together.

### Performance
Performance is greatly improved. Previously the process might not have even completed.

