### PR TITLE
Backup rates delete async

### DIFF
--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -54,6 +54,8 @@ class Configuration
     const TAXJAR_GIFT_CARD_TAX_CODE   = '14111803A0001';
     const TAXJAR_BACKUP_RATE_CODE     = 'TaxJar Backup Rates';
     const TAXJAR_X_API_VERSION        = '2020-08-07';
+    const TAXJAR_TOPIC_CREATE_RATES   = 'taxjar.backup_rates.create';
+    const TAXJAR_TOPIC_DELETE_RATES   = 'taxjar.backup_rates.delete';
 
     /**
      * @var \Magento\Config\Model\ResourceModel\Config

--- a/Model/Import/CreateRatesConsumer.php
+++ b/Model/Import/CreateRatesConsumer.php
@@ -4,36 +4,168 @@ declare(strict_types=1);
 
 namespace Taxjar\SalesTax\Model\Import;
 
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 
 class CreateRatesConsumer extends AbstractRatesConsumer
 {
-    protected function setData(): void
-    {
-        $serializedData = $this->operation->getSerializedData();
-        $data = $this->serializer->unserialize($serializedData);
+    /**
+     * @var array
+     */
+    private $newRates;
 
-        $this->rates = $data['rates'];
-        $this->productTaxClasses = $data['product_tax_classes'];
-        $this->customerTaxClasses = $data['customer_tax_classes'];
-        $this->shippingClass = $data['shipping_class'];
+    /**
+     * @var array
+     */
+    private $newShippingRates;
+
+    /**
+     * @var array
+     */
+    private $customerTaxClasses;
+
+    /**
+     * @var array
+     */
+    private $productTaxClasses;
+
+    /**
+     * @var string
+     */
+    private $shippingTaxClass;
+
+    /**
+     * @param string[] $values List of configured customer tax class names
+     * @return $this
+     */
+    private function setCustomerTaxClasses(array $values): self
+    {
+        $this->customerTaxClasses = $values;
+
+        return $this;
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException | \Exception
+     * @param string[] $values List of configured product tax class names
+     * @return $this
      */
-    protected function processOperation(): void
+    private function setProductTaxClasses(array $values): self
     {
-        $this->createRates();
-        $this->createRules();
+        $this->productTaxClasses = $values;
+
+        return $this;
+    }
+
+    /**
+     * @param string $value Configured shipping tax class name
+     * @return $this
+     */
+    private function setShippingTaxClass(string $value): self
+    {
+        $this->shippingTaxClass = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function setMemberData(): self
+    {
+        return $this->setRates($this->payload['rates'])
+            ->setProductTaxClasses($this->payload['product_tax_classes'])
+            ->setCustomerTaxClasses($this->payload['customer_tax_classes'])
+            ->setShippingTaxClass($this->payload['shipping_tax_class']);
+    }
+
+    /**
+     * @throws LocalizedException | Exception
+     */
+    protected function handle(): self
+    {
+        return $this->reset()
+            ->validate()
+            ->setMemberData()
+            ->createRates()
+            ->createRules();
+    }
+
+    /**
+     * Reset member variables as class is not re-instantiated between operations
+     */
+    private function reset(): self
+    {
+        $this->newRates = $this->newShippingRates = [];
+
+        return $this;
+    }
+
+    /**
+     * Validate that backup rates can be imported
+     *
+     * @throws LocalizedException
+     */
+    private function validate(): self
+    {
+        return $this->validatePayload()
+            ->validateBackupRatesEnabled()
+            ->validateAPIKey();
+    }
+
+    /**
+     * Validate that operation payload is an array containing the expected keys
+     *
+     * @throws LocalizedException
+     */
+    private function validatePayload(): self
+    {
+        if (is_array($this->payload)
+            && array_key_exists('rates', $this->payload)
+            && array_key_exists('product_tax_classes', $this->payload)
+            && array_key_exists('customer_tax_classes', $this->payload)
+            && array_key_exists('shipping_tax_class', $this->payload)
+        ) {
+            return $this;
+        }
+
+        throw new LocalizedException(__('Consumer %1 received invalid payload.', self::class));
+    }
+
+    /**
+     * Validate that settings are configured to allow backup rates
+     *
+     * @throws LocalizedException
+     */
+    private function validateBackupRatesEnabled(): self
+    {
+        if ($this->backupRatesEnabled()) {
+            return $this;
+        }
+
+        throw new LocalizedException(__('Backup rates are not enabled.'));
+    }
+
+    /**
+     * Validate API key is set
+     *
+     * @throws LocalizedException
+     */
+    private function validateApiKey(): self
+    {
+        if ($this->taxjarConfig->getApiKey()) {
+            return $this;
+        }
+
+        throw new LocalizedException(__('TaxJar account is not linked or API Token is invalid.'));
     }
 
     /**
      * Create new tax rates
      *
-     * @return void
+     * @return self
      */
-    private function createRates()
+    private function createRates(): self
     {
         $rate = $this->rateFactory->create();
 
@@ -48,15 +180,17 @@ class CreateRatesConsumer extends AbstractRatesConsumer
                 $this->newShippingRates[] = $rateIdWithShippingId[1];
             }
         }
+
+        return $this;
     }
 
     /**
      * Create or update existing tax rules with new rates
      *
-     * @throws \Exception
-     * @return void
+     * @return self
+     * @throws Exception
      */
-    private function createRules()
+    private function createRules(): self
     {
         $rule = $this->ruleFactory->create();
 
@@ -68,14 +202,26 @@ class CreateRatesConsumer extends AbstractRatesConsumer
             $this->newRates
         );
 
-        if ($this->shippingClass) {
+        if ($this->shippingTaxClass) {
             $rule->create(
                 TaxjarConfig::TAXJAR_BACKUP_RATE_CODE . ' (Shipping)',
                 $this->customerTaxClasses,
-                [$this->shippingClass],
+                [$this->shippingTaxClass],
                 2,
                 $this->newShippingRates
             );
         }
+
+        return $this;
+    }
+
+    /**
+     * Return boolean value whether TaxJar extension's Backup Rates feature is enabled.
+     *
+     * @return bool
+     */
+    private function backupRatesEnabled(): bool
+    {
+        return (bool) $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_BACKUP);
     }
 }

--- a/Model/Import/CreateRatesConsumer.php
+++ b/Model/Import/CreateRatesConsumer.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Model\Import;
+
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+
+class CreateRatesConsumer extends AbstractRatesConsumer
+{
+    protected function setData(): void
+    {
+        $serializedData = $this->operation->getSerializedData();
+        $data = $this->serializer->unserialize($serializedData);
+
+        $this->rates = $data['rates'];
+        $this->productTaxClasses = $data['product_tax_classes'];
+        $this->customerTaxClasses = $data['customer_tax_classes'];
+        $this->shippingClass = $data['shipping_class'];
+    }
+
+    /**
+     * @throws \Magento\Framework\Exception\LocalizedException | \Exception
+     */
+    protected function processOperation(): void
+    {
+        $this->createRates();
+        $this->createRules();
+    }
+
+    /**
+     * Create new tax rates
+     *
+     * @return void
+     */
+    private function createRates()
+    {
+        $rate = $this->rateFactory->create();
+
+        foreach ($this->rates as $newRate) {
+            $rateIdWithShippingId = $rate->create($newRate);
+
+            if ($rateIdWithShippingId[0]) {
+                $this->newRates[] = $rateIdWithShippingId[0];
+            }
+
+            if ($rateIdWithShippingId[1]) {
+                $this->newShippingRates[] = $rateIdWithShippingId[1];
+            }
+        }
+    }
+
+    /**
+     * Create or update existing tax rules with new rates
+     *
+     * @throws \Exception
+     * @return void
+     */
+    private function createRules()
+    {
+        $rule = $this->ruleFactory->create();
+
+        $rule->create(
+            TaxjarConfig::TAXJAR_BACKUP_RATE_CODE,
+            $this->customerTaxClasses,
+            $this->productTaxClasses,
+            1,
+            $this->newRates
+        );
+
+        if ($this->shippingClass) {
+            $rule->create(
+                TaxjarConfig::TAXJAR_BACKUP_RATE_CODE . ' (Shipping)',
+                $this->customerTaxClasses,
+                [$this->shippingClass],
+                2,
+                $this->newShippingRates
+            );
+        }
+    }
+}

--- a/Model/Import/DeleteRatesConsumer.php
+++ b/Model/Import/DeleteRatesConsumer.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Taxjar\SalesTax\Model\Import;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\DB\LoggerInterface;
 use Magento\Framework\EntityManager\EntityManager;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Tax\Model\Calculation\RateRepository;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
@@ -17,9 +20,21 @@ class DeleteRatesConsumer extends AbstractRatesConsumer
      */
     private $rateRepository;
 
+    /**
+     * DeleteRatesConsumer constructor.
+     * @param SerializerInterface $serializer
+     * @param ScopeConfigInterface $scopeConfig
+     * @param LoggerInterface $logger
+     * @param EntityManager $entityManager
+     * @param TaxjarConfig $taxjarConfig
+     * @param RateFactory $rateFactory
+     * @param RuleFactory $ruleFactory
+     * @param RateRepository $rateRepository
+     */
     public function __construct(
         SerializerInterface $serializer,
         ScopeConfigInterface $scopeConfig,
+        LoggerInterface $logger,
         EntityManager $entityManager,
         TaxjarConfig $taxjarConfig,
         RateFactory $rateFactory,
@@ -29,6 +44,7 @@ class DeleteRatesConsumer extends AbstractRatesConsumer
         parent::__construct(
             $serializer,
             $scopeConfig,
+            $logger,
             $entityManager,
             $taxjarConfig,
             $rateFactory,
@@ -38,18 +54,54 @@ class DeleteRatesConsumer extends AbstractRatesConsumer
         $this->rateRepository = $rateRepository;
     }
 
-    protected function setData(): void
+    /**
+     * @return self
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    protected function handle(): self
     {
-        $serializedData = $this->operation->getSerializedData();
-        $data = $this->serializer->unserialize($serializedData);
-
-        $this->rates = $data['rates'];
+        return $this->validate()
+            ->setMemberData()
+            ->deleteRates();
     }
 
-    protected function processOperation(): void
+    /**
+     * @return self
+     */
+    protected function setMemberData(): self
+    {
+        $this->setRates($this->payload['rates']);
+
+        return $this;
+    }
+
+    /**
+     * Throw exception if payload does not adhere to expected format
+     *
+     * @return self
+     * @throws LocalizedException
+     */
+    private function validate(): self
+    {
+        if (is_array($this->payload) && array_key_exists('rates', $this->payload)) {
+            return $this;
+        }
+
+        throw new LocalizedException(__('Consumer %1 received invalid payload.', self::class));
+    }
+
+    /**
+     * Delete `tax_calculation_rates` by ID
+     *
+     * @throws NoSuchEntityException
+     */
+    private function deleteRates(): self
     {
         foreach ($this->rates as $rate) {
             $this->rateRepository->deleteById($rate);
         }
+
+        return $this;
     }
 }

--- a/Model/Import/DeleteRatesConsumer.php
+++ b/Model/Import/DeleteRatesConsumer.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Model\Import;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\EntityManager\EntityManager;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Tax\Model\Calculation\RateRepository;
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+
+class DeleteRatesConsumer extends AbstractRatesConsumer
+{
+    /**
+     * @var RateRepository
+     */
+    private $rateRepository;
+
+    public function __construct(
+        SerializerInterface $serializer,
+        ScopeConfigInterface $scopeConfig,
+        EntityManager $entityManager,
+        TaxjarConfig $taxjarConfig,
+        RateFactory $rateFactory,
+        RuleFactory $ruleFactory,
+        RateRepository $rateRepository
+    ) {
+        parent::__construct(
+            $serializer,
+            $scopeConfig,
+            $entityManager,
+            $taxjarConfig,
+            $rateFactory,
+            $ruleFactory
+        );
+
+        $this->rateRepository = $rateRepository;
+    }
+
+    protected function setData(): void
+    {
+        $serializedData = $this->operation->getSerializedData();
+        $data = $this->serializer->unserialize($serializedData);
+
+        $this->rates = $data['rates'];
+    }
+
+    protected function processOperation(): void
+    {
+        foreach ($this->rates as $rate) {
+            $this->rateRepository->deleteById($rate);
+        }
+    }
+}

--- a/Model/Import/Rate.php
+++ b/Model/Import/Rate.php
@@ -158,6 +158,11 @@ class Rate
         }
     }
 
+    /**
+     * Get related Calculation Rule object
+     *
+     * @return \Magento\Tax\Model\Calculation\Rule
+     */
     public function getRule(): \Magento\Tax\Model\Calculation\Rule
     {
         return $this->rule;

--- a/Model/Import/Rate.php
+++ b/Model/Import/Rate.php
@@ -158,6 +158,11 @@ class Rate
         }
     }
 
+    public function getRule(): \Magento\Tax\Model\Calculation\Rule
+    {
+        return $this->rule;
+    }
+
     /**
      * Get existing TaxJar rates based on configuration states
      *
@@ -165,7 +170,7 @@ class Rate
      */
     public function getExistingRates()
     {
-        return $this->rule->load(TaxjarConfig::TAXJAR_BACKUP_RATE_CODE, 'code')->getRates();
+        return $this->getRule()->load(TaxjarConfig::TAXJAR_BACKUP_RATE_CODE, 'code')->getRates();
     }
 
     /**

--- a/Observer/ImportRates.php
+++ b/Observer/ImportRates.php
@@ -9,18 +9,22 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  *
- * @category   Taxjar
- * @package    Taxjar_SalesTax
- * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
- * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @category Taxjar
+ * @package Taxjar_SalesTax
+ * @copyright Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
+
+declare(strict_types=1);
 
 namespace Taxjar\SalesTax\Observer;
 
 use Magento\AsynchronousOperations\Api\Data\OperationInterface;
+use Magento\AsynchronousOperations\Model\Operation;
 use Magento\Config\Model\ResourceModel\Config;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -31,105 +35,68 @@ use Magento\AsynchronousOperations\Api\Data\OperationInterfaceFactory;
 use Magento\Framework\Bulk\BulkManagementInterface;
 use Magento\Authorization\Model\UserContextInterface;
 use Taxjar\SalesTax\Model\BackupRateOriginAddress;
+use Taxjar\SalesTax\Model\Client;
 use Taxjar\SalesTax\Model\ClientFactory;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 use Taxjar\SalesTax\Model\Import\RateFactory;
 use Taxjar\SalesTax\Model\Import\RuleFactory;
 
-/**
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- */
 class ImportRates implements ObserverInterface
 {
     /**
-     * @var \Magento\Framework\Event\ManagerInterface
+     * The default batch size used for bulk operations in `ImportRates::class`
      */
-    protected $eventManager;
+    private const BATCH_SIZE = 1000;
 
     /**
-     * @var \Magento\Framework\Message\ManagerInterface
+     * @var EventManagerInterface
      */
-    protected $messageManager;
+    private $eventManager;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var MessageManagerInterface
      */
-    protected $scopeConfig;
+    private $messageManager;
 
     /**
-     * @var \Magento\Config\Model\ResourceModel\Config
+     * @var ScopeConfigInterface
      */
-    protected $resourceConfig;
+    private $scopeConfig;
 
     /**
-     * @var \Taxjar\SalesTax\Model\ClientFactory
+     * @var Config
      */
-    protected $clientFactory;
+    private $resourceConfig;
 
     /**
-     * @var \Taxjar\SalesTax\Model\Import\RateFactory
+     * @var ClientFactory
      */
-    protected $rateFactory;
+    private $clientFactory;
 
     /**
-     * @var \Taxjar\SalesTax\Model\Import\RuleFactory
+     * @var RateFactory
      */
-    protected $ruleFactory;
+    private $rateFactory;
 
     /**
-     * @var BackupRateOriginAddress
+     * @var RuleFactory
      */
-    protected $backupRateOriginAddress;
-
-    /**
-     * @var string
-     */
-    protected $apiKey;
-
-    /**
-     * @var \Taxjar\SalesTax\Model\ClientFactory
-     */
-    protected $client;
-
-    /**
-     * @var string
-     */
-    protected $storeZip;
-
-    /**
-     * @var array
-     */
-    protected $customerTaxClasses;
-
-    /**
-     * @var array
-     */
-    protected $productTaxClasses;
-
-    /**
-     * @var array
-     */
-    protected $newRates = [];
-
-    /**
-     * @var array
-     */
-    protected $newShippingRates = [];
+    private $ruleFactory;
 
     /**
      * @var RateRepository
      */
-    protected $rateRepository;
+    private $rateRepository;
 
     /**
      * @var TaxjarConfig
      */
-    protected $taxjarConfig;
+    private $taxjarConfig;
 
     /**
-     * @var integer
+     * @var BackupRateOriginAddress
      */
-    private $batchSize;
+    private $backupRateOriginAddress;
 
     /**
      * @var IdentityGeneratorInterface
@@ -157,8 +124,33 @@ class ImportRates implements ObserverInterface
     private $userContext;
 
     /**
-     * @param ManagerInterface $eventManager
-     * @param \Magento\Framework\Message\ManagerInterface $messageManager
+     * @var Client|null
+     */
+    private $client;
+
+    /**
+     * @var array|null
+     */
+    private $customerTaxClasses;
+
+    /**
+     * @var array|null
+     */
+    private $productTaxClasses;
+
+    /**
+     * @var string|null
+     */
+    private $shippingTaxClass;
+
+    /**
+     * @var string|null
+     */
+    private $zipCode;
+
+    /**
+     * @param EventManagerInterface $eventManager
+     * @param MessageManagerInterface $messageManager
      * @param ScopeConfigInterface $scopeConfig
      * @param Config $resourceConfig
      * @param ClientFactory $clientFactory
@@ -174,8 +166,8 @@ class ImportRates implements ObserverInterface
      * @param UserContextInterface $userContext
      */
     public function __construct(
-        ManagerInterface $eventManager,
-        \Magento\Framework\Message\ManagerInterface $messageManager,
+        EventManagerInterface $eventManager,
+        MessageManagerInterface $messageManager,
         ScopeConfigInterface $scopeConfig,
         Config $resourceConfig,
         ClientFactory $clientFactory,
@@ -205,43 +197,107 @@ class ImportRates implements ObserverInterface
         $this->operationFactory = $operationFactory;
         $this->bulkManagement = $bulkManagement;
         $this->userContext = $userContext;
-        $this->apiKey = $this->taxjarConfig->getApiKey();
-        $this->batchSize = 1000;
+    }
+
+    /**
+     * Retrieve date string in required format for config update
+     * @return string
+     */
+    private function getDate(): string
+    {
+        return date('m-d-Y');
+    }
+
+    /**
+     * @param Client $client Instance of TaxJar's API Client
+     * @return self
+     */
+    private function setClient(Client $client): self
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    /**
+     * @param string $value A comma-delimited string of customer tax classes
+     * @return self
+     */
+    private function setCustomerTaxClasses(string $value): self
+    {
+        $this->customerTaxClasses = array_filter(
+            explode(',', $value)
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $value A comma-delimited string of product tax classes
+     * @return self
+     */
+    private function setProductTaxClasses(string $value): self
+    {
+        $this->productTaxClasses = array_filter(
+            explode(',', $value)
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $value Magento store's configured shipping tax class
+     * @return self
+     */
+    private function setShippingTaxClass(string $value): self
+    {
+        $this->shippingTaxClass = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param string $value The Magento store's shipping zip code
+     * @return self
+     */
+    private function setZipCode(string $value): self
+    {
+        $this->zipCode = $value;
+
+        return $this;
     }
 
     /**
      * @param Observer $observer
-     * @return $this
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @return self
      * @throws LocalizedException
      */
-    // @codingStandardsIgnoreStart
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): self
     {
-        // @codingStandardsIgnoreEnd
-        $isEnabled = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_BACKUP);
+        if ($this->backupRatesEnabled() && $this->taxjarConfig->getApiKey()) {
+            $client = $this->clientFactory->create();
+            $zipCode = $this->backupRateOriginAddress->getShippingZipCode();
+            $customerTaxClassConfig = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES);
+            $productTaxClassConfig = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES);
+            $shippingTaxClass = $this->scopeConfig->getValue('tax/classes/shipping_tax_class');
 
-        if ($isEnabled && $this->apiKey) {
-            $this->client = $this->clientFactory->create();
-            $this->storeZip = $this->backupRateOriginAddress->getShippingZipCode();
-            $this->customerTaxClasses = explode(
-                ',',
-                $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES)
-            );
-            $this->productTaxClasses = explode(
-                ',',
-                $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES)
-            );
-            $this->_importRates();
+            $this->setClient($client)
+                ->setZipCode($zipCode)
+                ->setCustomerTaxClasses($customerTaxClassConfig)
+                ->setProductTaxClasses($productTaxClassConfig)
+                ->setShippingTaxClass($shippingTaxClass)
+                ->importRates();
         } else {
-            $states = json_decode($this->scopeConfig->getValue(TaxjarConfig::TAXJAR_STATES), true);
+            $statesConfig = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_STATES);
+            $states = json_decode($statesConfig, true);
 
             if (!empty($states)) {
-                $this->purgeRates();
+                $this->purgeExistingRates();
             }
 
-            $this->_setLastUpdateDate(null);
-            $this->resourceConfig->saveConfig(TaxjarConfig::TAXJAR_BACKUP, 0, 'default', 0);
+            $this->setLastUpdate(null);
+
+            $this->resourceConfig->saveConfig(TaxjarConfig::TAXJAR_BACKUP, 0, 'default');
             $this->messageManager->addNoticeMessage(__('Backup rates imported by TaxJar have been removed.'));
         }
 
@@ -251,94 +307,86 @@ class ImportRates implements ObserverInterface
     }
 
     /**
-     * Execute observer action during cron job
-     *
-     * @throws LocalizedException
-     */
-    public function cron()
-    {
-        $this->execute(new Observer);
-    }
-
-    /**
-     * Import tax rates from TaxJar
+     * Execute observer action during cron job.
      *
      * @return void
      * @throws LocalizedException
      */
-    private function _importRates()
+    public function cron(): void
     {
-        $isDebugMode = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_DEBUG);
-
-        if ($isDebugMode) {
-            $this->messageManager->addNoticeMessage(
-                __('Debug mode enabled. Backup tax rates have not been altered.')
-            );
-            return;
-        }
-
-        if (! $this->isZipCodeValid()) {
-            // @codingStandardsIgnoreStart
-            throw new LocalizedException(
-                __('Please check that your zip code is a valid US zip code in Shipping Settings.')
-            );
-            // @codingStandardsIgnoreEnd
-        }
-
-        if (! count($this->productTaxClasses) || ! count($this->customerTaxClasses)) {
-            // @codingStandardsIgnoreStart
-            throw new LocalizedException(
-                __('Please select at least one product tax class and one customer tax class to import backup rates from TaxJar.')
-            );
-            // @codingStandardsIgnoreEnd
-        }
-
-        $ratesJson = $this->_getRatesJson();
-
-        $this->shippingClass = $this->scopeConfig->getValue('tax/classes/shipping_tax_class');
-
-        if ($this->shippingClass && in_array($this->shippingClass, $this->productTaxClasses)) {
-            throw new LocalizedException(
-                __('For backup shipping rates, please use a unique tax class for shipping.')
-            );
-        }
-
-        $this->purgeRates();
-        $this->createRates($ratesJson['rates']);
-
-        $this->_setLastUpdateDate(date('m-d-Y'));
-
-        $this->messageManager->addSuccessMessage(
-            __('TaxJar has added new rates to your database. Thanks for using TaxJar!')
-        );
-
-        $this->eventManager->dispatch('taxjar_salestax_import_rates_after');
-
+        $this->execute(new Observer());
     }
 
     /**
-     * Build asynchronous operation
+     * Schedule bulk operation(s) to remove any existing backup tax rates and store new backup tax rates
+     * from TaxJar API client response.
      *
-     * @param array $rates
-     * @param int $bulkUuid
+     * @return void
+     * @throws LocalizedException
+     */
+    private function importRates(): void
+    {
+        if ($this->debugEnabled()) {
+            $this->messageManager->addNoticeMessage(
+                __('Debug mode enabled. Backup tax rates have not been altered.')
+            );
+
+            return;
+        }
+
+        $rates = $this->getRatesJson();
+        $date = $this->getDate();
+
+        $this->validateZipCode()
+            ->validateTaxClasses()
+            ->validateShippingClass()
+            ->purgeExistingRates()
+            ->createRates($rates)
+            ->setLastUpdate($date);
+
+        $this->messageManager->addSuccessMessage(
+            __('TaxJar has successfully queued backup tax rate sync. Thanks for using TaxJar!')
+        );
+
+        $this->eventManager->dispatch('taxjar_salestax_import_rates_after');
+    }
+
+    /**
+     * Return boolean value whether TaxJar extension's Backup Rates feature is enabled.
      *
+     * @return bool
+     */
+    private function backupRatesEnabled(): bool
+    {
+        return (bool) $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_BACKUP);
+    }
+
+    /**
+     * Return boolean value whether TaxJar extension's debug mode is enabled.
+     *
+     * @return bool
+     */
+    private function debugEnabled(): bool
+    {
+        return (bool) $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_DEBUG);
+    }
+
+    /**
+     * Create asynchronous operation for provided topic with an initial status of "open".
+     *
+     * @param string $bulkUuid Unique identifier for the current topic instance
+     * @param string $topic Message queue topic
+     * @param array $payload Topic data for serialization
      * @return OperationInterface
      */
-    private function makeOperation($rates, $bulkUuid, $topic): OperationInterface
+    private function createOperation(string $bulkUuid, string $topic, array $payload): OperationInterface
     {
-        $dataToEncode = [
-            'rates' => $rates,
-            'product_tax_classes' => $this->productTaxClasses,
-            'customer_tax_classes' => $this->customerTaxClasses,
-            'shipping_class' => $this->shippingClass,
-        ];
-
         $data = [
             'data' => [
                 'bulk_uuid' => $bulkUuid,
                 'topic_name' => $topic,
-                'serialized_data' => $this->serializer->serialize($dataToEncode),
-                'status' => \Magento\Framework\Bulk\OperationInterface::STATUS_TYPE_OPEN,
+                'serialized_data' => $this->serializer->serialize($payload),
+                'status' => OperationInterface::STATUS_TYPE_OPEN,
             ]
         ];
 
@@ -346,126 +394,238 @@ class ImportRates implements ObserverInterface
     }
 
     /**
-     * @param string $bulkUuid
-     * @param array $operations
-     * @param string $bulkDescription
-     * @throws LocalizedException
+     * Retrieve chunked payload for topic `taxjar.backup_rates.delete` with given array of rate IDs.
+     *
+     * @param array $rates List of `tax_calculation_rates` IDs
+     * @return array[]
      */
-    private function schedule($bulkUuid, $operations, $bulkDescription): void
+    private function getDeleteRatesPayload(array $rates): array
     {
-        $userId = $this->userContext->getUserId();
-        $result = $this->bulkManagement->scheduleBulk($bulkUuid, $operations, $bulkDescription, $userId);
+        $data = [];
 
-        if (! $result) {
-            throw new LocalizedException(
-                __('Something went wrong while processing the request.')
-            );
+        foreach (array_chunk($rates, self::BATCH_SIZE) as $ratesChunk) {
+            $data[] = [
+                'rates' => $ratesChunk,
+            ];
         }
+
+        return $data;
     }
 
     /**
-     * Purge existing rule calculations and rates
+     * Retrieve chunked payload for topic `taxjar.backup_rates.create` with given array of rate IDs.
      *
-     * @return void
+     * @param array $rates List of `tax_calculation_rates` IDs
+     * @return array[]
+     */
+    private function getCreateRatesPayload(array $rates): array
+    {
+        $data = [];
+
+        foreach (array_chunk($rates, self::BATCH_SIZE) as $ratesChunk) {
+            $data[] = [
+                'rates' => $ratesChunk,
+                'product_tax_classes' => $this->productTaxClasses,
+                'customer_tax_classes' => $this->customerTaxClasses,
+                'shipping_tax_class' => $this->shippingTaxClass,
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Schedule asynchronous operation(s) with the given UUID and description.
+     *
+     * @param string $uuid Unique identifier for the current topic instance
+     * @param array|Operation[] $operations List of operations to be scheduled
+     * @param string $description User-friendly description of the bulk operation
+     * @return bool
+     */
+    private function schedule(string $uuid, array $operations, string $description): bool
+    {
+        $userId = $this->userContext->getUserId();
+        return $this->bulkManagement->scheduleBulk($uuid, $operations, $description, $userId);
+    }
+
+    /**
+     * Delete existing TaxJar `tax_calculation_rules` entry and related `tax_calculations` entries, and schedule
+     * bulk operation(s) to asynchronously delete remaining `tax_calculation_rates` entries.
+     *
+     * @return self
      * @throws LocalizedException
      */
-    private function purgeRates()
+    private function purgeExistingRates(): self
     {
         $rateModel = $this->rateFactory->create();
         $rates = $rateModel->getExistingRates();
 
-        if ($rule = $rateModel->getRule()) {
-            $rule->getCalculationModel()->deleteByRuleId($rule->getId());
-            $rule->delete();
-        }
+        $rule = $rateModel->getRule();
+        $rule->getCalculationModel()->deleteByRuleId($rule->getId());
+        $rule->delete();
 
         if (! empty($rates)) {
-            $chunkedRatesForDeletion = array_chunk($rates, $this->batchSize);
-            $bulkUuid = $this->identityService->generateId();
+            $payload = $this->getDeleteRatesPayload($rates);
 
-            $operations = [];
-            foreach ($chunkedRatesForDeletion as $rateDeleteChunk) {
-                $operations[] = $this->makeOperation(
-                    $rateDeleteChunk,
-                    $bulkUuid,
-                    TaxjarConfig::TAXJAR_TOPIC_DELETE_RATES
-                );
-            }
-
-            if (! empty($operations)) {
-                $bulkDescription = __('Delete %1 TaxJar backup tax rates.', $this->batchSize);
-                $this->schedule($bulkUuid, $operations, $bulkDescription);
-            }
-        }
-    }
-
-    private function createRates(array $rates)
-    {
-        $rateChunks = array_chunk($rates, $this->batchSize);
-        $bulkUuid = $this->identityService->generateId();
-
-        $operations = [];
-        foreach ($rateChunks as $rateChunk) {
-            $operations[] = $this->makeOperation(
-                $rateChunk,
-                $bulkUuid,
-                TaxjarConfig::TAXJAR_TOPIC_CREATE_RATES
+            $this->scheduleBulkOperation(
+                $payload,
+                TaxjarConfig::TAXJAR_TOPIC_DELETE_RATES,
+                'Delete TaxJar backup tax rates.'
             );
         }
 
-        if (!empty($operations)) {
-            $bulkDescription = __('Create ' . $this->batchSize . ' TaxJar backup tax rates.');
-            $this->schedule($bulkUuid, $operations, $bulkDescription);
+        return $this;
+    }
+
+    /**
+     * Schedule bulk operation(s) to asynchronously create `tax_calculation_rates` entries and relate rates to new
+     * TaxJar `tax_calculation_rules` entry by way of `tax_calculations` entries.
+     *
+     * @param array $rates List of rates to create
+     * @return ImportRates
+     * @throws LocalizedException
+     */
+    private function createRates(array $rates): self
+    {
+        $payload = $this->getCreateRatesPayload($rates);
+
+        $this->scheduleBulkOperation(
+            $payload,
+            TaxjarConfig::TAXJAR_TOPIC_CREATE_RATES,
+            'Create TaxJar backup tax rates.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Creates and schedules bulk operation(s) prescribed by input topic.
+     *
+     * @param array[] $data List of operation payloads
+     * @param string $topic Message queue topic name
+     * @param string $description User-friendly description of the bulk operation
+     * @throws LocalizedException
+     */
+    private function scheduleBulkOperation(array $data, string $topic, string $description): void
+    {
+        $operations = [];
+        $bulkUuid = $this->identityService->generateId();
+
+        foreach ($data as $datum) {
+            $operations[] = $this->createOperation($bulkUuid, $topic, $datum);
+        }
+
+        if (! empty($operations)) {
+            $result = $this->schedule($bulkUuid, $operations, $description);
+
+            if (! $result) {
+                throw new LocalizedException(
+                    __('Something went wrong while processing the request.')
+                );
+            }
         }
     }
 
     /**
-     * Get TaxJar backup rates
+     * Retrieve TaxJar backup rates from client response.
      *
      * @return array
      */
-    private function _getRatesJson()
+    private function getRatesJson(): array
     {
-        // @codingStandardsIgnoreStart
-        $ratesJson = $this->client->getResource(
-            'rates',
-            [
-                '403' => __('Your last backup rate sync from TaxJar was too recent. Please wait at least 5 minutes and try again.')
-            ]
-        );
-        // @codingStandardsIgnoreEnd
-        return $ratesJson;
+        $rates = $this->client->getResource('rates', [
+            '403' => __(
+                'Your last backup rate sync from TaxJar was too recent. Please wait at least 5 minutes and try again.'
+            )
+        ]);
+
+        return $rates['rates'];
     }
 
     /**
-     * Set the last updated date
+     * Set the last updated value in framework configuration.
      *
-     * @param string $date
+     * @param string|null $value Value to set as last update; Either a date in "m-d-Y" or NULL
      * @return void
      */
-    private function _setLastUpdateDate($date)
+    private function setLastUpdate(?string $value): void
     {
-        $this->resourceConfig->saveConfig(TaxjarConfig::TAXJAR_LAST_UPDATE, $date, 'default', 0);
+        $this->resourceConfig->saveConfig(TaxjarConfig::TAXJAR_LAST_UPDATE, $value, 'default');
     }
 
     /**
-     * Checks whether the zip code is valid to import rates
+     * Throw exception when zip code is determined to be invalid.
+     *
+     * A valid shipping address zip code is required for backup rate accuracy.
+     *
+     * @throws LocalizedException
+     */
+    private function validateZipCode(): self
+    {
+        if ($this->zipCodeIsValid()) {
+            return $this;
+        }
+
+        throw new LocalizedException(
+            __('Please check that your zip code is a valid US zip code in Shipping Settings.')
+        );
+    }
+
+    /**
+     * Return boolean representing whether the zip code is valid.
+     *
+     * A valid zip code for US is determined by format Zip 5 or Zip 5+4 while all other regions only validate the
+     * existence of a value for the parameter.
      *
      * @return bool
      */
-    private function isZipCodeValid() {
-        $is_valid = false;
-
+    private function zipCodeIsValid(): bool
+    {
         if ($this->backupRateOriginAddress->isScopeCountryCodeUS()) {
-            if ($this->storeZip && preg_match("/(\d{5}-\d{4})|(\d{5})/", $this->storeZip)){
-                $is_valid = true;
-            }
-        } else {
-            if ($this->storeZip) {
-                $is_valid = true;
-            }
+            return $this->zipCode && preg_match("/^\d{5}(-?\d{4})?$/", $this->zipCode);
         }
 
-       return $is_valid;
+        return (bool) $this->zipCode;
+    }
+
+    /**
+     * Throw exception when product tax or customer tax classes are not selected.
+     *
+     * At least one product tax class and one customer tax class are required to properly store backup rates.
+     *
+     * @return self
+     * @throws LocalizedException
+     */
+    private function validateTaxClasses(): self
+    {
+        if (! empty($this->productTaxClasses) && ! empty($this->customerTaxClasses)) {
+            return $this;
+        }
+
+        throw new LocalizedException(
+            __(
+                'Please select at least one product tax class and one customer tax class to ' .
+                'configure backup rates from TaxJar.'
+            )
+        );
+    }
+
+    /**
+     * Throws exception if selected shipping tax class exists in product tax classes array.
+     *
+     * Shipping tax class must be unique from product tax classes.
+     *
+     * @return self
+     * @throws LocalizedException
+     */
+    private function validateShippingClass(): self
+    {
+        if ($this->shippingTaxClass && in_array($this->shippingTaxClass, $this->productTaxClasses)) {
+            throw new LocalizedException(
+                __('For backup shipping rates, please use a unique tax class for shipping.')
+            );
+        }
+
+        return $this;
     }
 }

--- a/Test/Unit/Observer/ImportRatesTest.php
+++ b/Test/Unit/Observer/ImportRatesTest.php
@@ -1,0 +1,1085 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Test\Unit\Observer;
+
+use Magento\AsynchronousOperations\Api\Data\OperationInterfaceFactory;
+use Magento\AsynchronousOperations\Model\Operation;
+use Magento\Authorization\Model\UserContextInterface;
+use Magento\Config\Model\ResourceModel\Config;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Bulk\BulkManagementInterface;
+use Magento\Framework\DataObject\IdentityGeneratorInterface;
+use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Tax\Model\Calculation;
+use Magento\Tax\Model\Calculation\RateRepository;
+use Magento\Tax\Model\Calculation\Rule;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Taxjar\SalesTax\Model\BackupRateOriginAddress;
+use Taxjar\SalesTax\Model\Client;
+use Taxjar\SalesTax\Model\ClientFactory;
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+use Taxjar\SalesTax\Model\Import\Rate;
+use Taxjar\SalesTax\Model\Import\RateFactory;
+use Taxjar\SalesTax\Model\Import\RuleFactory;
+use Taxjar\SalesTax\Observer\ImportRates;
+
+class ImportRatesTest extends TestCase
+{
+    public function testExecuteWithBackupRatesEnabledAndValidApiKeyWhenDebugEnabled(): void
+    {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockMessageManager = $this->createMock(MessageManagerInterface::class);
+        $mockMessageManager->expects($this->once())
+            ->method('addNoticeMessage')
+            ->withAnyParameters();
+
+        $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
+
+        $mockScopeConfigInterface->expects($this->exactly(5))
+            ->method('getValue')
+            ->withConsecutive(
+                [TaxjarConfig::TAXJAR_BACKUP],
+                [TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES],
+                [TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES],
+                ['tax/classes/shipping_tax_class'],
+                [TaxjarConfig::TAXJAR_DEBUG]
+            )->willReturnOnConsecutiveCalls(
+                1,
+                'customer_class_1,customer_class_1',
+                'product_class_1,product_class_2',
+                'shipping_product_tax_class',
+                1
+            );
+
+        $mockResourceConfig = $this->createMock(Config::class);
+
+        $mockClient = $this->createMock(Client::class);
+
+        $mockClientFactory = $this->createMock(ClientFactory::class);
+        $mockClientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockClient);
+
+        $mockRateFactory = $this->createMock(RateFactory::class);
+        $mockRuleFactory = $this->createMock(RuleFactory::class);
+        $mockRateRepository = $this->createMock(RateRepository::class);
+
+        $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
+        $mockTaxjarConfig->expects($this->once())
+            ->method('getApiKey')
+            ->willReturn('valid-api-key');
+
+        $mockBackupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('getShippingZipCode')
+            ->willReturn('99999');
+
+        $mockIdentityGeneratorInterface = $this->createMock(IdentityGeneratorInterface::class);
+        $mockSerializerInterface = $this->createMock(SerializerInterface::class);
+        $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
+        $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
+        $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+
+        $sut = new ImportRates(
+            $mockEventManager,
+            $mockMessageManager,
+            $mockScopeConfigInterface,
+            $mockResourceConfig,
+            $mockClientFactory,
+            $mockRateFactory,
+            $mockRuleFactory,
+            $mockRateRepository,
+            $mockTaxjarConfig,
+            $mockBackupRateOriginAddress,
+            $mockIdentityGeneratorInterface,
+            $mockSerializerInterface,
+            $mockOperationInterfaceFactory,
+            $mockBulkManagementInterface,
+            $mockUserContextInterface
+        );
+
+        $result = $sut->execute(new Observer());
+
+        $this->assertInstanceOf(ImportRates::class, $result);
+    }
+
+    public function testExecuteWithInvalidZipCodeThrowsException(): void
+    {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockMessageManager = $this->createMock(MessageManagerInterface::class);
+
+        $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
+        $mockScopeConfigInterface->expects($this->exactly(5))
+            ->method('getValue')
+            ->withConsecutive(
+                [TaxjarConfig::TAXJAR_BACKUP],
+                [TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES],
+                [TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES],
+                ['tax/classes/shipping_tax_class'],
+                [TaxjarConfig::TAXJAR_DEBUG]
+            )->willReturnOnConsecutiveCalls(
+                1,
+                'customer_class_1,customer_class_1',
+                'product_class_1,product_class_2',
+                'shipping_product_tax_class',
+                0
+            );
+
+        $mockResourceConfig = $this->createMock(Config::class);
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())
+            ->method('getResource')
+            ->with('rates', [
+                Response::HTTP_FORBIDDEN => __(
+                    'Your last backup rate sync from TaxJar was too recent. ' .
+                    'Please wait at least 5 minutes and try again.'
+                ),
+            ])
+            ->willReturn([
+                'rates' => [
+                    'some',
+                    'list',
+                    'of',
+                    'values',
+                ],
+            ]);
+
+        $mockClientFactory = $this->createMock(ClientFactory::class);
+        $mockClientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockClient);
+
+        $mockRateFactory = $this->createMock(RateFactory::class);
+        $mockRuleFactory = $this->createMock(RuleFactory::class);
+        $mockRateRepository = $this->createMock(RateRepository::class);
+
+        $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
+        $mockTaxjarConfig->expects($this->once())
+            ->method('getApiKey')
+            ->willReturn('valid-api-key');
+
+        $mockBackupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('getShippingZipCode')
+            ->willReturn('1234567');
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('isScopeCountryCodeUS')
+            ->willReturn(true);
+
+        $mockIdentityGeneratorInterface = $this->createMock(IdentityGeneratorInterface::class);
+        $mockSerializerInterface = $this->createMock(SerializerInterface::class);
+        $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
+        $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
+        $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+
+        $sut = new ImportRates(
+            $mockEventManager,
+            $mockMessageManager,
+            $mockScopeConfigInterface,
+            $mockResourceConfig,
+            $mockClientFactory,
+            $mockRateFactory,
+            $mockRuleFactory,
+            $mockRateRepository,
+            $mockTaxjarConfig,
+            $mockBackupRateOriginAddress,
+            $mockIdentityGeneratorInterface,
+            $mockSerializerInterface,
+            $mockOperationInterfaceFactory,
+            $mockBulkManagementInterface,
+            $mockUserContextInterface
+        );
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Please check that your zip code is a valid US zip code in Shipping Settings.');
+
+        $sut->execute(new Observer());
+    }
+
+    public function testExecuteWithInvalidTaxClassesThrowsException(): void
+    {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockMessageManager = $this->createMock(MessageManagerInterface::class);
+
+        $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
+        $mockScopeConfigInterface->expects($this->exactly(5))
+            ->method('getValue')
+            ->withConsecutive(
+                [TaxjarConfig::TAXJAR_BACKUP],
+                [TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES],
+                [TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES],
+                ['tax/classes/shipping_tax_class'],
+                [TaxjarConfig::TAXJAR_DEBUG]
+            )->willReturnOnConsecutiveCalls(
+                1,
+                '',
+                '',
+                'shipping_product_tax_class',
+                0
+            );
+
+        $mockResourceConfig = $this->createMock(Config::class);
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())
+            ->method('getResource')
+            ->with('rates', [
+                Response::HTTP_FORBIDDEN => __(
+                    'Your last backup rate sync from TaxJar was too recent. ' .
+                    'Please wait at least 5 minutes and try again.'
+                ),
+            ])
+            ->willReturn([
+                'rates' => [
+                    'some',
+                    'list',
+                    'of',
+                    'values',
+                ],
+            ]);
+
+        $mockClientFactory = $this->createMock(ClientFactory::class);
+        $mockClientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockClient);
+
+        $mockRateFactory = $this->createMock(RateFactory::class);
+        $mockRuleFactory = $this->createMock(RuleFactory::class);
+        $mockRateRepository = $this->createMock(RateRepository::class);
+
+        $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
+        $mockTaxjarConfig->expects($this->once())
+            ->method('getApiKey')
+            ->willReturn('valid-api-key');
+
+        $mockBackupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('getShippingZipCode')
+            ->willReturn('99999');
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('isScopeCountryCodeUS')
+            ->willReturn(true);
+
+        $mockIdentityGeneratorInterface = $this->createMock(IdentityGeneratorInterface::class);
+        $mockSerializerInterface = $this->createMock(SerializerInterface::class);
+        $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
+        $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
+        $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+
+        $sut = new ImportRates(
+            $mockEventManager,
+            $mockMessageManager,
+            $mockScopeConfigInterface,
+            $mockResourceConfig,
+            $mockClientFactory,
+            $mockRateFactory,
+            $mockRuleFactory,
+            $mockRateRepository,
+            $mockTaxjarConfig,
+            $mockBackupRateOriginAddress,
+            $mockIdentityGeneratorInterface,
+            $mockSerializerInterface,
+            $mockOperationInterfaceFactory,
+            $mockBulkManagementInterface,
+            $mockUserContextInterface
+        );
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage(
+            'Please select at least one product tax class and one customer tax class to ' .
+            'configure backup rates from TaxJar.'
+        );
+
+        $sut->execute(new Observer());
+    }
+
+    public function testExecuteWithInvalidShippingTaxClassThrowsException(): void
+    {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockMessageManager = $this->createMock(MessageManagerInterface::class);
+
+        $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
+        $mockScopeConfigInterface->expects($this->exactly(5))
+            ->method('getValue')
+            ->withConsecutive(
+                [TaxjarConfig::TAXJAR_BACKUP],
+                [TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES],
+                [TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES],
+                ['tax/classes/shipping_tax_class'],
+                [TaxjarConfig::TAXJAR_DEBUG]
+            )->willReturnOnConsecutiveCalls(
+                1,
+                'customer_class_1,customer_class_1',
+                'product_class_1,product_class_2',
+                'product_class_1',
+                0
+            );
+
+        $mockResourceConfig = $this->createMock(Config::class);
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())
+            ->method('getResource')
+            ->with('rates', [
+                Response::HTTP_FORBIDDEN => __(
+                    'Your last backup rate sync from TaxJar was too recent. ' .
+                    'Please wait at least 5 minutes and try again.'
+                ),
+            ])
+            ->willReturn([
+                'rates' => [
+                    'some',
+                    'list',
+                    'of',
+                    'values',
+                ],
+            ]);
+
+        $mockClientFactory = $this->createMock(ClientFactory::class);
+        $mockClientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockClient);
+
+        $mockRateFactory = $this->createMock(RateFactory::class);
+        $mockRuleFactory = $this->createMock(RuleFactory::class);
+        $mockRateRepository = $this->createMock(RateRepository::class);
+
+        $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
+        $mockTaxjarConfig->expects($this->once())
+            ->method('getApiKey')
+            ->willReturn('valid-api-key');
+
+        $mockBackupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('getShippingZipCode')
+            ->willReturn('99999');
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('isScopeCountryCodeUS')
+            ->willReturn(true);
+
+        $mockIdentityGeneratorInterface = $this->createMock(IdentityGeneratorInterface::class);
+        $mockSerializerInterface = $this->createMock(SerializerInterface::class);
+        $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
+        $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
+        $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+
+        $sut = new ImportRates(
+            $mockEventManager,
+            $mockMessageManager,
+            $mockScopeConfigInterface,
+            $mockResourceConfig,
+            $mockClientFactory,
+            $mockRateFactory,
+            $mockRuleFactory,
+            $mockRateRepository,
+            $mockTaxjarConfig,
+            $mockBackupRateOriginAddress,
+            $mockIdentityGeneratorInterface,
+            $mockSerializerInterface,
+            $mockOperationInterfaceFactory,
+            $mockBulkManagementInterface,
+            $mockUserContextInterface
+        );
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage(
+            'For backup shipping rates, please use a unique tax class for shipping.'
+        );
+
+        $sut->execute(new Observer());
+    }
+
+    public function testExecuteThrowsExceptionWhenScheduleBulkOperationFails(): void
+    {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockMessageManager = $this->createMock(MessageManagerInterface::class);
+        $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
+        $mockScopeConfigInterface->expects($this->exactly(5))
+            ->method('getValue')
+            ->withConsecutive(
+                [TaxjarConfig::TAXJAR_BACKUP],
+                [TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES],
+                [TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES],
+                ['tax/classes/shipping_tax_class'],
+                [TaxjarConfig::TAXJAR_DEBUG]
+            )->willReturnOnConsecutiveCalls(
+                1,
+                'customer_class_1,customer_class_1',
+                'product_class_1,product_class_2',
+                'shipping_class_1',
+                0
+            );
+
+        $mockResourceConfig = $this->createMock(Config::class);
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())
+            ->method('getResource')
+            ->with('rates', [
+                Response::HTTP_FORBIDDEN => __(
+                    'Your last backup rate sync from TaxJar was too recent. ' .
+                    'Please wait at least 5 minutes and try again.'
+                ),
+            ])
+            ->willReturn([
+                'rates' => [
+                    'some',
+                    'list',
+                    'of',
+                    'values',
+                ],
+            ]);
+
+        $mockClientFactory = $this->createMock(ClientFactory::class);
+        $mockClientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockClient);
+
+        $mockCalculation = $this->createMock(Calculation::class);
+        $mockCalculation->expects($this->once())
+            ->method('deleteByRuleId')
+            ->with(42)
+            ->willReturnSelf();
+
+        $mockRule = $this->createMock(Rule::class);
+        $mockRule->expects($this->once())
+            ->method('getId')
+            ->willReturn(42);
+        $mockRule->expects($this->once())
+            ->method('getCalculationModel')
+            ->willReturn($mockCalculation);
+        $mockRule->expects($this->once())
+            ->method('delete');
+
+        $mockRateModel = $this->createMock(Rate::class);
+        $mockRateModel->expects($this->once())
+            ->method('getExistingRates')
+            ->willReturn(['old_rate_1', 'old_rate_2']);
+        $mockRateModel->expects($this->once())
+            ->method('getRule')
+            ->willReturn($mockRule);
+
+        $mockRateFactory = $this->createMock(RateFactory::class);
+        $mockRateFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockRateModel);
+
+        $mockRuleFactory = $this->createMock(RuleFactory::class);
+        $mockRateRepository = $this->createMock(RateRepository::class);
+
+        $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
+        $mockTaxjarConfig->expects($this->once())
+            ->method('getApiKey')
+            ->willReturn('valid-api-key');
+
+        $mockBackupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('getShippingZipCode')
+            ->willReturn('99999');
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('isScopeCountryCodeUS')
+            ->willReturn(false);
+
+        $mockIdentityGeneratorInterface = $this->createMock(IdentityGeneratorInterface::class);
+        $mockIdentityGeneratorInterface->expects($this->once())
+            ->method('generateId')
+            ->willReturn('unique-identifier');
+
+        $mockSerializerInterface = $this->createMock(SerializerInterface::class);
+        $mockSerializerInterface->expects($this->once())
+            ->method('serialize')
+            ->willReturn(json_encode(['data' => 'payload']));
+
+        $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
+        $mockOperationInterfaceFactory->expects($this->once())
+            ->method('create')
+            ->withAnyParameters()
+            ->willReturn($this->createMock(Operation::class));
+
+        $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
+        $mockBulkManagementInterface->expects($this->once())
+            ->method('scheduleBulk')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+        $mockUserContextInterface->expects($this->once())
+            ->method('getUserId')
+            ->willReturn('9999999');
+
+        $sut = new ImportRates(
+            $mockEventManager,
+            $mockMessageManager,
+            $mockScopeConfigInterface,
+            $mockResourceConfig,
+            $mockClientFactory,
+            $mockRateFactory,
+            $mockRuleFactory,
+            $mockRateRepository,
+            $mockTaxjarConfig,
+            $mockBackupRateOriginAddress,
+            $mockIdentityGeneratorInterface,
+            $mockSerializerInterface,
+            $mockOperationInterfaceFactory,
+            $mockBulkManagementInterface,
+            $mockUserContextInterface
+        );
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage(
+            'Something went wrong while processing the request.'
+        );
+
+        $sut->execute(new Observer());
+    }
+
+    public function testExecuteWithExistingRates()
+    {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockEventManager->expects($this->exactly(2))
+            ->method('dispatch')
+            ->withConsecutive(
+                ['taxjar_salestax_import_rates_after'],
+                ['adminhtml_cache_flush_all']
+            );
+
+        $mockMessageManager = $this->createMock(MessageManagerInterface::class);
+        $mockMessageManager->expects($this->once())->method('addSuccessMessage');
+
+        $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
+        $mockScopeConfigInterface->expects($this->exactly(5))
+            ->method('getValue')
+            ->withConsecutive(
+                [TaxjarConfig::TAXJAR_BACKUP],
+                [TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES],
+                [TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES],
+                ['tax/classes/shipping_tax_class'],
+                [TaxjarConfig::TAXJAR_DEBUG]
+            )->willReturnOnConsecutiveCalls(
+                1,
+                'customer_class_1,customer_class_1',
+                'product_class_1,product_class_2',
+                'shipping_class_1',
+                0
+            );
+
+        $mockResourceConfig = $this->createMock(Config::class);
+        $mockResourceConfig->expects($this->once())->method('saveConfig');
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())
+            ->method('getResource')
+            ->with('rates', [
+                Response::HTTP_FORBIDDEN => __(
+                    'Your last backup rate sync from TaxJar was too recent. ' .
+                    'Please wait at least 5 minutes and try again.'
+                ),
+            ])
+            ->willReturn([
+                'rates' => [
+                    'some',
+                    'list',
+                    'of',
+                    'values',
+                ],
+            ]);
+
+        $mockClientFactory = $this->createMock(ClientFactory::class);
+        $mockClientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockClient);
+
+        $mockCalculation = $this->createMock(Calculation::class);
+        $mockCalculation->expects($this->once())
+            ->method('deleteByRuleId')
+            ->with(42)
+            ->willReturnSelf();
+
+        $mockRule = $this->createMock(Rule::class);
+        $mockRule->expects($this->once())
+            ->method('getId')
+            ->willReturn(42);
+        $mockRule->expects($this->once())
+            ->method('getCalculationModel')
+            ->willReturn($mockCalculation);
+        $mockRule->expects($this->once())
+            ->method('delete');
+
+        $mockRateModel = $this->createMock(Rate::class);
+        $mockRateModel->expects($this->once())
+            ->method('getExistingRates')
+            ->willReturn(['old_rate_1', 'old_rate_2']);
+        $mockRateModel->expects($this->once())
+            ->method('getRule')
+            ->willReturn($mockRule);
+
+        $mockRateFactory = $this->createMock(RateFactory::class);
+        $mockRateFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockRateModel);
+
+        $mockRuleFactory = $this->createMock(RuleFactory::class);
+        $mockRateRepository = $this->createMock(RateRepository::class);
+
+        $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
+        $mockTaxjarConfig->expects($this->once())
+            ->method('getApiKey')
+            ->willReturn('valid-api-key');
+
+        $mockBackupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('getShippingZipCode')
+            ->willReturn('99999');
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('isScopeCountryCodeUS')
+            ->willReturn(true);
+
+        $mockIdentityGeneratorInterface = $this->createMock(IdentityGeneratorInterface::class);
+        $mockIdentityGeneratorInterface->expects($this->exactly(2))
+            ->method('generateId')
+            ->willReturn('unique-identifier');
+
+        $mockSerializerInterface = $this->createMock(SerializerInterface::class);
+        $mockSerializerInterface->expects($this->exactly(2))
+            ->method('serialize')
+            ->willReturn(json_encode(['data' => 'payload']));
+
+        $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
+        $mockOperationInterfaceFactory->expects($this->exactly(2))
+            ->method('create')
+            ->withAnyParameters()
+            ->willReturn($this->createMock(Operation::class));
+
+        $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
+        $mockBulkManagementInterface->expects($this->exactly(2))
+            ->method('scheduleBulk')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+        $mockUserContextInterface->expects($this->exactly(2))
+            ->method('getUserId')
+            ->willReturn('9999999');
+
+        $sut = new ImportRates(
+            $mockEventManager,
+            $mockMessageManager,
+            $mockScopeConfigInterface,
+            $mockResourceConfig,
+            $mockClientFactory,
+            $mockRateFactory,
+            $mockRuleFactory,
+            $mockRateRepository,
+            $mockTaxjarConfig,
+            $mockBackupRateOriginAddress,
+            $mockIdentityGeneratorInterface,
+            $mockSerializerInterface,
+            $mockOperationInterfaceFactory,
+            $mockBulkManagementInterface,
+            $mockUserContextInterface
+        );
+
+        $result = $sut->execute(new Observer());
+
+        $this->assertInstanceOf(ImportRates::class, $result);
+    }
+
+    public function testExecuteWithoutExistingRates()
+    {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockEventManager->expects($this->exactly(2))
+            ->method('dispatch')
+            ->withConsecutive(
+                ['taxjar_salestax_import_rates_after'],
+                ['adminhtml_cache_flush_all']
+            );
+
+        $mockMessageManager = $this->createMock(MessageManagerInterface::class);
+        $mockMessageManager->expects($this->once())->method('addSuccessMessage');
+
+        $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
+        $mockScopeConfigInterface->expects($this->exactly(5))
+            ->method('getValue')
+            ->withConsecutive(
+                [TaxjarConfig::TAXJAR_BACKUP],
+                [TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES],
+                [TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES],
+                ['tax/classes/shipping_tax_class'],
+                [TaxjarConfig::TAXJAR_DEBUG]
+            )->willReturnOnConsecutiveCalls(
+                1,
+                'customer_class_1,customer_class_1',
+                'product_class_1,product_class_2',
+                'shipping_class_1',
+                0
+            );
+
+        $mockResourceConfig = $this->createMock(Config::class);
+        $mockResourceConfig->expects($this->once())->method('saveConfig');
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())
+            ->method('getResource')
+            ->with('rates', [
+                Response::HTTP_FORBIDDEN => __(
+                    'Your last backup rate sync from TaxJar was too recent. ' .
+                    'Please wait at least 5 minutes and try again.'
+                ),
+            ])
+            ->willReturn([
+                'rates' => [
+                    'some',
+                    'list',
+                    'of',
+                    'values',
+                ],
+            ]);
+
+        $mockClientFactory = $this->createMock(ClientFactory::class);
+        $mockClientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockClient);
+
+        $mockCalculation = $this->createMock(Calculation::class);
+        $mockCalculation->expects($this->once())
+            ->method('deleteByRuleId')
+            ->with(42)
+            ->willReturnSelf();
+
+        $mockRule = $this->createMock(Rule::class);
+        $mockRule->expects($this->once())
+            ->method('getId')
+            ->willReturn(42);
+        $mockRule->expects($this->once())
+            ->method('getCalculationModel')
+            ->willReturn($mockCalculation);
+        $mockRule->expects($this->once())
+            ->method('delete');
+
+        $mockRateModel = $this->createMock(Rate::class);
+        $mockRateModel->expects($this->once())
+            ->method('getExistingRates')
+            ->willReturn([]);
+        $mockRateModel->expects($this->once())
+            ->method('getRule')
+            ->willReturn($mockRule);
+
+        $mockRateFactory = $this->createMock(RateFactory::class);
+        $mockRateFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockRateModel);
+
+        $mockRuleFactory = $this->createMock(RuleFactory::class);
+        $mockRateRepository = $this->createMock(RateRepository::class);
+
+        $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
+        $mockTaxjarConfig->expects($this->once())
+            ->method('getApiKey')
+            ->willReturn('valid-api-key');
+
+        $mockBackupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('getShippingZipCode')
+            ->willReturn('99999');
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('isScopeCountryCodeUS')
+            ->willReturn(true);
+
+        $mockIdentityGeneratorInterface = $this->createMock(IdentityGeneratorInterface::class);
+        $mockIdentityGeneratorInterface->expects($this->once())
+            ->method('generateId')
+            ->willReturn('unique-identifier');
+
+        $mockSerializerInterface = $this->createMock(SerializerInterface::class);
+        $mockSerializerInterface->expects($this->once())
+            ->method('serialize')
+            ->willReturn(json_encode(['data' => 'payload']));
+
+        $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
+        $mockOperationInterfaceFactory->expects($this->once())
+            ->method('create')
+            ->withAnyParameters()
+            ->willReturn($this->createMock(Operation::class));
+
+        $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
+        $mockBulkManagementInterface->expects($this->once())
+            ->method('scheduleBulk')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+        $mockUserContextInterface->expects($this->once())
+            ->method('getUserId')
+            ->willReturn('9999999');
+
+        $sut = new ImportRates(
+            $mockEventManager,
+            $mockMessageManager,
+            $mockScopeConfigInterface,
+            $mockResourceConfig,
+            $mockClientFactory,
+            $mockRateFactory,
+            $mockRuleFactory,
+            $mockRateRepository,
+            $mockTaxjarConfig,
+            $mockBackupRateOriginAddress,
+            $mockIdentityGeneratorInterface,
+            $mockSerializerInterface,
+            $mockOperationInterfaceFactory,
+            $mockBulkManagementInterface,
+            $mockUserContextInterface
+        );
+
+        $result = $sut->execute(new Observer());
+
+        $this->assertInstanceOf(ImportRates::class, $result);
+    }
+
+
+
+    public function testCron()
+    {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockEventManager->expects($this->exactly(2))
+            ->method('dispatch')
+            ->withConsecutive(
+                ['taxjar_salestax_import_rates_after'],
+                ['adminhtml_cache_flush_all']
+            );
+
+        $mockMessageManager = $this->createMock(MessageManagerInterface::class);
+        $mockMessageManager->expects($this->once())->method('addSuccessMessage');
+
+        $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
+        $mockScopeConfigInterface->expects($this->exactly(5))
+            ->method('getValue')
+            ->withConsecutive(
+                [TaxjarConfig::TAXJAR_BACKUP],
+                [TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES],
+                [TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES],
+                ['tax/classes/shipping_tax_class'],
+                [TaxjarConfig::TAXJAR_DEBUG]
+            )->willReturnOnConsecutiveCalls(
+                1,
+                'customer_class_1,customer_class_1',
+                'product_class_1,product_class_2',
+                'shipping_class_1',
+                0
+            );
+
+        $mockResourceConfig = $this->createMock(Config::class);
+        $mockResourceConfig->expects($this->once())->method('saveConfig');
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())
+            ->method('getResource')
+            ->with('rates', [
+                Response::HTTP_FORBIDDEN => __(
+                    'Your last backup rate sync from TaxJar was too recent. ' .
+                    'Please wait at least 5 minutes and try again.'
+                ),
+            ])
+            ->willReturn([
+                'rates' => [
+                    'some',
+                    'list',
+                    'of',
+                    'values',
+                ],
+            ]);
+
+        $mockClientFactory = $this->createMock(ClientFactory::class);
+        $mockClientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockClient);
+
+        $mockCalculation = $this->createMock(Calculation::class);
+        $mockCalculation->expects($this->once())
+            ->method('deleteByRuleId')
+            ->with(42)
+            ->willReturnSelf();
+
+        $mockRule = $this->createMock(Rule::class);
+        $mockRule->expects($this->once())
+            ->method('getId')
+            ->willReturn(42);
+        $mockRule->expects($this->once())
+            ->method('getCalculationModel')
+            ->willReturn($mockCalculation);
+        $mockRule->expects($this->once())
+            ->method('delete');
+
+        $mockRateModel = $this->createMock(Rate::class);
+        $mockRateModel->expects($this->once())
+            ->method('getExistingRates')
+            ->willReturn(['old_rate_1', 'old_rate_2']);
+        $mockRateModel->expects($this->once())
+            ->method('getRule')
+            ->willReturn($mockRule);
+
+        $mockRateFactory = $this->createMock(RateFactory::class);
+        $mockRateFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockRateModel);
+
+        $mockRuleFactory = $this->createMock(RuleFactory::class);
+        $mockRateRepository = $this->createMock(RateRepository::class);
+
+        $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
+        $mockTaxjarConfig->expects($this->once())
+            ->method('getApiKey')
+            ->willReturn('valid-api-key');
+
+        $mockBackupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('getShippingZipCode')
+            ->willReturn('99999');
+        $mockBackupRateOriginAddress->expects($this->once())
+            ->method('isScopeCountryCodeUS')
+            ->willReturn(true);
+
+        $mockIdentityGeneratorInterface = $this->createMock(IdentityGeneratorInterface::class);
+        $mockIdentityGeneratorInterface->expects($this->exactly(2))
+            ->method('generateId')
+            ->willReturn('unique-identifier');
+
+        $mockSerializerInterface = $this->createMock(SerializerInterface::class);
+        $mockSerializerInterface->expects($this->exactly(2))
+            ->method('serialize')
+            ->willReturn(json_encode(['data' => 'payload']));
+
+        $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
+        $mockOperationInterfaceFactory->expects($this->exactly(2))
+            ->method('create')
+            ->withAnyParameters()
+            ->willReturn($this->createMock(Operation::class));
+
+        $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
+        $mockBulkManagementInterface->expects($this->exactly(2))
+            ->method('scheduleBulk')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+        $mockUserContextInterface->expects($this->exactly(2))
+            ->method('getUserId')
+            ->willReturn('9999999');
+
+        $sut = new ImportRates(
+            $mockEventManager,
+            $mockMessageManager,
+            $mockScopeConfigInterface,
+            $mockResourceConfig,
+            $mockClientFactory,
+            $mockRateFactory,
+            $mockRuleFactory,
+            $mockRateRepository,
+            $mockTaxjarConfig,
+            $mockBackupRateOriginAddress,
+            $mockIdentityGeneratorInterface,
+            $mockSerializerInterface,
+            $mockOperationInterfaceFactory,
+            $mockBulkManagementInterface,
+            $mockUserContextInterface
+        );
+
+        $sut->cron();
+    }
+
+    public function testExecuteWithoutBackupRatesEnabled()
+    {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockEventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('adminhtml_cache_flush_all');
+
+        $mockMessageManager = $this->createMock(MessageManagerInterface::class);
+        $mockMessageManager->expects($this->once())
+            ->method('addNoticeMessage')
+            ->with(__('Backup rates imported by TaxJar have been removed.'));
+
+        $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
+        $mockScopeConfigInterface->expects($this->exactly(2))
+            ->method('getValue')
+            ->withConsecutive(
+                [TaxjarConfig::TAXJAR_BACKUP],
+                [TaxjarConfig::TAXJAR_STATES]
+            )->willReturnOnConsecutiveCalls(
+                0,
+                json_encode(['state_1' => 'some_rate'])
+            );
+
+        $mockResourceConfig = $this->createMock(Config::class);
+        $mockResourceConfig->expects($this->exactly(2))->method('saveConfig');
+
+        $mockClientFactory = $this->createMock(ClientFactory::class);
+
+        $mockCalculation = $this->createMock(Calculation::class);
+        $mockCalculation->expects($this->once())
+            ->method('deleteByRuleId')
+            ->with(42)
+            ->willReturnSelf();
+
+        $mockRule = $this->createMock(Rule::class);
+        $mockRule->expects($this->once())
+            ->method('getId')
+            ->willReturn(42);
+        $mockRule->expects($this->once())
+            ->method('getCalculationModel')
+            ->willReturn($mockCalculation);
+        $mockRule->expects($this->once())
+            ->method('delete');
+
+        $mockRateModel = $this->createMock(Rate::class);
+        $mockRateModel->expects($this->once())
+            ->method('getExistingRates')
+            ->willReturn([]);
+        $mockRateModel->expects($this->once())
+            ->method('getRule')
+            ->willReturn($mockRule);
+
+        $mockRateFactory = $this->createMock(RateFactory::class);
+        $mockRateFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($mockRateModel);
+
+        $mockRuleFactory = $this->createMock(RuleFactory::class);
+        $mockRateRepository = $this->createMock(RateRepository::class);
+        $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
+        $mockBackupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
+        $mockIdentityGeneratorInterface = $this->createMock(IdentityGeneratorInterface::class);
+        $mockSerializerInterface = $this->createMock(SerializerInterface::class);
+        $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
+        $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
+        $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+
+        $sut = new ImportRates(
+            $mockEventManager,
+            $mockMessageManager,
+            $mockScopeConfigInterface,
+            $mockResourceConfig,
+            $mockClientFactory,
+            $mockRateFactory,
+            $mockRuleFactory,
+            $mockRateRepository,
+            $mockTaxjarConfig,
+            $mockBackupRateOriginAddress,
+            $mockIdentityGeneratorInterface,
+            $mockSerializerInterface,
+            $mockOperationInterfaceFactory,
+            $mockBulkManagementInterface,
+            $mockUserContextInterface
+        );
+
+        $result = $sut->execute(new Observer());
+
+        $this->assertInstanceOf(ImportRates::class, $result);
+    }
+}

--- a/etc/communication.xml
+++ b/etc/communication.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
-    <topic name="taxjar.create_backup_rates" request="Magento\AsynchronousOperations\Api\Data\OperationInterface">
-        <handler name="taxjar.create_backup_rates" type="Taxjar\SalesTax\Model\Import\Consumer" method="process" />
+    <topic name="taxjar.backup_rates.delete" request="Magento\AsynchronousOperations\Api\Data\OperationInterface">
+        <handler name="taxjar.backup_rates.delete" type="Taxjar\SalesTax\Model\Import\DeleteRatesConsumer" method="process" />
+    </topic>
+    <topic name="taxjar.backup_rates.create" request="Magento\AsynchronousOperations\Api\Data\OperationInterface">
+        <handler name="taxjar.backup_rates.create" type="Taxjar\SalesTax\Model\Import\CreateRatesConsumer" method="process" />
     </topic>
 </config>

--- a/etc/queue_consumer.xml
+++ b/etc/queue_consumer.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
-    <consumer name="taxjar.create_backup_rates" queue="taxjar.create_backup_rates" connection="db" maxMessages="5000" consumerInstance="Magento\Framework\MessageQueue\Consumer" handler="Taxjar\SalesTax\Model\Import\Consumer::process" />
+    <consumer name="taxjar.backup_rates.delete" queue="taxjar.backup_rates.delete" connection="db" maxMessages="5000" consumerInstance="Magento\Framework\MessageQueue\Consumer" handler="Taxjar\SalesTax\Model\Import\DeleteRatesConsumer::process" />
+    <consumer name="taxjar.backup_rates.create" queue="taxjar.backup_rates.create" connection="db" maxMessages="5000" consumerInstance="Magento\Framework\MessageQueue\Consumer" handler="Taxjar\SalesTax\Model\Import\CreateRatesConsumer::process" />
 </config>

--- a/etc/queue_publisher.xml
+++ b/etc/queue_publisher.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/publisher.xsd">
-    <publisher topic="taxjar.create_backup_rates">
+    <publisher topic="taxjar.backup_rates.delete">
+        <connection name="db" exchange="taxjar" />
+    </publisher>
+    <publisher topic="taxjar.backup_rates.create">
         <connection name="db" exchange="taxjar" />
     </publisher>
 </config>

--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
     <exchange name="taxjar" type="topic" connection="db">
-        <binding id="backupRatesBinding" topic="taxjar.create_backup_rates" destinationType="queue" destination="taxjar.create_backup_rates"/>
+        <binding id="deleteRatesBinding" topic="taxjar.backup_rates.delete" destinationType="queue" destination="taxjar.backup_rates.delete"/>
+        <binding id="createRatesBinding" topic="taxjar.backup_rates.create" destinationType="queue" destination="taxjar.backup_rates.create"/>
     </exchange>
 </config>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Users have experienced timeouts due to backup rate sync when a large number of nexus addresses are configured.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR builds on the previously implemented bulk action making rate creation asynchronous.
- Re-uses the existing chunk size already defined for async rate creation.
- Adds constants to the Taxjar Configuration class for message queue topics.
- Refactors many functionalities of the previous rates topic consumer to an abstract class, `AbstractRatesConsumer::class`, which the existing `Consumer::class` now extends from, as well as the newly created `DeleteRatesConsumer::class`
- Configures new topic for bulk action in message queue across various `etc/*.xml`

![Screen Shot 2021-08-04 at 10 31 50 AM](https://user-images.githubusercontent.com/47947793/128215145-c2aeb0ca-e00d-4729-b087-99e22d8cbdc0.png)
_Messages displayed now upon clicking "sync rates"_

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
For some users, the long-running synchronous task of deleting existing backup rates would lead to browser timeout. This change makes the process asynchronous, so no matter the number of backup rates stored, control of the browser will immediately be returned to the admin user while batched deletes process in the background.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
Prerequisites:
- TaxJar extension enabled in Magento 2
- At least one nexus address configured in TaxJar app and synced in Magento (preferably in a more tax-heavy US region such as California or Colorado)

1. From Admin dashboard, navigate to `Stores>Configuration>Sales>Tax` 
![image](https://user-images.githubusercontent.com/47947793/128218619-1b8569ad-b6de-4aa4-8299-817aa7146fd0.png)
2. In dropdown box for "Backup Rates Enabled" select option "Yes" 
![image](https://user-images.githubusercontent.com/47947793/128218534-01f103c7-43ea-4fa1-a4fb-a4524c27ecd3.png)
3. In top right, click "Save Config". ![image](https://user-images.githubusercontent.com/47947793/128218352-d49fec27-85fd-469d-b819-e48f8f31f327.png)
4. Since there should not be any previous rates, no deletion should occur, but message should be displayed that bulk action to create backup rates has been queued.
5. Refresh the page and observe that backup rates are created
![image](https://user-images.githubusercontent.com/47947793/128218205-6d59a2ad-d553-4cf7-8e3c-2a31bae12c13.png)
6. In the backup rates section, select "Sync Backup Rates" to force-refresh backup rates. 
![image](https://user-images.githubusercontent.com/47947793/128219028-a53f46e7-1faa-4098-9e1e-c4c639d29402.png)
7. Observe bulk action notifications that backup rates are being deleted as well as created. 
![image](https://user-images.githubusercontent.com/47947793/128219276-262cbfa2-923b-4fa9-8043-5f446703cbcb.png)
8. The outcome of delete/create can be verified by inspecting entries on the `tax_calculations`, `tax_calculation_rates` and `tax_calculation_rules` tables, as previous entries should no longer exist.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [ ] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
