### PR TITLE
INT-1892: Backup rates progress indicator

### DIFF
--- a/Block/Adminhtml/Backup.php
+++ b/Block/Adminhtml/Backup.php
@@ -23,6 +23,7 @@ use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Shipping\Model\Config as MagentoShippingConfig;
 use Magento\Tax\Api\TaxRateRepositoryInterface;
 use Magento\Backend\Model\UrlInterface;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
@@ -55,7 +56,7 @@ class Backup extends Field
     /**
      * @var \Taxjar\SalesTax\Model\Import\RateFactory
      */
-    protected $importRateFactory;
+    protected $rateFactory;
 
     /**
      * @var \Magento\Directory\Model\RegionFactory
@@ -84,7 +85,7 @@ class Backup extends Field
 
     /**
      * @param Context $context
-     * @param RateFactory $importRateFactory
+     * @param RateFactory $rateFactory
      * @param TaxRateRepositoryInterface $rateService
      * @param RegionFactory $regionFactory
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
@@ -95,7 +96,7 @@ class Backup extends Field
      */
     public function __construct(
         Context $context,
-        RateFactory $importRateFactory,
+        RateFactory $rateFactory,
         TaxRateRepositoryInterface $rateService,
         RegionFactory $regionFactory,
         SearchCriteriaBuilder $searchCriteriaBuilder,
@@ -107,7 +108,7 @@ class Backup extends Field
         $this->cache = $context->getCache();
         $this->scopeConfig = $context->getScopeConfig();
         $this->rateService = $rateService;
-        $this->importRateFactory = $importRateFactory;
+        $this->rateFactory = $rateFactory;
         $this->regionFactory = $regionFactory;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->filterBuilder = $filterBuilder;
@@ -116,7 +117,7 @@ class Backup extends Field
         $this->apiKey = $taxjarConfig->getApiKey();
 
         $region = $this->regionFactory->create();
-        $regionId = $this->scopeConfig->getValue('shipping/origin/region_id');
+        $regionId = $this->scopeConfig->getValue(MagentoShippingConfig::XML_PATH_ORIGIN_REGION_ID);
         $this->_regionCode = $region->load($regionId)->getCode();
 
         parent::__construct($context, $data);
@@ -128,7 +129,7 @@ class Backup extends Field
      * @param AbstractElement $element
      * @return string
      */
-    protected function _getElementHtml(AbstractElement $element)
+    protected function _getElementHtml(AbstractElement $element): string
     {
         if ($this->apiKey) {
             $this->_cacheElementValue($element);
@@ -154,143 +155,38 @@ class Backup extends Field
      *
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
-        $isEnabled = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_BACKUP);
-
-        if ($isEnabled) {
-            return true;
-        }
-
-        return false;
+        return (bool) (int) $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_BACKUP);
     }
 
-    /**
-     * Build HTML list of states
-     *
-     * @return string
-     */
-    public function getStateList()
+    public function getActualRateCount(): int
     {
-        $states = json_decode($this->scopeConfig->getValue(TaxjarConfig::TAXJAR_STATES), true);
-        $states[] = $this->_regionCode;
-        $statesHtml = '';
-        $lastUpdate = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_LAST_UPDATE);
+        $rateModel = $this->rateFactory->create();
+        $rates = $rateModel->getExistingRates();
 
-        sort($states);
+        return count($rates) ?? 0;
+    }
 
-        $taxRatesByState = $this->_getNumberOfRatesLoaded($states);
+    public function getExpectedRateCount(): int
+    {
+        return $this->taxjarConfig->getBackupRateCount();
+    }
 
-        foreach (array_unique($states) as $state) {
-            $statesHtml .= $this->_getStateListItem($taxRatesByState, $state);
-        }
-
-        if ($taxRatesByState['rates_loaded'] != $taxRatesByState['total_rates']) {
-            $matches = 'error';
-        } else {
-            $matches = 'success';
-        }
-
-        $statesHtml .= '<p class="' . $matches . '-msg" style="background: none !important;">';
-        $statesHtml .= '<small>&nbsp;&nbsp;' . number_format($taxRatesByState['total_rates']);
-        $statesHtml .= ' of ' . number_format($taxRatesByState['rates_loaded']);
-        $statesHtml .= ' expected rates loaded.</small></p>';
-
-        if (!empty($lastUpdate)) {
-            $statesHtml .= '<p class="' . $matches . '-msg" style="background: none !important;">';
-            $statesHtml .= '<small>&nbsp;&nbsp;' . 'Last synced on ' . $lastUpdate . '.</small>';
-            $statesHtml .= '</p><br/>';
-        }
-
-        return $statesHtml;
+    public function getLastSyncedDate(): string
+    {
+        return $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_LAST_UPDATE) ?? 'N/A';
     }
 
     /**
      * Get store URL
      *
      * @param string $route
-     * @param array $params
+     * @param array|null $params
      * @return string
      */
-    public function getStoreUrl($route, $params = [])
+    public function getStoreUrl(string $route, ?array $params = []): string
     {
         return $this->backendUrl->getUrl($route, $params);
-    }
-
-    /**
-     * Get region name from region code
-     *
-     * @param string $regionCode
-     * @return string
-     */
-    private function _getStateName($regionCode)
-    {
-        $region = $this->regionFactory->create();
-        return $region->loadByCode($regionCode, 'US')->getDefaultName();
-    }
-
-    /**
-     * Generate state list item
-     *
-     * @param array $rates
-     * @param string $state
-     * @return string
-     */
-    private function _getStateListItem($rates, $state)
-    {
-        $originResourceUrl = 'http://blog.taxjar.com/charging-sales-tax-rates/';
-        $nexusUrl = $this->getUrl('taxjar/nexus/index');
-
-        if (($name = $this->_getStateName($state)) && !empty($name)) {
-            if ($rates['rates_by_state'][$state] == 1 && ($rates['rates_loaded'] == $rates['total_rates'])) {
-                $class = 'success';
-                $total = "1 rate (<a href='{$originResourceUrl}' target='_blank'>Origin-based</a>)";
-            } elseif ($rates['rates_by_state'][$state] == 0 && ($rates['rates_loaded'] == $rates['total_rates'])) {
-                $class = 'error';
-                $total = "<a href='{$nexusUrl}'>Click here</a> and add a zip code for this state to load rates.";
-            } else {
-                $class = 'success';
-                $total = number_format($rates['rates_by_state'][$state]) . ' rates';
-            }
-
-            $itemClass = "message message-{$class} {$class}";
-
-            return "<div class='{$itemClass}'><span style='font-size: 1.2em'>{$name}</span>: {$total}</div>";
-        }
-
-        return '';
-    }
-
-    /**
-     * Get the number of rates loaded
-     *
-     * @param array $states
-     * @return array
-     */
-    private function _getNumberOfRatesLoaded($states)
-    {
-        $ratesByState = [];
-
-        foreach (array_unique($states) as $state) {
-            $region = $this->regionFactory->create();
-            $regionId = $region->loadByCode($state, 'US')->getId();
-            $filter = $this->filterBuilder
-                ->setField('tax_region_id')
-                ->setValue($regionId)
-                ->create();
-            $searchCriteria = $this->searchCriteriaBuilder->addFilters([$filter])->create();
-
-            $ratesByState[$state] = $this->rateService->getList($searchCriteria)->getTotalCount();
-        }
-
-        $importRateModel = $this->importRateFactory->create();
-
-        $rateCalcs = [
-            'total_rates' => array_sum($ratesByState),
-            'rates_loaded' => count($importRateModel->getExistingRates()),
-            'rates_by_state' => $ratesByState
-        ];
-
-        return $rateCalcs;
     }
 }

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -17,9 +17,10 @@
 
 namespace Taxjar\SalesTax\Model;
 
-use Magento\Config\Model\ResourceModel\Config;
+use Magento\Config\Model\ResourceModel\Config as MagentoConfig;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Tax\Model\Config as MagentoTaxConfig;
 
 class Configuration
 {
@@ -32,6 +33,7 @@ class Configuration
     const TAXJAR_APIKEY               = 'tax/taxjar/apikey';
     const TAXJAR_SANDBOX_APIKEY       = 'tax/taxjar/sandbox_apikey';
     const TAXJAR_BACKUP               = 'tax/taxjar/backup';
+    const TAXJAR_BACKUP_RATE_COUNT    = 'tax/taxjar/backup_rate_count';
     const TAXJAR_CONNECTED            = 'tax/taxjar/connected';
     const TAXJAR_CUSTOMER_TAX_CLASSES = 'tax/taxjar/customer_tax_classes';
     const TAXJAR_DEBUG                = 'tax/taxjar/debug';
@@ -58,21 +60,21 @@ class Configuration
     const TAXJAR_TOPIC_DELETE_RATES   = 'taxjar.backup_rates.delete';
 
     /**
-     * @var \Magento\Config\Model\ResourceModel\Config
+     * @var MagentoConfig
      */
     protected $resourceConfig;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var ScopeConfigInterface
      */
     protected $scopeConfig;
 
     /**
-     * @param Config $resourceConfig
+     * @param MagentoConfig $resourceConfig
      * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
-        Config $resourceConfig,
+        MagentoConfig $resourceConfig,
         ScopeConfigInterface $scopeConfig
     ) {
         $this->resourceConfig = $resourceConfig;
@@ -84,7 +86,7 @@ class Configuration
      *
      * @return string
      */
-    public function getApiUrl()
+    public function getApiUrl(): string
     {
         return $this->isSandboxEnabled() ? self::TAXJAR_SANDBOX_API_URL : self::TAXJAR_API_URL;
     }
@@ -92,10 +94,10 @@ class Configuration
     /**
      * Returns the scoped API token
      *
-     * @param int $storeId
+     * @param int|null $storeId
      * @return string
      */
-    public function getApiKey($storeId = null)
+    public function getApiKey(?int $storeId = null): string
     {
         return preg_replace('/\s+/', '', $this->scopeConfig->getValue(
             $this->isSandboxEnabled() ? self::TAXJAR_SANDBOX_APIKEY : self::TAXJAR_APIKEY,
@@ -109,17 +111,18 @@ class Configuration
      *
      * @return bool
      */
-    public function isSandboxEnabled() {
+    public function isSandboxEnabled(): bool
+    {
         return (bool) $this->scopeConfig->getValue(self::TAXJAR_SANDBOX_ENABLED);
     }
 
     /**
      * Sets tax basis in Magento
      *
-     * @param string $configJson
+     * @param $configJson
      * @return void
      */
-    public function setTaxBasis($configJson)
+    public function setTaxBasis($configJson): void
     {
         $basis = 'shipping';
 
@@ -127,7 +130,17 @@ class Configuration
             $basis = 'origin';
         }
 
-        $this->_setConfig('tax/calculation/based_on', $basis);
+        $this->_setConfig(MagentoTaxConfig::CONFIG_XML_PATH_BASED_ON, $basis);
+    }
+
+    public function getBackupRateCount(): int
+    {
+        return (int) $this->scopeConfig->getValue(self::TAXJAR_BACKUP_RATE_COUNT);
+    }
+
+    public function setBackupRateCount($value): void
+    {
+        $this->_setConfig(self::TAXJAR_BACKUP_RATE_COUNT, $value);
     }
 
     /**
@@ -135,14 +148,14 @@ class Configuration
      *
      * @return void
      */
-    public function setDisplaySettings()
+    public function setDisplaySettings(): void
     {
         $settings = [
-            'tax/display/type',
-            'tax/display/shipping',
-            'tax/cart_display/price',
-            'tax/cart_display/subtotal',
-            'tax/cart_display/shipping'
+            MagentoTaxConfig::CONFIG_XML_PATH_PRICE_DISPLAY_TYPE,
+            MagentoTaxConfig::CONFIG_XML_PATH_DISPLAY_SHIPPING,
+            MagentoTaxConfig::XML_PATH_DISPLAY_CART_PRICE,
+            MagentoTaxConfig::XML_PATH_DISPLAY_CART_SUBTOTAL,
+            MagentoTaxConfig::XML_PATH_DISPLAY_CART_SHIPPING,
         ];
 
         foreach ($settings as $setting) {
@@ -154,11 +167,11 @@ class Configuration
      * Store config
      *
      * @param string $path
-     * @param string $value
+     * @param mixed $value
      * @return void
      */
-    private function _setConfig($path, $value)
+    private function _setConfig(string $path, $value): void
     {
-        $this->resourceConfig->saveConfig($path, $value, 'default', 0);
+        $this->resourceConfig->saveConfig($path, $value, 'default');
     }
 }

--- a/Model/Import/Rate.php
+++ b/Model/Import/Rate.php
@@ -22,6 +22,8 @@ use Magento\Framework\App\CacheInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Tax\Api\TaxRateRepositoryInterface;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 
@@ -173,7 +175,7 @@ class Rate
      *
      * @return array
      */
-    public function getExistingRates()
+    public function getExistingRates(): array
     {
         return $this->getRule()->load(TaxjarConfig::TAXJAR_BACKUP_RATE_CODE, 'code')->getRates();
     }
@@ -182,14 +184,13 @@ class Rate
      * Get existing TaxJar rule calculations based on the rate ID
      *
      * @param string $rateId
-     * @return \Magento\Tax\Model\ResourceModel\Calculation\Collection
+     * @return AbstractDb|AbstractCollection|null
      */
-    public function getCalculationsByRateId($rateId)
+    public function getCalculationsByRateId(string $rateId)
     {
         $calculationModel = $this->_calculationFactory->create();
-        $calculations = $calculationModel->getCollection()
-                        ->addFieldToFilter('tax_calculation_rate_id', $rateId);
-
-        return $calculations;
+        return $calculationModel
+            ->getCollection()
+            ->addFieldToFilter('tax_calculation_rate_id', $rateId);
     }
 }

--- a/Observer/ImportRates.php
+++ b/Observer/ImportRates.php
@@ -20,20 +20,21 @@ declare(strict_types=1);
 namespace Taxjar\SalesTax\Observer;
 
 use Magento\AsynchronousOperations\Api\Data\OperationInterface;
+use Magento\AsynchronousOperations\Api\Data\OperationInterfaceFactory;
 use Magento\AsynchronousOperations\Model\Operation;
+use Magento\Authorization\Model\UserContextInterface;
 use Magento\Config\Model\ResourceModel\Config;
+use Magento\Framework\App\Cache\Manager as CacheManager;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
-use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Framework\Bulk\BulkManagementInterface;
+use Magento\Framework\DataObject\IdentityGeneratorInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Tax\Model\Calculation\RateRepository;
-use Magento\Framework\DataObject\IdentityGeneratorInterface;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
 use Magento\Framework\Serialize\SerializerInterface;
-use Magento\AsynchronousOperations\Api\Data\OperationInterfaceFactory;
-use Magento\Framework\Bulk\BulkManagementInterface;
-use Magento\Authorization\Model\UserContextInterface;
+use Magento\Tax\Model\Calculation\RateRepository;
+use Magento\Tax\Model\Config as MagentoTaxConfig;
 use Taxjar\SalesTax\Model\BackupRateOriginAddress;
 use Taxjar\SalesTax\Model\Client;
 use Taxjar\SalesTax\Model\ClientFactory;
@@ -47,11 +48,6 @@ class ImportRates implements ObserverInterface
      * The default batch size used for bulk operations in `ImportRates::class`
      */
     private const BATCH_SIZE = 1000;
-
-    /**
-     * @var EventManagerInterface
-     */
-    private $eventManager;
 
     /**
      * @var MessageManagerInterface
@@ -149,7 +145,11 @@ class ImportRates implements ObserverInterface
     private $zipCode;
 
     /**
-     * @param EventManagerInterface $eventManager
+     * @var CacheManager
+     */
+    private $cacheManager;
+
+    /**
      * @param MessageManagerInterface $messageManager
      * @param ScopeConfigInterface $scopeConfig
      * @param Config $resourceConfig
@@ -164,9 +164,9 @@ class ImportRates implements ObserverInterface
      * @param OperationInterfaceFactory $operationFactory
      * @param BulkManagementInterface $bulkManagement
      * @param UserContextInterface $userContext
+     * @param CacheManager $cacheManager
      */
     public function __construct(
-        EventManagerInterface $eventManager,
         MessageManagerInterface $messageManager,
         ScopeConfigInterface $scopeConfig,
         Config $resourceConfig,
@@ -180,9 +180,9 @@ class ImportRates implements ObserverInterface
         SerializerInterface $serializer,
         OperationInterfaceFactory $operationFactory,
         BulkManagementInterface $bulkManagement,
-        UserContextInterface $userContext
+        UserContextInterface $userContext,
+        CacheManager $cacheManager
     ) {
-        $this->eventManager = $eventManager;
         $this->messageManager = $messageManager;
         $this->scopeConfig = $scopeConfig;
         $this->resourceConfig = $resourceConfig;
@@ -197,6 +197,7 @@ class ImportRates implements ObserverInterface
         $this->operationFactory = $operationFactory;
         $this->bulkManagement = $bulkManagement;
         $this->userContext = $userContext;
+        $this->cacheManager = $cacheManager;
     }
 
     /**
@@ -279,7 +280,7 @@ class ImportRates implements ObserverInterface
             $zipCode = $this->backupRateOriginAddress->getShippingZipCode();
             $customerTaxClassConfig = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_CUSTOMER_TAX_CLASSES);
             $productTaxClassConfig = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_PRODUCT_TAX_CLASSES);
-            $shippingTaxClass = $this->scopeConfig->getValue('tax/classes/shipping_tax_class');
+            $shippingTaxClass = $this->scopeConfig->getValue(MagentoTaxConfig::CONFIG_XML_PATH_SHIPPING_TAX_CLASS);
 
             $this->setClient($client)
                 ->setZipCode($zipCode)
@@ -288,20 +289,13 @@ class ImportRates implements ObserverInterface
                 ->setShippingTaxClass($shippingTaxClass)
                 ->importRates();
         } else {
-            $statesConfig = $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_STATES);
-            $states = json_decode($statesConfig, true);
-
-            if (! empty($states)) {
-                $this->purgeExistingRates();
-            }
-
+            $this->purgeExistingRates();
             $this->setLastUpdate(null);
-
             $this->resourceConfig->saveConfig(TaxjarConfig::TAXJAR_BACKUP, 0, 'default');
-            $this->messageManager->addNoticeMessage(__('Backup rates imported by TaxJar have been removed.'));
+            $this->messageManager->addNoticeMessage(__('Backup rates imported by TaxJar have been queued for removal.'));
         }
 
-        $this->eventManager->dispatch('adminhtml_cache_flush_all');
+        $this->cacheManager->flush($this->cacheManager->getAvailableTypes());
 
         return $this;
     }
@@ -347,8 +341,6 @@ class ImportRates implements ObserverInterface
         $this->messageManager->addSuccessMessage(
             __('TaxJar has successfully queued backup tax rate sync. Thanks for using TaxJar!')
         );
-
-        $this->eventManager->dispatch('taxjar_salestax_import_rates_after');
     }
 
     /**
@@ -465,6 +457,8 @@ class ImportRates implements ObserverInterface
         $rule->getCalculationModel()->deleteByRuleId($rule->getId());
         $rule->delete();
 
+        $this->setRateCount(0);
+
         if (! empty($rates)) {
             $payload = $this->getDeleteRatesPayload($rates);
 
@@ -479,6 +473,17 @@ class ImportRates implements ObserverInterface
     }
 
     /**
+     * Updates the current backup rate count stored in global config.
+     *
+     * @param int $value
+     * @return void
+     */
+    private function setRateCount(int $value): void
+    {
+        $this->taxjarConfig->setBackupRateCount($value);
+    }
+
+    /**
      * Schedule bulk operation(s) to asynchronously create `tax_calculation_rates` entries and relate rates to new
      * TaxJar `tax_calculation_rules` entry by way of `tax_calculations` entries.
      *
@@ -488,6 +493,8 @@ class ImportRates implements ObserverInterface
      */
     private function createRates(array $rates): self
     {
+        $this->setRateCount(count($rates));
+
         $payload = $this->getCreateRatesPayload($rates);
 
         $this->scheduleBulkOperation(

--- a/Observer/ImportRates.php
+++ b/Observer/ImportRates.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace Taxjar\SalesTax\Observer;
 
+use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
 use Magento\AsynchronousOperations\Api\Data\OperationInterface;
 use Magento\AsynchronousOperations\Api\Data\OperationInterfaceFactory;
 use Magento\AsynchronousOperations\Model\Operation;
@@ -48,6 +49,11 @@ class ImportRates implements ObserverInterface
      * The default batch size used for bulk operations in `ImportRates::class`
      */
     private const BATCH_SIZE = 1000;
+
+    /**
+     * @var EventManagerInterface
+     */
+    protected $eventManager;
 
     /**
      * @var MessageManagerInterface
@@ -150,6 +156,7 @@ class ImportRates implements ObserverInterface
     private $cacheManager;
 
     /**
+     * @param EventManagerInterface $eventManager
      * @param MessageManagerInterface $messageManager
      * @param ScopeConfigInterface $scopeConfig
      * @param Config $resourceConfig
@@ -167,6 +174,7 @@ class ImportRates implements ObserverInterface
      * @param CacheManager $cacheManager
      */
     public function __construct(
+        EventManagerInterface $eventManager,
         MessageManagerInterface $messageManager,
         ScopeConfigInterface $scopeConfig,
         Config $resourceConfig,
@@ -183,6 +191,7 @@ class ImportRates implements ObserverInterface
         UserContextInterface $userContext,
         CacheManager $cacheManager
     ) {
+        $this->eventManager = $eventManager;
         $this->messageManager = $messageManager;
         $this->scopeConfig = $scopeConfig;
         $this->resourceConfig = $resourceConfig;
@@ -341,6 +350,8 @@ class ImportRates implements ObserverInterface
         $this->messageManager->addSuccessMessage(
             __('TaxJar has successfully queued backup tax rate sync. Thanks for using TaxJar!')
         );
+
+        $this->eventManager->dispatch('taxjar_salestax_import_rates_after');
     }
 
     /**

--- a/Test/Unit/Observer/ImportRatesTest.php
+++ b/Test/Unit/Observer/ImportRatesTest.php
@@ -8,6 +8,7 @@ use Magento\AsynchronousOperations\Api\Data\OperationInterfaceFactory;
 use Magento\AsynchronousOperations\Model\Operation;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Config\Model\ResourceModel\Config;
+use Magento\Framework\App\Cache\Manager;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Bulk\BulkManagementInterface;
 use Magento\Framework\DataObject\IdentityGeneratorInterface;
@@ -34,14 +35,12 @@ class ImportRatesTest extends UnitTestCase
 {
     public function testExecuteWithBackupRatesEnabledAndValidApiKeyWhenDebugEnabled(): void
     {
-        $mockEventManager = $this->createMock(EventManagerInterface::class);
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())
             ->method('addNoticeMessage')
             ->withAnyParameters();
 
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
-
         $mockScopeConfigInterface->expects($this->exactly(5))
             ->method('getValue')
             ->withConsecutive(
@@ -87,8 +86,11 @@ class ImportRatesTest extends UnitTestCase
         $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
         $mockUserContextInterface = $this->createMock(UserContextInterface::class);
 
+        $mockCacheManager = $this->createMock(Manager::class);
+        $mockCacheManager->expects($this->once())->method('getAvailableTypes')->willReturn(['type']);
+        $mockCacheManager->expects($this->once())->method('flush')->with(['type'])->willReturn(true);
+
         $sut = new ImportRates(
-            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -102,7 +104,8 @@ class ImportRatesTest extends UnitTestCase
             $mockSerializerInterface,
             $mockOperationInterfaceFactory,
             $mockBulkManagementInterface,
-            $mockUserContextInterface
+            $mockUserContextInterface,
+            $mockCacheManager
         );
 
         $result = $sut->execute(new Observer());
@@ -112,7 +115,6 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithInvalidZipCodeThrowsException(): void
     {
-        $mockEventManager = $this->createMock(EventManagerInterface::class);
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
 
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
@@ -179,9 +181,9 @@ class ImportRatesTest extends UnitTestCase
         $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
         $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
         $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+        $mockCacheManager = $this->createMock(Manager::class);
 
         $sut = new ImportRates(
-            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -195,7 +197,8 @@ class ImportRatesTest extends UnitTestCase
             $mockSerializerInterface,
             $mockOperationInterfaceFactory,
             $mockBulkManagementInterface,
-            $mockUserContextInterface
+            $mockUserContextInterface,
+            $mockCacheManager
         );
 
         $this->expectException(LocalizedException::class);
@@ -206,7 +209,6 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithInvalidTaxClassesThrowsException(): void
     {
-        $mockEventManager = $this->createMock(EventManagerInterface::class);
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
 
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
@@ -273,9 +275,9 @@ class ImportRatesTest extends UnitTestCase
         $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
         $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
         $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+        $mockCacheManager = $this->createMock(Manager::class);
 
         $sut = new ImportRates(
-            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -289,7 +291,8 @@ class ImportRatesTest extends UnitTestCase
             $mockSerializerInterface,
             $mockOperationInterfaceFactory,
             $mockBulkManagementInterface,
-            $mockUserContextInterface
+            $mockUserContextInterface,
+            $mockCacheManager
         );
 
         $this->expectException(LocalizedException::class);
@@ -303,7 +306,6 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithInvalidShippingTaxClassThrowsException(): void
     {
-        $mockEventManager = $this->createMock(EventManagerInterface::class);
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
 
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
@@ -370,9 +372,9 @@ class ImportRatesTest extends UnitTestCase
         $mockOperationInterfaceFactory = $this->createMock(OperationInterfaceFactory::class);
         $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
         $mockUserContextInterface = $this->createMock(UserContextInterface::class);
+        $mockCacheManager = $this->createMock(Manager::class);
 
         $sut = new ImportRates(
-            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -386,7 +388,8 @@ class ImportRatesTest extends UnitTestCase
             $mockSerializerInterface,
             $mockOperationInterfaceFactory,
             $mockBulkManagementInterface,
-            $mockUserContextInterface
+            $mockUserContextInterface,
+            $mockCacheManager
         );
 
         $this->expectException(LocalizedException::class);
@@ -399,7 +402,6 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteThrowsExceptionWhenScheduleBulkOperationFails(): void
     {
-        $mockEventManager = $this->createMock(EventManagerInterface::class);
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
         $mockScopeConfigInterface->expects($this->exactly(5))
@@ -514,8 +516,9 @@ class ImportRatesTest extends UnitTestCase
             ->method('getUserId')
             ->willReturn('9999999');
 
+        $mockCacheManager = $this->createMock(Manager::class);
+
         $sut = new ImportRates(
-            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -529,7 +532,8 @@ class ImportRatesTest extends UnitTestCase
             $mockSerializerInterface,
             $mockOperationInterfaceFactory,
             $mockBulkManagementInterface,
-            $mockUserContextInterface
+            $mockUserContextInterface,
+            $mockCacheManager
         );
 
         $this->expectException(LocalizedException::class);
@@ -542,14 +546,6 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithExistingRates()
     {
-        $mockEventManager = $this->createMock(EventManagerInterface::class);
-        $mockEventManager->expects($this->exactly(2))
-            ->method('dispatch')
-            ->withConsecutive(
-                ['taxjar_salestax_import_rates_after'],
-                ['adminhtml_cache_flush_all']
-            );
-
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())->method('addSuccessMessage');
 
@@ -668,8 +664,11 @@ class ImportRatesTest extends UnitTestCase
             ->method('getUserId')
             ->willReturn('9999999');
 
+        $mockCacheManager = $this->createMock(Manager::class);
+        $mockCacheManager->expects($this->once())->method('flush')->withAnyParameters()->willReturn(true);
+        $mockCacheManager->expects($this->once())->method('getAvailableTypes')->withAnyParameters()->willReturn([]);
+
         $sut = new ImportRates(
-            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -683,7 +682,8 @@ class ImportRatesTest extends UnitTestCase
             $mockSerializerInterface,
             $mockOperationInterfaceFactory,
             $mockBulkManagementInterface,
-            $mockUserContextInterface
+            $mockUserContextInterface,
+            $mockCacheManager
         );
 
         $result = $sut->execute(new Observer());
@@ -693,14 +693,6 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithoutExistingRates()
     {
-        $mockEventManager = $this->createMock(EventManagerInterface::class);
-        $mockEventManager->expects($this->exactly(2))
-            ->method('dispatch')
-            ->withConsecutive(
-                ['taxjar_salestax_import_rates_after'],
-                ['adminhtml_cache_flush_all']
-            );
-
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())->method('addSuccessMessage');
 
@@ -819,8 +811,11 @@ class ImportRatesTest extends UnitTestCase
             ->method('getUserId')
             ->willReturn('9999999');
 
+        $mockCacheManager = $this->createMock(Manager::class);
+        $mockCacheManager->expects($this->once())->method('getAvailableTypes')->willReturn(['type']);
+        $mockCacheManager->expects($this->once())->method('flush')->with(['type'])->willReturn(true);
+
         $sut = new ImportRates(
-            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -834,7 +829,8 @@ class ImportRatesTest extends UnitTestCase
             $mockSerializerInterface,
             $mockOperationInterfaceFactory,
             $mockBulkManagementInterface,
-            $mockUserContextInterface
+            $mockUserContextInterface,
+            $mockCacheManager
         );
 
         $result = $sut->execute(new Observer());
@@ -844,14 +840,6 @@ class ImportRatesTest extends UnitTestCase
 
     public function testCron()
     {
-        $mockEventManager = $this->createMock(EventManagerInterface::class);
-        $mockEventManager->expects($this->exactly(2))
-            ->method('dispatch')
-            ->withConsecutive(
-                ['taxjar_salestax_import_rates_after'],
-                ['adminhtml_cache_flush_all']
-            );
-
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())->method('addSuccessMessage');
 
@@ -970,8 +958,12 @@ class ImportRatesTest extends UnitTestCase
             ->method('getUserId')
             ->willReturn('9999999');
 
+        $mockCacheManager = $this->createMock(Manager::class);
+        $mockCacheManager->expects($this->once())->method('getAvailableTypes')->willReturn(['type']);
+        $mockCacheManager->expects($this->once())->method('flush')->with(['type'])->willReturn(true);
+
+
         $sut = new ImportRates(
-            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -985,7 +977,8 @@ class ImportRatesTest extends UnitTestCase
             $mockSerializerInterface,
             $mockOperationInterfaceFactory,
             $mockBulkManagementInterface,
-            $mockUserContextInterface
+            $mockUserContextInterface,
+            $mockCacheManager
         );
 
         $sut->cron();
@@ -993,26 +986,16 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithoutBackupRatesEnabled()
     {
-        $mockEventManager = $this->createMock(EventManagerInterface::class);
-        $mockEventManager->expects($this->once())
-            ->method('dispatch')
-            ->with('adminhtml_cache_flush_all');
-
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())
             ->method('addNoticeMessage')
-            ->with(__('Backup rates imported by TaxJar have been removed.'));
+            ->with(__('Backup rates imported by TaxJar have been queued for removal.'));
 
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
-        $mockScopeConfigInterface->expects($this->exactly(2))
+        $mockScopeConfigInterface->expects($this->once())
             ->method('getValue')
-            ->withConsecutive(
-                [TaxjarConfig::TAXJAR_BACKUP],
-                [TaxjarConfig::TAXJAR_STATES]
-            )->willReturnOnConsecutiveCalls(
-                0,
-                json_encode(['state_1' => 'some_rate'])
-            );
+            ->with(TaxjarConfig::TAXJAR_BACKUP)
+            ->willReturn(0);
 
         $mockResourceConfig = $this->createMock(Config::class);
         $mockResourceConfig->expects($this->exactly(2))->method('saveConfig');
@@ -1058,8 +1041,11 @@ class ImportRatesTest extends UnitTestCase
         $mockBulkManagementInterface = $this->createMock(BulkManagementInterface::class);
         $mockUserContextInterface = $this->createMock(UserContextInterface::class);
 
+        $mockCacheManager = $this->createMock(Manager::class);
+        $mockCacheManager->expects($this->once())->method('getAvailableTypes')->willReturn(['type']);
+        $mockCacheManager->expects($this->once())->method('flush')->with(['type'])->willReturn(true);
+
         $sut = new ImportRates(
-            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -1073,7 +1059,8 @@ class ImportRatesTest extends UnitTestCase
             $mockSerializerInterface,
             $mockOperationInterfaceFactory,
             $mockBulkManagementInterface,
-            $mockUserContextInterface
+            $mockUserContextInterface,
+            $mockCacheManager
         );
 
         $result = $sut->execute(new Observer());

--- a/Test/Unit/Observer/ImportRatesTest.php
+++ b/Test/Unit/Observer/ImportRatesTest.php
@@ -35,6 +35,8 @@ class ImportRatesTest extends UnitTestCase
 {
     public function testExecuteWithBackupRatesEnabledAndValidApiKeyWhenDebugEnabled(): void
     {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())
             ->method('addNoticeMessage')
@@ -91,6 +93,7 @@ class ImportRatesTest extends UnitTestCase
         $mockCacheManager->expects($this->once())->method('flush')->with(['type'])->willReturn(true);
 
         $sut = new ImportRates(
+            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -115,6 +118,7 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithInvalidZipCodeThrowsException(): void
     {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
 
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
@@ -184,6 +188,7 @@ class ImportRatesTest extends UnitTestCase
         $mockCacheManager = $this->createMock(Manager::class);
 
         $sut = new ImportRates(
+            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -209,6 +214,7 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithInvalidTaxClassesThrowsException(): void
     {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
 
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
@@ -278,6 +284,7 @@ class ImportRatesTest extends UnitTestCase
         $mockCacheManager = $this->createMock(Manager::class);
 
         $sut = new ImportRates(
+            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -306,6 +313,7 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithInvalidShippingTaxClassThrowsException(): void
     {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
 
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
@@ -375,6 +383,7 @@ class ImportRatesTest extends UnitTestCase
         $mockCacheManager = $this->createMock(Manager::class);
 
         $sut = new ImportRates(
+            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -402,6 +411,7 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteThrowsExceptionWhenScheduleBulkOperationFails(): void
     {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockScopeConfigInterface = $this->createMock(ScopeConfigInterface::class);
         $mockScopeConfigInterface->expects($this->exactly(5))
@@ -519,6 +529,7 @@ class ImportRatesTest extends UnitTestCase
         $mockCacheManager = $this->createMock(Manager::class);
 
         $sut = new ImportRates(
+            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -546,6 +557,11 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithExistingRates()
     {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockEventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('taxjar_salestax_import_rates_after');
+
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())->method('addSuccessMessage');
 
@@ -669,6 +685,7 @@ class ImportRatesTest extends UnitTestCase
         $mockCacheManager->expects($this->once())->method('getAvailableTypes')->withAnyParameters()->willReturn([]);
 
         $sut = new ImportRates(
+            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -693,6 +710,11 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithoutExistingRates()
     {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockEventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('taxjar_salestax_import_rates_after');
+
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())->method('addSuccessMessage');
 
@@ -816,6 +838,7 @@ class ImportRatesTest extends UnitTestCase
         $mockCacheManager->expects($this->once())->method('flush')->with(['type'])->willReturn(true);
 
         $sut = new ImportRates(
+            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -840,6 +863,11 @@ class ImportRatesTest extends UnitTestCase
 
     public function testCron()
     {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+        $mockEventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('taxjar_salestax_import_rates_after');
+
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())->method('addSuccessMessage');
 
@@ -964,6 +992,7 @@ class ImportRatesTest extends UnitTestCase
 
 
         $sut = new ImportRates(
+            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,
@@ -986,6 +1015,8 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithoutBackupRatesEnabled()
     {
+        $mockEventManager = $this->createMock(EventManagerInterface::class);
+
         $mockMessageManager = $this->createMock(MessageManagerInterface::class);
         $mockMessageManager->expects($this->once())
             ->method('addNoticeMessage')
@@ -1046,6 +1077,7 @@ class ImportRatesTest extends UnitTestCase
         $mockCacheManager->expects($this->once())->method('flush')->with(['type'])->willReturn(true);
 
         $sut = new ImportRates(
+            $mockEventManager,
             $mockMessageManager,
             $mockScopeConfigInterface,
             $mockResourceConfig,

--- a/view/adminhtml/templates/backup.phtml
+++ b/view/adminhtml/templates/backup.phtml
@@ -15,26 +15,55 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
-// @codingStandardsIgnoreFile
-
+/** @var \Taxjar\SalesTax\Block\Adminhtml\Backup $block */
 ?>
-<p class='note'><span>Download zip-based rates from TaxJar as a fallback. TaxJar uses your shipping origin and nexus addresses to sync rates each month.</span></p><br/>
+
+<p class='note'>
+    <span>
+        Download zip-based rates from TaxJar as a fallback. TaxJar uses your shipping origin and nexus addresses to
+        sync rates each month.
+    </span>
+</p>
 
 <?php if ($block->isEnabled()) { ?>
-    <?php echo $block->getStateList() ?>
-    <p><button type="button" class="scalable" onclick="syncBackupRates()"><span>Sync Backup Rates</span></button></p>
+    <p class="success-msg" style="background: none !important; padding-left: 1rem; font-weight: 700;">
+        <small>
+            <?php echo $block->getActualRateCount() ?>
+            of
+            <?php echo $block->getExpectedRateCount() ?>
+            expected rates loaded.
+        </small>
+    </p>
+
+    <p class="success-msg" style="background: none !important; padding-left: 1rem;">
+        <small>Last synced on <?php echo $block->getLastSyncedDate() ?>.</small>
+    </p>
+
+    <p style="margin-top: 1rem">
+        <button type="button" class="scalable" onclick="syncBackupRates()">
+            <span>Sync Backup Rates</span>
+        </button>
+    </p>
+
     <script>
         function syncBackupRates() {
-            new Ajax.Request('<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/syncRates')) ?>', {
-                method: 'get',
-                onCreate: function(request) {
-                    varienLoaderHandler.handler.onCreate({options: {loaderArea: true}});
-                },
-                onComplete: function(data) {
-                    varienLoaderHandler.handler.onComplete();
-                    window.location = '<?php echo $block->escapeUrl($block->getStoreUrl('adminhtml/system_config/edit', ['section' => 'tax'])) ?>';
+            new Ajax.Request(
+                '<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/syncRates')) ?>',
+                {
+                    method: 'get',
+                    onCreate: function(request) {
+                        varienLoaderHandler.handler.onCreate({
+                            options: { loaderArea: true }
+                        });
+                    },
+                    onComplete: function(data) {
+                        varienLoaderHandler.handler.onComplete();
+                        window.location = '<?php echo $block->escapeUrl(
+                            $block->getStoreUrl('adminhtml/system_config/edit', ['section' => 'tax'])
+                        )?>';
+                    }
                 }
-            });
+            );
         }
     </script>
 <?php } ?>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
The existing backup rates indicator shows how many rates exist, not specifically TaxJar backup rates. It is not a true indicator of how many of the available backup rates have been imported.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Adds global configuration value for expected TaxJar backup rates count.
- Updates Backup Rates UI template (`backup.phtml`) and "controller" `Block.php` to provide data values from Block.php and render HTML in template (instead of concatenating a raw HTML string in Block.php)
- Removes Backup Rates UI element(s) for displaying individual states and their tax rate counts.
- Replaces "magic" strings with framework const values where applicable
- Updates cache flush method in `ImportRates.php`

![Screen Shot 2021-08-24 at 11 13 03 AM](https://user-images.githubusercontent.com/47947793/130746466-ee06002e-1b19-446f-a848-0ae2e182f203.png)

![Screen Shot 2021-08-24 at 11 49 27 AM](https://user-images.githubusercontent.com/47947793/130746495-1f0dda76-7f77-4f00-a14b-ffa33defddab.png)

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
There is a somewhat negligible performance ding due to the cache clearing that is required to accurately display expected backup rates count when value is updated in global config.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. With TJ extension enabled and nexus synced in Magento 2, navigate to `Stores > Configuration > Sales > Tax`
2. Enable backup rates, then select "Save Config"
3. Observe values set for expected rates count and last updated at date.
4. Wait for async rates to process and observe that actual rates count matches expected rates count. (If verifying against DB values, note that any values that are not associated with TaxJar's `tax_calculation_rules` entry are not included in rate count, and the expected rates count value is set on table `core_config_data`.
5. Disable backup rates, then select "Save Config"
6. Wait for async rates delete process to finish, then observe TaxJar tax rule and related rates are deleted. Backup rates count value is set to `0` on table `core_config_data`.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
