### PR TITLE
INT-1978: Backup rates upsert/delete

### DIFF
--- a/Block/Adminhtml/Backup.php
+++ b/Block/Adminhtml/Backup.php
@@ -22,6 +22,8 @@ use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\App\Cache\Manager;
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
 use Magento\Shipping\Model\Config as MagentoShippingConfig;
 use Magento\Tax\Api\TaxRateRepositoryInterface;
@@ -84,6 +86,7 @@ class Backup extends Field
     protected $taxjarConfig;
 
     /**
+     * @param CacheInterface $cache
      * @param Context $context
      * @param RateFactory $rateFactory
      * @param TaxRateRepositoryInterface $rateService
@@ -95,6 +98,7 @@ class Backup extends Field
      * @param array $data
      */
     public function __construct(
+        CacheInterface $cache,
         Context $context,
         RateFactory $rateFactory,
         TaxRateRepositoryInterface $rateService,
@@ -105,7 +109,7 @@ class Backup extends Field
         TaxjarConfig $taxjarConfig,
         array $data = []
     ) {
-        $this->cache = $context->getCache();
+        $this->cache = $cache;
         $this->scopeConfig = $context->getScopeConfig();
         $this->rateService = $rateService;
         $this->rateFactory = $rateFactory;
@@ -163,7 +167,7 @@ class Backup extends Field
     public function getActualRateCount(): int
     {
         $rateModel = $this->rateFactory->create();
-        $rates = $rateModel->getExistingRates();
+        $rates = $rateModel->getExistingRates() ?? [];
 
         return count($rates) ?? 0;
     }

--- a/Block/Adminhtml/Enabled.php
+++ b/Block/Adminhtml/Enabled.php
@@ -19,6 +19,7 @@ namespace Taxjar\SalesTax\Block\Adminhtml;
 
 use Magento\Backend\Block\Template\Context;
 use Magento\Backend\Model\UrlInterface;
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 
@@ -67,18 +68,20 @@ class Enabled extends PopupField
     protected $taxjarConfig;
 
     /**
+     * @param CacheInterface $cache
      * @param Context $context
      * @param UrlInterface $backendUrl
      * @param TaxjarConfig $taxjarConfig
      * @param array $data
      */
     public function __construct(
+        CacheInterface $cache,
         Context $context,
         UrlInterface $backendUrl,
         TaxjarConfig $taxjarConfig,
         array $data = []
     ) {
-        $this->cache = $context->getCache();
+        $this->cache = $cache;
         $this->request = $context->getRequest();
         $this->scopeConfig = $context->getScopeConfig();
         $this->backendUrl = $backendUrl;

--- a/Model/Import/Rule.php
+++ b/Model/Import/Rule.php
@@ -80,7 +80,19 @@ class Rule
                         'customer_tax_class_id' => $c,
                         'product_tax_class_id' => $p,
                     ];
-                    $ruleModel->getCalculationModel()->setData($dataArray)->save();
+                    $calculation = $ruleModel->getCalculationModel();
+
+                    $calculationModel = $calculation->getCollection()
+                        ->addFieldToFilter('tax_calculation_rate_id', $r)
+                        ->addFieldToFilter('customer_tax_class_id', $c)
+                        ->addFieldToFilter('product_tax_class_id', $p)
+                        ->getFirstItem();
+
+                    if ($calculationModel->getId()) {
+                        $calculationModel->delete();
+                    }
+
+                    $calculation->setData($dataArray)->save();
                 }
             }
         }

--- a/Observer/ConfigChanged.php
+++ b/Observer/ConfigChanged.php
@@ -75,14 +75,12 @@ class ConfigChanged implements ObserverInterface
      */
     private function _updateSmartcalcs()
     {
-        $enabled = (int)$this->scopeConfig->getValue(TaxjarConfig::TAXJAR_ENABLED);
-        $prevEnabled = (int)$this->cache->load('taxjar_salestax_config_enabled');
+        $currentValue = (int) $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_ENABLED);
+        $previousValue = (int) $this->cache->load('taxjar_salestax_config_enabled');
 
-        if (isset($prevEnabled)) {
-            if ($prevEnabled != $enabled && $enabled == 1) {
-                $this->eventManager->dispatch('taxjar_salestax_import_categories');
-                $this->eventManager->dispatch('taxjar_salestax_import_data');
-            }
+        if ($currentValue === 1 && $currentValue !== $previousValue) {
+            $this->eventManager->dispatch('taxjar_salestax_import_categories');
+            $this->eventManager->dispatch('taxjar_salestax_import_data');
         }
     }
 
@@ -91,15 +89,13 @@ class ConfigChanged implements ObserverInterface
      */
     private function _updateBackupRates()
     {
-        $enabled = (int)$this->scopeConfig->getValue(TaxjarConfig::TAXJAR_BACKUP);
-        $prevEnabled = (int)$this->cache->load('taxjar_salestax_config_backup');
+        $currentValue = (int) $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_BACKUP);
+        $previousValue = (int) $this->cache->load('taxjar_salestax_config_backup');
 
-        if (isset($prevEnabled)) {
-            if ($prevEnabled != $enabled) {
-                $this->eventManager->dispatch('taxjar_salestax_import_categories');
-                $this->eventManager->dispatch('taxjar_salestax_import_data');
-                $this->eventManager->dispatch('taxjar_salestax_import_rates');
-            }
+        if ($currentValue !== $previousValue) {
+            $this->eventManager->dispatch('taxjar_salestax_import_categories');
+            $this->eventManager->dispatch('taxjar_salestax_import_data');
+            $this->eventManager->dispatch('taxjar_salestax_import_rates');
         }
     }
 }

--- a/Test/Unit/Observer/ImportRatesTest.php
+++ b/Test/Unit/Observer/ImportRatesTest.php
@@ -62,6 +62,16 @@ class ImportRatesTest extends UnitTestCase
         $mockResourceConfig = $this->createMock(Config::class);
 
         $mockClient = $this->createMock(Client::class);
+        $mockClient->expects($this->once())
+            ->method('getResource')
+            ->willReturn([
+                'rates' => [
+                    [
+                        'state' => 'TX',
+                        'zip' => 78758,
+                    ],
+                ]
+            ]);
 
         $mockClientFactory = $this->createMock(ClientFactory::class);
         $mockClientFactory->expects($this->once())
@@ -442,11 +452,11 @@ class ImportRatesTest extends UnitTestCase
             ])
             ->willReturn([
                 'rates' => [
-                    'some',
-                    'list',
-                    'of',
-                    'values',
-                ],
+                    [
+                        'state' => 'TX',
+                        'zip' => 78758,
+                    ],
+                ]
             ]);
 
         $mockClientFactory = $this->createMock(ClientFactory::class);
@@ -596,11 +606,11 @@ class ImportRatesTest extends UnitTestCase
             ])
             ->willReturn([
                 'rates' => [
-                    'some',
-                    'list',
-                    'of',
-                    'values',
-                ],
+                    [
+                        'state' => 'TX',
+                        'zip' => 78758,
+                    ],
+                ]
             ]);
 
         $mockClientFactory = $this->createMock(ClientFactory::class);
@@ -638,7 +648,16 @@ class ImportRatesTest extends UnitTestCase
             ->willReturn($mockRateModel);
 
         $mockRuleFactory = $this->createMock(RuleFactory::class);
+
+        $mockRate = $this->createMock(Calculation\Rate::class);
+        $mockRate->expects($this->once())
+            ->method('getCode')
+            ->willReturn('US-TX-*');
+
         $mockRateRepository = $this->createMock(RateRepository::class);
+        $mockRateRepository->expects($this->once())
+            ->method('get')
+            ->willReturn($mockRate);
 
         $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
         $mockTaxjarConfig->expects($this->once())
@@ -749,11 +768,11 @@ class ImportRatesTest extends UnitTestCase
             ])
             ->willReturn([
                 'rates' => [
-                    'some',
-                    'list',
-                    'of',
-                    'values',
-                ],
+                    [
+                        'state' => 'TX',
+                        'zip' => 78758,
+                    ],
+                ]
             ]);
 
         $mockClientFactory = $this->createMock(ClientFactory::class);
@@ -902,11 +921,11 @@ class ImportRatesTest extends UnitTestCase
             ])
             ->willReturn([
                 'rates' => [
-                    'some',
-                    'list',
-                    'of',
-                    'values',
-                ],
+                    [
+                        'state' => 'TX',
+                        'zip' => 78758,
+                    ],
+                ]
             ]);
 
         $mockClientFactory = $this->createMock(ClientFactory::class);
@@ -944,7 +963,17 @@ class ImportRatesTest extends UnitTestCase
             ->willReturn($mockRateModel);
 
         $mockRuleFactory = $this->createMock(RuleFactory::class);
+
+        $mockRate = $this->createMock(Calculation\Rate::class);
+        $mockRate->expects($this->once())
+            ->method('getCode')
+            ->willReturn('US-TX-*');
+
         $mockRateRepository = $this->createMock(RateRepository::class);
+        $mockRateRepository->expects($this->once())
+            ->method('get')
+            ->willReturn($mockRate);
+
 
         $mockTaxjarConfig = $this->createMock(TaxjarConfig::class);
         $mockTaxjarConfig->expects($this->once())


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Acceptance testing of previous PR uncovered an error in rate creation/deletion.

Although the DB schema does not prescribe it, Tax Calculation Rates should be created with unique "codes" and the framework enforces this expectation. Because of this, and because of how TaxCalcRates were being created, if a TaxCalcRate already existed with the given code, it would not be updated, which would lead to inaccurate backup tax rates.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR corrects the issue described above by upsert-ing rates from the API request. For each rate from the request, if a Magento `tax_calculation_rate` already exists with the resulting code, that calculation rate will be updated from the request rate, otherwise a new calculation rate will be created from the request rate.

We also remove any calculation rates complementary to the request rates from the DB by creating a list of the resulting "codes" of all request rates, and then removing all Taxjar-specific calculation rates with codes that do not exist in the list. This modified delete method should work for all instances, as when the extension backup rates configuration is modified from enabled to disabled, a request will not be made, the resulting rates array will be empty and all existing TJ calculation rates would then be complementary.

As an added bonus, while testing, I found that with multiple product tax categories (PTCs) selected, the resulting count of rates displayed in the admin block would be the result of multiplying # of rates by # of PTCs, which turned out to be the number of `tax_calculation` entries created. For whatever reason, each calculation is viewed as an individual rate, even when multiple calculations relate to the same rate. A simple fix was added to the "Block' controller, using `array_unique()` to filter duplicate values when retrieving TJ-rule related rates.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
No noticeable change in performance. The creating of the request rate codes list may take some perceivable amount of time, but rate creation and deletion is still an asynchronous process, so control of browser session is quickly returned to admin user.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
#### Recreate the problem:
1. Before checking out this branch, with backup rates enabled and synced
2. Modify the `rate` value of any Taxjar rate in the `tax_calculation_rates` table
3. From the store configuration page, run "Sync Rates"
4. Observe that the modified rate's value is not corrected/changed

#### Creation:
1. Enable backup rates and save configuration
2. Observe rates are created in bulk actions process
3. Number of rates created matches value stored in config on table `core_config_data`

#### Update with rate difference:
1. With backup rates enabled and synced
2. Modify some `tax_calculation_rates` entry's `rate` value to simulate when a request value differs from DB state
3. Observe the modified rate is now updated with expected value from request

#### Update with Nexus removal triggers deletion:
1. With backup rates enabled and synced, note the existing number of rates.
2. Visit `app.taxjar.com` and remove "nexus" from one region
3. In Magento 2, from the tax admin panel, select the option to sync backup rates.
4. Observe that the resulting rate count is now less that previously observed and any rates for the excluded nexus region are removed.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [ ] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
