### PR TITLE
INT-1990: Backup rates tax class modification queues sync

### DIFF
--- a/Block/Adminhtml/Backup/AbstractTaxClassSelect.php
+++ b/Block/Adminhtml/Backup/AbstractTaxClassSelect.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Block\Adminhtml\Backup;
+
+use Magento\Backend\Block\Template\Context;
+use Magento\Framework\Config\CacheInterface;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Taxjar\SalesTax\Block\Adminhtml\Multiselect;
+use Taxjar\SalesTax\Block\CachesConfiguration;
+
+abstract class AbstractTaxClassSelect extends Multiselect
+{
+    use CachesConfiguration;
+
+    /**
+     * @var CacheInterface
+     */
+    protected $cache;
+
+    public function __construct(
+        CacheInterface $cache,
+        Context $context,
+        array $data = [],
+        ?SecureHtmlRenderer $secureRenderer = null
+    ) {
+        parent::__construct($context, $data, $secureRenderer);
+        $this->cache = $cache;
+    }
+
+    /**
+     * Get the element HTML
+     *
+     * @param AbstractElement $element
+     * @return string
+     */
+    protected function _getElementHtml(AbstractElement $element): string
+    {
+        $element->setSize($this->getSize());
+
+        $this->onCache($this->cache)
+            ->cacheValue(
+                (string) $element->getValue(),
+                $this->getCacheIdentifier()
+            );
+
+        return parent::_getElementHtml($element);
+    }
+
+    abstract function getSize(): int;
+
+    abstract function getCacheIdentifier(): string;
+}

--- a/Block/Adminhtml/Backup/CustomerTaxClassSelect.php
+++ b/Block/Adminhtml/Backup/CustomerTaxClassSelect.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Block\Adminhtml\Backup;
+
+class CustomerTaxClassSelect extends AbstractTaxClassSelect
+{
+    protected const SELECT_LENGTH = 4;
+    protected const CACHE_IDENTIFIER = 'taxjar_salestax_backup_rates_ctcs';
+
+    function getSize(): int
+    {
+        return self::SELECT_LENGTH;
+    }
+
+    function getCacheIdentifier(): string
+    {
+        return self::CACHE_IDENTIFIER;
+    }
+}

--- a/Block/Adminhtml/Backup/ProductTaxClassSelect.php
+++ b/Block/Adminhtml/Backup/ProductTaxClassSelect.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Block\Adminhtml\Backup;
+
+class ProductTaxClassSelect extends AbstractTaxClassSelect
+{
+    protected const SELECT_LENGTH = 4;
+    protected const CACHE_IDENTIFIER = 'taxjar_salestax_backup_rates_ptcs';
+
+    function getSize(): int
+    {
+        return self::SELECT_LENGTH;
+    }
+
+    function getCacheIdentifier(): string
+    {
+        return self::CACHE_IDENTIFIER;
+    }
+}

--- a/Block/Adminhtml/Enabled.php
+++ b/Block/Adminhtml/Enabled.php
@@ -21,10 +21,13 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Backend\Model\UrlInterface;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Taxjar\SalesTax\Block\CachesConfiguration;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
 
 class Enabled extends PopupField
 {
+    use CachesConfiguration;
+
     /**
      * @var string
      */
@@ -103,22 +106,14 @@ class Enabled extends PopupField
         if (!$this->apiKey) {
             $element->setDisabled('disabled');
         } else {
-            $this->_cacheElementValue($element);
+            $this->onCache($this->cache)
+                ->cacheValue(
+                    (string) $element->getValue(),
+                    'taxjar_salestax_config_enabled'
+                );
         }
 
         return parent::_getElementHtml($element) . $this->_toHtml();
-    }
-
-    /**
-     * Cache the element value
-     *
-     * @param AbstractElement $element
-     * @return void
-     */
-    protected function _cacheElementValue(AbstractElement $element)
-    {
-        $elementValue = (string) $element->getValue();
-        $this->cache->save($elementValue, 'taxjar_salestax_config_enabled');
     }
 
     /**

--- a/Block/CachesConfiguration.php
+++ b/Block/CachesConfiguration.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Block;
+
+trait CachesConfiguration
+{
+    protected $configCache;
+
+    protected function onCache($cache): self
+    {
+        $this->configCache = $cache;
+
+        return $this;
+    }
+
+    protected function cacheValue($data, $identifier, array $tags = [], $lifeTime = null): bool
+    {
+        if ($this->configCache) {
+            return $this->configCache->save($data, $identifier, $tags, $lifeTime);
+        }
+
+        return false;
+    }
+
+
+}

--- a/Model/Import/Rule.php
+++ b/Model/Import/Rule.php
@@ -45,7 +45,6 @@ class Rule
      * @param integer $position
      * @param array $rates
      * @throws \Exception
-     * @return void
      */
     public function create($code, $customerClasses, $productClasses, $position, $rates)
     {
@@ -59,7 +58,10 @@ class Rule
         $ruleModel->setPriority(1);
         $ruleModel->setCalculateSubtotal(0);
         $ruleModel->save();
+
         $this->saveCalculationData($ruleModel, $rates);
+
+        return $ruleModel;
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -49,14 +49,14 @@
                     <label>Backup Product Tax Classes</label>
                     <comment>When creating or updating backup tax rules, TaxJar will use these product tax classes.</comment>
                     <source_model>Taxjar\SalesTax\Model\Config\Taxclass\Source\Product</source_model>
-                    <frontend_model>Taxjar\SalesTax\Block\Adminhtml\Multiselect</frontend_model>
+                    <frontend_model>Taxjar\SalesTax\Block\Adminhtml\Backup\ProductTaxClassSelect</frontend_model>
                     <depends><field id="connected">1</field></depends>
                 </field>
                 <field id="customer_tax_classes" translate="label" sortOrder="6" type="multiselect" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Backup Customer Tax Classes</label>
                     <comment>When creating or updating backup tax rules, TaxJar will use these customer tax classes.</comment>
                     <source_model>Taxjar\SalesTax\Model\Config\Taxclass\Source\Customer</source_model>
-                    <frontend_model>Taxjar\SalesTax\Block\Adminhtml\Multiselect</frontend_model>
+                    <frontend_model>Taxjar\SalesTax\Block\Adminhtml\Backup\CustomerTaxClassSelect</frontend_model>
                     <depends><field id="connected">1</field></depends>
                 </field>
                 <field id="debug" translate="label" sortOrder="10" type="select" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Admin store tax UI allows for selection of one or more product or customer tax classes to be configured for backup rates sync, but currently, modifying PTC or CTC selection will not issue the event to trigger backup rates observer. This means that any change to PTC or CTC selection will not be reflected in backup rate selection until the next Crontab sync or backup rates are manually synced by administrator.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
With changes in this PR, the extension will now:
- Cache PTC and CTC config values
- Check for changes to PTC or CTC config in ConfigChanged observer to issue 'taxjar_salestax_import_rates' event
- Purge stale tax calculations related to removed PTCs or CTCs in "create rates" bulk operation

Since a similar method of caching to what was needed for this implementation was already being used in the `Enabled.php` Block class, the current caching logic was abstracted into a trait for reusability.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
No noticeable change in performance. 

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
#### To reproduce bug:
1. From current Backup rates feature branch, navigate to "Stores > Configuration > Sales > Tax"
2. Under "Backup Product Tax Classes" option, select first Product Tax Class option, then save configuration.
3. Enable backup rates feature
4. Observe rates are created, observe number of `tax_calculation` entries in DB.
5. Modify "Backup Product Tax Classes", either selecting a different PTC or multiple PTCs.
6. Observe that Backup Rates do not sync, no change to entries on `tax_calculation` table in DB, only notified that configuration was saved.

#### To prove bug fix:
1. From PR branch, navigate to "Stores > Configuration > Sales > Tax"
2. Under "Backup Product Tax Classes" option, select first Product Tax Class option, then save configuration.
3. Enable backup rates feature
4. Observe rates are created, observe number of `tax_calculation` entries in DB.
5. Modify "Backup Product Tax Classes", either selecting a different PTC or multiple PTCs.
6. Observe notification that configuration was saved as well as Backup Rates are being synced.
7. Observe bulk actions to sync backup rates queued

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [ ] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
