### PR TITLE
Refactor DI for M2 v2.3 compatibility

### DIFF
--- a/Block/Adminhtml/Backup/AbstractTaxClassSelect.php
+++ b/Block/Adminhtml/Backup/AbstractTaxClassSelect.php
@@ -7,7 +7,6 @@ namespace Taxjar\SalesTax\Block\Adminhtml\Backup;
 use Magento\Backend\Block\Template\Context;
 use Magento\Framework\Config\CacheInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
-use Magento\Framework\View\Helper\SecureHtmlRenderer;
 use Taxjar\SalesTax\Block\Adminhtml\Multiselect;
 use Taxjar\SalesTax\Block\CachesConfiguration;
 
@@ -26,10 +25,9 @@ abstract class AbstractTaxClassSelect extends Multiselect
     public function __construct(
         CacheInterface $cache,
         Context $context,
-        array $data = [],
-        ?SecureHtmlRenderer $secureRenderer = null
+        array $data = []
     ) {
-        parent::__construct($context, $data, $secureRenderer);
+        parent::__construct($context, $data);
         $this->cache = $cache;
     }
 


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
There is a `Block` M2 class related to rendering product and customer tax classes (PTCs and CTCs) in the browser using HTML multi-select form elements. The `Block` class uses DI to include its parent constructor parameters. One of the optional parent parameters may not be present in installations of M2 v2.3, and causes M2 DI compilation error if missing.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Removes unnecessary constructor parameter that can cause DI compilation error in M2 v2.3.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Improves backwards-compatibility

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
Desired behavior:
1. Install Magento 2.3.x via Composer 2
2. Enable TaxJar extension `bin/magento module:enable Taxjar_SalesTax --clear-static-content`
3. Upgrade code base `bin/magento setup:upgrade`
4. Compile DI configuration `bin/magento setup:di:compile`
5. Observe compiled successfully

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
