### PR TITLE
INT-2041: Command flag option to force API transaction sync

### DIFF
--- a/Block/Adminhtml/TransactionSync/Form.php
+++ b/Block/Adminhtml/TransactionSync/Form.php
@@ -104,12 +104,32 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         );
 
         $fieldset->addField(
-            'force',
-            'checkbox',
+            'force_sync_flag',
+            'select',
             [
-                'name' => 'force',
-                'label' => __('Force'),
-                'title' => __('Force'),
+                'name' => 'force_sync_flag',
+                'label' => __('Force sync'),
+                'title' => __('Enable force transaction sync'),
+                'values' => [
+                    [
+                        'value' => 0,
+                        'label' => 'No',
+                    ],
+                    [
+                        'value' => 1,
+                        'label' => 'Yes',
+                    ],
+                ],
+                'class' => 'select',
+                'after_element_html' => '
+                    <span class="tooltip-top" style="margin-left: 0.5rem">
+                        <a href="#" class="tooltip-toggle">What is this?</a>
+                        <span class="tooltip-content">
+                            The "Force sync" option will update all selected orders and credit
+                            memos in TaxJar regardless of last updated or synced dates.
+                        </span>
+                    </span>
+                ',
             ]
         );
 

--- a/Block/Adminhtml/TransactionSync/Form.php
+++ b/Block/Adminhtml/TransactionSync/Form.php
@@ -103,6 +103,16 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             ]
         );
 
+        $fieldset->addField(
+            'force',
+            'checkbox',
+            [
+                'name' => 'force',
+                'label' => __('Force'),
+                'title' => __('Force'),
+            ]
+        );
+
         $form->setAction('#');
         $form->setUseContainer(true);
         $form->setId(self::FORM_ELEMENT_ID);

--- a/Console/Command/SyncTransactionsCommand.php
+++ b/Console/Command/SyncTransactionsCommand.php
@@ -17,6 +17,7 @@ class SyncTransactionsCommand extends Command
     const FROM_ARGUMENT = '<from>';
     const TO_ARGUMENT = '<to>';
     const OPTION_FORCE = 'force';
+    const OPTION_FORCE_SHORT = 'f';
 
     /**
      * @var \Magento\Framework\App\State
@@ -66,7 +67,7 @@ class SyncTransactionsCommand extends Command
             ->setDescription('Sync transactions from Magento to TaxJar')
             ->addArgument(self::FROM_ARGUMENT, InputArgument::OPTIONAL)
             ->addArgument(self::TO_ARGUMENT, InputArgument::OPTIONAL)
-            ->addOption(self::OPTION_FORCE, 'f');
+            ->addOption(self::OPTION_FORCE, self::OPTION_FORCE_SHORT);
     }
 
     /**

--- a/Console/Command/SyncTransactionsCommand.php
+++ b/Console/Command/SyncTransactionsCommand.php
@@ -16,6 +16,7 @@ class SyncTransactionsCommand extends Command
 {
     const FROM_ARGUMENT = '<from>';
     const TO_ARGUMENT = '<to>';
+    const OPTION_FORCE = 'force';
 
     /**
      * @var \Magento\Framework\App\State
@@ -64,7 +65,8 @@ class SyncTransactionsCommand extends Command
         $this->setName('taxjar:transactions:sync')
             ->setDescription('Sync transactions from Magento to TaxJar')
             ->addArgument(self::FROM_ARGUMENT, InputArgument::OPTIONAL)
-            ->addArgument(self::TO_ARGUMENT, InputArgument::OPTIONAL);
+            ->addArgument(self::TO_ARGUMENT, InputArgument::OPTIONAL)
+            ->addOption(self::OPTION_FORCE, 'f');
     }
 
     /**
@@ -80,12 +82,11 @@ class SyncTransactionsCommand extends Command
         try {
             $this->state->setAreaCode('adminhtml');
             $this->logger->console($output);
-            $this->backfillTransactions->execute(
-                new Observer([
-                    'from_date' => $input->getArgument(self::FROM_ARGUMENT),
-                    'to_date' => $input->getArgument(self::TO_ARGUMENT)
-                ])
-            );
+            $this->backfillTransactions->execute(new Observer([
+                'from_date' => $input->getArgument(self::FROM_ARGUMENT),
+                'to_date' => $input->getArgument(self::TO_ARGUMENT),
+                'force' => (bool) $input->getOption(self::OPTION_FORCE)
+            ]));
         } catch (\Exception $e) {
             $output->writeln(PHP_EOL . '<error>Failed to sync transactions: ' . $e->getMessage() . '</error>');
         }

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -115,10 +115,10 @@ class Transaction
     /**
      * Check if a transaction is synced
      *
-     * @param string $syncDate
+     * @param string|null $syncDate
      * @return bool
      */
-    protected function isSynced(string $syncDate): bool
+    protected function isSynced(?string $syncDate): bool
     {
         return ! (empty($syncDate) || $syncDate == '0000-00-00 00:00:00');
     }

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -21,6 +21,7 @@ use DateTime;
 use Exception;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\AbstractModel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -33,7 +34,7 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
     protected const SYNCABLE_COUNTRIES = ['US'];
 
     /**
-     * @var OrderInterface
+     * @var OrderInterface|AbstractModel
      */
     protected $originalOrder;
 
@@ -126,7 +127,8 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
                 'api'
             );
 
-            $this->originalOrder->setData('tj_salestax_sync_date', gmdate('Y-m-d H:i:s'))->save();
+            $this->originalOrder->setData('tj_salestax_sync_date', gmdate('Y-m-d H:i:s'));
+            $this->originalOrder->getResource()->saveAttribute($this->originalOrder, 'tj_salestax_sync_date');
         } catch (LocalizedException $e) {
             $this->logger->log('Error: ' . $e->getMessage(), 'error');
             $error = json_decode($e->getMessage());

--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -192,7 +192,7 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
 
     /**
      * Handles case where error occurs when POSTing a resource that already
-     * exists of PUTing a resource that has not been created yet.
+     * exists or PUTing a resource that has not been created yet.
      *
      * @param object $error `jsonDecode()`ed response error message object
      * @param string $method HTTP method used in request

--- a/Test/BaseTestCase.php
+++ b/Test/BaseTestCase.php
@@ -41,4 +41,19 @@ class BaseTestCase extends TestCase
         $property->setAccessible(true);
         return $property->getValue($object);
     }
+
+    /**
+     * @param $object
+     * @param $propertyName
+     * @param $value
+     * @throws \ReflectionException
+     */
+    public function setProperty($object, $propertyName, $value)
+    {
+        $reflection = new \ReflectionProperty($object, $propertyName);
+        $reflection->setAccessible(true);
+        $reflection->setValue($object, $value);
+
+        return $object;
+    }
 }

--- a/Test/Unit/Observer/BackfillTransactionsTest.php
+++ b/Test/Unit/Observer/BackfillTransactionsTest.php
@@ -126,7 +126,7 @@ class BackfillTransactionsTest extends UnitTestCase
         $this->searchCriteriaBuilder->expects($this->exactly(1))->method('create')->willReturn($mockCriteria);
 
         $sut = $this->getTestSubject();
-        $result = $sut->getSearchCriteria([]);
+        $result = $sut->getSearchCriteria();
 
         self::assertInstanceOf(SearchCriteria::class, $result);
     }

--- a/Test/Unit/UnitTestCase.php
+++ b/Test/Unit/UnitTestCase.php
@@ -11,13 +11,13 @@ use Taxjar\SalesTax\Test\BaseTestCase;
 class UnitTestCase extends BaseTestCase
 {
     /**
-     * @var ObjectManagerInterface
+     * @param int|string $dataName
+     *
+     * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
-    protected $objectManager;
-
-    public function __construct()
+    public function __construct(?string $name = null, array $data = [], $dataName = '')
     {
-        parent::__construct();
+        parent::__construct($name, $data, $dataName);
 
         $this->objectManager = new ObjectManager($this);
     }

--- a/view/adminhtml/templates/transaction_sync.phtml
+++ b/view/adminhtml/templates/transaction_sync.phtml
@@ -66,6 +66,7 @@
             window.backfillTransactions = function(syncButton) {
                 var fromDate = $('#date_from').val();
                 var toDate = $('#date_to').val();
+                var force = $('#force_sync_flag').val()
 
                 $('#transaction-sync-log').find('> pre').html('Syncing transactions to TaxJar, please wait...');
 
@@ -75,6 +76,7 @@
                     data: {
                         from_date: fromDate,
                         to_date: toDate,
+                        force: force,
                         store: '<?php echo $this->getRequest()->getParam('store') ?>',
                         website: '<?php echo $this->getRequest()->getParam('website') ?>',
                     }

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -15,3 +15,7 @@
  */
 @import '_address-validation.less';
 @import '_admin-configuration.less';
+
+.tooltip-top {
+    .lib-tooltip(top);
+}


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Users have reached out regarding issues with syncing M2 transactions where the state of the order has changed, and those changes need to be reflected in the TaxJar service, but due to the comparison of a transaction's `updated_at `and `tj_salestax_last_sync` dates, the transaction will continue to be skipped.

Currently, the only acceptable workaround for this problem is for M2 administrators to manually modify date values in DB, which for a large number of transactions.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Adds flag `-f|--force` to CLI command `taxjar:transaction:sync` ![image](https://user-images.githubusercontent.com/47947793/137945544-7790ac7c-7d8d-4b05-9fad-ddc69dc47653.png)

- Refactors methods `\Taxjar\SalesTax\Model\Transaction\Order::push()` and `\Taxjar\SalesTax\Model\Transaction\Refund::push()` to accept optional parameters for http method and force-flag option.
- Adds "Force" select element (and tooltip) to the TaxJar transaction sync form 
![image](https://user-images.githubusercontent.com/47947793/138459614-06e1b765-539a-46a5-94c8-bf1ec19f7152.png)

- Adds unit test coverage for `\Taxjar\SalesTax\Model\Transaction\Backfill::process()` with `force` feature

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This should not have much if any affect on current extension performance,  but should resolve an on-going customer issue.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. With TaxJar's transaction sync feature enabled, *place an order*, either as customer, or as admin on behalf of customer, then invoice and mark shipped as necessary to move order status to "complete".
2. Verify that the order transaction has been persisted to TaxJar.
3. In DB, manually modify a value on the order such as an address value, or the order's `created_at` value.
4. From extension UI, attempt to sync transactions WITHOUT force-flag enabled. (using a date range containing the order)
5. Observe values not updated in TaxJar.
6. From extension UI, attempt to sync transactions WITH force-flag enabled (again, with proper date range).
7. Observe values updated in TaxJar.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
