### PR TITLE
INT 1963: Sync partially cancelled order items

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -19,7 +19,6 @@ namespace Taxjar\SalesTax\Model;
 
 use Magento\Bundle\Model\Product\Price;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\Data\OrderInterface;
 use Taxjar\SalesTax\Helper\Data as TaxjarHelper;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
@@ -250,8 +249,13 @@ class Transaction
             }
 
             $itemId = $item->getOrderItemId() ? $item->getOrderItemId() : $item->getItemId();
-            $discount = (float) $item->getDiscountAmount();
-            $tax = (float) $item->getTaxAmount();
+            $discount = (float) $item->getDiscountInvoiced();
+            $tax = (float) $item->getTaxInvoiced();
+
+            if ($type == 'refund' && isset($creditMemoItem)) {
+                $discount = (float) $creditMemoItem->getDiscountAmount();
+                $tax = (float) $creditMemoItem->getTaxAmount();
+            }
 
             if (isset($parentDiscounts[$itemId])) {
                 $discount = $parentDiscounts[$itemId] ?: $discount;

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -219,7 +219,7 @@ class Transaction
 
             $parentItem = $item->getParentItem();
             $unitPrice = (float) $item->getPrice();
-            $quantity = (int) $item->getQtyOrdered();
+            $quantity = (int) $item->getQtyInvoiced();
 
             if ($type == 'refund' && isset($creditMemoItem)) {
                 $quantity = (int) $creditMemoItem->getQty();

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -53,11 +53,11 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
     public function build(OrderInterface $order): array
     {
         $createdAt = new DateTime($order->getCreatedAt());
-        $subtotal = (float) $order->getSubtotal();
-        $shipping = (float) $order->getShippingAmount();
-        $discount = (float) $order->getDiscountAmount();
+        $subtotal = (float) $order->getSubtotalInvoiced();
+        $shipping = (float) $order->getShippingInvoiced();
+        $discount = (float) $order->getDiscountInvoiced();
         $shippingDiscount = (float) $order->getShippingDiscountAmount();
-        $salesTax = (float) $order->getTaxAmount();
+        $salesTax = (float) $order->getTaxInvoiced();
 
         $this->originalOrder = $order;
 

--- a/Test/Unit/Model/TransactionTest.php
+++ b/Test/Unit/Model/TransactionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Test\Unit\Model;
+
+use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;
+use Taxjar\SalesTax\Model\Transaction;
+use Taxjar\SalesTax\Test\Unit\UnitTestCase;
+
+class TransactionTest extends UnitTestCase
+{
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface|mixed|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $scopeConfig;
+    /**
+     * @var mixed|\PHPUnit\Framework\MockObject\MockObject|\Taxjar\SalesTax\Model\ClientFactory
+     */
+    private $clientFactory;
+    /**
+     * @var \Magento\Catalog\Model\ProductRepository|mixed|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $productRepository;
+    /**
+     * @var \Magento\Directory\Model\RegionFactory|mixed|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $regionFactory;
+    /**
+     * @var \Magento\Tax\Api\TaxClassRepositoryInterface|mixed|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $taxClassRepository;
+    /**
+     * @var mixed|\PHPUnit\Framework\MockObject\MockObject|\Taxjar\SalesTax\Model\Logger
+     */
+    private $logger;
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface|mixed|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $mockObjectManager;
+    /**
+     * @var mixed|\PHPUnit\Framework\MockObject\MockObject|\Taxjar\SalesTax\Helper\Data
+     */
+    private $helper;
+    /**
+     * @var mixed|\PHPUnit\Framework\MockObject\MockObject|TaxjarConfig
+     */
+    private $taxjarConfig;
+    /**
+     * @var mixed|\PHPUnit\Framework\MockObject\MockObject|\Taxjar\SalesTax\Model\Client
+     */
+    private $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->scopeConfig = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+        $this->clientFactory =  $this->createMock(\Taxjar\SalesTax\Model\ClientFactory::class);
+        $this->productRepository =  $this->createMock(\Magento\Catalog\Model\ProductRepository::class);
+        $this->regionFactory =  $this->createMock(\Magento\Directory\Model\RegionFactory::class);
+        $this->taxClassRepository =  $this->createMock(\Magento\Tax\Api\TaxClassRepositoryInterface::class);
+        $this->logger =  $this->createMock(\Taxjar\SalesTax\Model\Logger::class);
+        $this->mockObjectManager =  $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
+        $this->helper =  $this->createMock(\Taxjar\SalesTax\Helper\Data::class);
+        $this->taxjarConfig =  $this->createMock(\Taxjar\SalesTax\Model\Configuration::class);
+        $this->client = $this->createMock(\Taxjar\SalesTax\Model\Client::class);
+        $this->clientFactory->expects($this->once())->method('create')->willReturn($this->client);
+    }
+
+    public function testBuildLineItems()
+    {
+        $mockOrder = $this->createMock(\Magento\Sales\Model\Order::class);
+        $mockItem = $this->getMockBuilder(\Magento\Sales\Model\Order\Item::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getItemId',
+                'getProductType',
+                'getPrice',
+                'getQtyInvoiced',
+                'getTaxAmount',
+                'getSku',
+                'getName',
+            ])
+            ->addMethods(['getTjPtc']) // The interface that provides this method signature is generated in compile
+            ->getMock();
+        $mockItem->expects($this->once())->method('getItemId')->willReturn(9);
+        $mockItem->expects($this->once())->method('getPrice')->willReturn(60.0);
+        $mockItem->expects($this->once())->method('getQtyInvoiced')->willReturn(2);
+        $mockItem->expects($this->once())->method('getProductType')->willReturn('simple');
+        $mockItem->expects($this->once())->method('getTaxAmount')->willReturn(5.0);
+        $mockItem->expects($this->any())->method('getTjPtc')->willReturn('22222');
+        $mockItem->expects($this->any())->method('getSku')->willReturn('some-sku');
+        $mockItem->expects($this->any())->method('getName')->willReturn('A great product');
+
+        $sut = $this->getTestSubject();
+        $result = $this->callMethod($sut, 'buildLineItems', [$mockOrder, [$mockItem]]);
+
+        self::assertSame([
+            'line_items' => [
+                [
+                    'id' => 9,
+                    'quantity' => 2,
+                    'product_identifier' => 'some-sku',
+                    'description' => 'A great product',
+                    'unit_price' => 60.0,
+                    'discount' => 0.0,
+                    'sales_tax' => 5.0,
+                    'product_tax_code' => '22222',
+                ],
+            ],
+        ], $result);
+    }
+
+    protected function getTestSubject(): Transaction
+    {
+        return new Transaction(
+            $this->scopeConfig,
+            $this->clientFactory,
+            $this->productRepository,
+            $this->regionFactory,
+            $this->taxClassRepository,
+            $this->logger,
+            $this->mockObjectManager,
+            $this->helper,
+            $this->taxjarConfig
+        );
+    }
+}


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
M2 extension does not account for "cancelled" items on completed orders.

When an order is created for some positive quantity (X), a quantity less than X is invoiced and shipped, and the remaining quantity is subsequently cancelled, no credit memo (refund) is created for the cancelled items since they were never invoiced. Since there is not credit memo, the API extension counts the cancelled item quantities as valid and still parses them to be sent to TaxJar.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
The act of invoicing an order creates the taxable event, therefore it should actually be the _invoiced_ amount that is used in line item calculations. The tax burden is dependent upon some exchange of goods, so that the act of "creating" the order in M2 is more akin to creating a COD purchase order request, and it is not until invoicing that a taxable exchange has occurred.

For those reasons, the `\Taxjar\SalesTax\Model\Transaction\Order::class` class has been refactored to use the actual invoiced amounts when building transaction sync request payloads. The `\Taxjar\SalesTax\Model\Transaction::class` class now uses the invoiced quantity instead of the originally requested quantity.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Corrects known issue, but no measurable performance gains or losses.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Checkout the "develop" main branch.
2. With TaxJar activated and transaction sync enabled, place an order on behalf of customer for qty > 1.
3. Invoice the order for less than total quantity and ship that same less-than-total quantity, then cancel the remaining portion of the order.
4. Observe that the order's "grand total" and "tax total" does not reflect what is shown in M2 as the cost of the cancelled item(s) is/are still included in the TaxJar transaction amounts.
5. Checkout this PR branch, run setup DI and upgrade commands.
6. Sync backup rates with "force" flag either via UI or CLI.
7. Observe that values in TaxJar have been overwritten with updated values which account for cancelled item and tax amounts.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
