### PR TITLE
INT-2108: Address validation JS error

### DIFF
--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -124,6 +124,7 @@ function (
                 originalAddress.country_id = addrs[id].address.countryId;
                 originalAddress.postcode = addrs[id].address.postcode;
                 originalAddress.region_id = addrs[id].address.regionId;
+                originalAddress.telephone = addrs[id].address.telephone ?? quote.shippingAddress().telephone;
 
                 addrs[id].address.street.forEach(function(item, index) {
                    originalAddress.street[index] = item;


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Closes #194

Open issue was received in July '21, confirmed by 2nd contributor in Nov. '21.

Bug was triaged and confirmed, when a TaxJar-validated version of an existing customer's STORED address is selected, the telephone number is not copied to the validated address object, making the address invalid and preventing checkout.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
When our JS attempts to update the selected address, it will try to persist the telephone number from the selected address and if one does not exist, it will be retrieved from the shipping address.

I would've liked to include some JS specs with this small change, but since we do not have any JS testing practices established yet, it seemed like an unnecessary lift to unblock this  currently-unusable feature.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Break fix

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
#### Replicate issue:
1. Checkout current develop or trx-backfill-feat branch
2. From frontend, create user, add item to cart, navigate to checkout
3. Create and store new (REAL) address during checkout and be sure to only input the 5-digit zip code, not 5+4, complete checkout
4. As admin, enable TJ/Address validation
5. As user, add item to cart, navigate to checkout
6. With the 5-digit zip-code address selected for shipping, select the 5+4 version of the same address under "Suggested Addresses", select any shipping option and proceed. ![Screen Shot 2021-11-17 at 1 18 46 PM](https://user-images.githubusercontent.com/47947793/142273395-6c204e64-4c5c-4342-8423-9c2171f16bdc.png)
7. No matter what option is selected under billing address, the user is alerted that that are unable to proceed with checkout due to a missing telephone number ![Screen Shot 2021-11-17 at 1 19 20 PM](https://user-images.githubusercontent.com/47947793/142273492-a02d090b-5eb0-42cc-bd3d-c1d66d144dcc.png)

#### Verify solution:
1. Checkout PR branch
2. As previously created user, navigate to checkout
3. Select the 5+4 version of the saved shipping address under "Suggested Addresses", select any shipping option and proceed
4. Whether the "Billing Address same as shipping address" option is selected or not, observe that the same user is now able to successfully checkout with same cart/address configuration.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
