### PR TITLE
INT-2090: Removes empty adjustment refund line item

### DIFF
--- a/Model/Transaction/Refund.php
+++ b/Model/Transaction/Refund.php
@@ -96,7 +96,7 @@ class Refund extends \Taxjar\SalesTax\Model\Transaction
                 $itemDiscounts += $lineItem['discount'];
             }
 
-            if ($adjustmentRefund) {
+            if ($adjustmentRefund > 0) {
                 $this->request['line_items'][] = [
                     'id' => 'adjustment-refund',
                     'quantity' => 1,


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
When building creditmemos, a $0 adjustment-refund line item is included when no refund is present.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Only includes adjustment-refund line item if adjustment-refund amount is greater than $0

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Checked out current feature branch and synced a credit memo to verify bug.
2. Implemented fix
3. Re-synced (w/force) same creditmemo
4. Verified refund line item was not present

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
