### PR TITLE
INT-2140: Order page additional info UI template

### DIFF
--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View;
+
+use Magento\Directory\Helper\Data as DirectoryHelper;
+use Magento\Framework\Json\Helper\Data as JsonHelper;
+use Magento\Framework\Registry;
+use Taxjar\SalesTax\Helper\Data as TaxjarHelper;
+
+class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\Block\Widget\Tab\TabInterface
+{
+    /**
+     * Template
+     *
+     * @var string
+     */
+    protected $_template = 'Taxjar_SalesTax::order/view/tab/taxjar/info.phtml';
+
+    /**
+     * @var TaxjarHelper
+     */
+    private TaxjarHelper $tjHelper;
+
+    /**
+     * @var \Magento\Framework\Registry
+     */
+    private $coreRegistry;
+
+    /**
+     * @param TaxjarHelper $tjHelper
+     * @param \Magento\Framework\Registry $coreRegistry
+     * @param \Magento\Backend\Block\Template\Context $context
+     * @param array $data
+     * @param JsonHelper|null $jsonHelper
+     * @param DirectoryHelper|null $directoryHelper
+     */
+    public function __construct(
+        TaxjarHelper $tjHelper,
+        \Magento\Framework\Registry $coreRegistry,
+        \Magento\Backend\Block\Template\Context $context,
+        array $data = [],
+        ?JsonHelper $jsonHelper = null,
+        ?DirectoryHelper $directoryHelper = null
+    ) {
+        $this->tjHelper = $tjHelper;
+        $this->coreRegistry = $coreRegistry;
+
+        parent::__construct($context, $data, $jsonHelper, $directoryHelper);
+    }
+
+    /**
+     * @return \Magento\Framework\Phrase|string
+     */
+    public function getTabLabel()
+    {
+        return __('TaxJar Information');
+    }
+
+    /**
+     * @return \Magento\Framework\Phrase|string
+     */
+    public function getTabTitle()
+    {
+        return __('TaxJar Information');
+    }
+
+    /**
+     * @return bool
+     */
+    public function canShowTab()
+    {
+        return $this->tjHelper->isEnabled();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHidden()
+    {
+        return !$this->tjHelper->isEnabled();
+    }
+
+    /**
+     * Retrieve order model instance
+     *
+     * @return \Magento\Sales\Model\Order
+     */
+    public function getOrder()
+    {
+        return $this->coreRegistry->registry('current_order');
+    }
+
+    /**
+     * Get order admin date
+     *
+     * @param int $syncedAt
+     * @return \DateTime
+     */
+    public function getOrderSyncedAtDate($syncedAt)
+    {
+        return $this->_localeDate->date(new \DateTime($syncedAt));
+    }
+}

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -65,6 +65,17 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->priceCurrency = $priceCurrency;
     }
 
+    public function isEnabled(
+        $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+        $scopeCode = null
+    ): bool {
+        return $this->scopeConfig->getValue(
+            \Taxjar\SalesTax\Model\Configuration::TAXJAR_ENABLED,
+            $scope,
+            $scopeCode
+        );
+    }
+
     /**
      * Transaction Sync enabled check
      *

--- a/Test/Unit/Block/Adminhtml/Order/View/SyncedTest.php
+++ b/Test/Unit/Block/Adminhtml/Order/View/SyncedTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Taxjar\SalesTax\Test\Unit\Block\Adminhtml\Order\View;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\TestFramework\ObjectManager;
+use Taxjar\SalesTax\Block\Adminhtml\Order\View\Synced;
+use Taxjar\SalesTax\Test\Unit\UnitTestCase;
+
+class SyncedTest extends UnitTestCase
+{
+    public function testClassExists()
+    {
+        static::assertTrue(class_exists(Synced::class));
+    }
+
+    public function testGetSyncedAtDate()
+    {
+        $orderMock = $this->getMockBuilder(OrderInterface::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getTjSalestaxSyncDate']) // added to DB in module's setup script
+            ->getMockForAbstractClass();
+        $orderMock->expects(static::once())->method('getTjSalestaxSyncDate');
+        $sut = $this->objectManager->getObject(Synced::class);
+        $sut->getSyncedAtDate($orderMock);
+    }
+}
+

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Taxjar\SalesTax\Test\Unit\Helper;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Taxjar\SalesTax\Model\Configuration;
+
 class DataTest extends \Taxjar\SalesTax\Test\Unit\UnitTestCase
 {
     /**
@@ -52,6 +55,23 @@ class DataTest extends \Taxjar\SalesTax\Test\Unit\UnitTestCase
             ->getMockForAbstractClass();
 
         $this->setExpectations();
+    }
+
+    public function testIsEnabled()
+    {
+        $scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfigMock->expects(static::atLeastOnce())
+            ->method('getValue')
+            ->with(Configuration::TAXJAR_ENABLED, 'store', null)
+            ->willReturn(true);
+
+        $this->contextMock->expects(static::atLeastOnce())
+            ->method('getScopeConfig')
+            ->willReturn($scopeConfigMock);
+
+        $this->setExpectations();
+
+        static::assertTrue($this->sut->isEnabled());
     }
 
     /**

--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -18,8 +18,14 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceBlock name="order_info">
-            <block class="Taxjar\SalesTax\Block\Adminhtml\Order\View\Synced" name="sales_order_view_synced" template="order/view/synced.phtml" after="-" />
+        <referenceBlock name="sales_order_tabs">
+            <referenceBlock name="order_info">
+                <block class="Taxjar\SalesTax\Block\Adminhtml\Order\View\Synced" name="sales_order_view_synced" template="order/view/synced.phtml" after="-" />
+            </referenceBlock>
+            <action method="addTab">
+                <argument name="name" xsi:type="string">taxjar_info</argument>
+                <argument name="block" xsi:type="string">Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View\Info</argument>
+            </action>
         </referenceBlock>
     </body>
 </page>

--- a/view/adminhtml/templates/order/view/tab/taxjar/info.phtml
+++ b/view/adminhtml/templates/order/view/tab/taxjar/info.phtml
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+/** @var $block \Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View\Info */
+
+$order = $block->getOrder();
+$syncDate = $order->getData('tj_salestax_sync_date');
+if ($syncDate) {
+    $orderAdminDate = $block->formatDate(
+        $block->getOrderSyncedAtDate($syncDate),
+        \IntlDateFormatter::MEDIUM,
+        true
+    );
+}
+?>
+
+<section class="admin__page-section">
+    <div class="admin__page-section-title">
+        <span class="title"><?= $block->escapeHtml(__('TaxJar Information')) ?></span>
+    </div>
+    <div class="admin__page-section-content">
+        <div class="admin__page-section-item">
+            <div class="admin__page-section-item-title">
+                <span class="title"><?= $block->escapeHtml(__('Last Synced At')) ?></span>
+            </div>
+            <div class="admin__page-section-item-content">
+                <span><?= $orderAdminDate ?? 'Not synced' ?></span>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Refactor logging to increase visibility similar to recent Woo updates.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Adds Taxjar section to Sales Order view

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
This PR can be manually tested by viewing a completed, "synced" Sales order in Magento. A tab titled "Taxjar Information" will be added to Sales Order view.

![image](https://user-images.githubusercontent.com/47947793/147004379-277a25ff-885a-42cd-b50d-87bf58d31909.png)

Unit test coverage:
- `Test/Unit/Block/Adminhtml/Order/View/SyncedTest.php`
- `Test/Unit/Helper/DataTest.php`

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [x] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
- [ ] PHP 5.x
