### PR TITLE
Version 1.8.0 (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.8.0] - 2021-12-06
+- Improve transaction backfill by making process asynchronous
+- Add "force sync" feature to transaction sync and transaction backfill
+- Fix address validation issues when checking out as existing user (thanks @sanchit-redmonks)
+- Fix creditmemo transaction sync bug of no-cost line item
+- Fix issue parsing partial creditmemo discounts and order invoiced amounts
+
 ## [1.7.1] - 2021-11-08
 - Fix minor code standards issue
 
@@ -244,7 +251,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Initial release of our Magento 2 extension.** Sales tax calculations at checkout with backup zip-based rates powered by TaxJar. Supports product exemptions, shipping taxability, sourcing logic, and international calculations in more than 30 countries.
 - **Special promo sales tax calculations for Magento merchants.** Existing M2 beta users must upgrade to this version to receive special promo calculations at checkout using our new API endpoint.
 
-[Unreleased]: https://github.com/taxjar/taxjar-magento2-extension/compare/v1.7.1..HEAD
+[Unreleased]: https://github.com/taxjar/taxjar-magento2-extension/compare/v1.8.0..HEAD
+[1.8.0]: https://github.com/taxjar/taxjar-magento2-extension/compare/v1.7.1...v1.8.0
 [1.7.1]: https://github.com/taxjar/taxjar-magento2-extension/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/taxjar/taxjar-magento2-extension/compare/v1.6.5...v1.7.0
 [1.6.5]: https://github.com/taxjar/taxjar-magento2-extension/compare/v1.6.4...v1.6.5

--- a/Console/Command/SyncTransactionsCommand.php
+++ b/Console/Command/SyncTransactionsCommand.php
@@ -3,6 +3,7 @@
 namespace Taxjar\SalesTax\Console\Command;
 
 use Magento\Framework\App\State;
+use Magento\Framework\Event\Manager;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Event\Observer;
 use Symfony\Component\Console\Command\Command;
@@ -25,7 +26,7 @@ class SyncTransactionsCommand extends Command
     protected $state;
 
     /**
-     * @var \Magento\Framework\Event\ManagerInterface
+     * @var \Magento\Framework\Event\ManagerInterface|Manager
      */
     protected $eventManager;
 
@@ -41,13 +42,13 @@ class SyncTransactionsCommand extends Command
 
     /**
      * @param State $state
-     * @param ManagerInterface $eventManager
+     * @param ManagerInterface|Manager $eventManager
      * @param Logger $logger
      * @param BackfillTransactions $backfillTransactions
      */
     public function __construct(
         State $state,
-        ManagerInterface $eventManager,
+        Manager $eventManager,
         Logger $logger,
         BackfillTransactions $backfillTransactions
     ) {
@@ -74,7 +75,7 @@ class SyncTransactionsCommand extends Command
      * @param InputInterface $input
      * @param OutputInterface $output
      *
-     * @return string
+     * @return void
      */
     protected function execute(
         InputInterface $input,

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -24,7 +24,7 @@ use Magento\Tax\Model\Config as MagentoTaxConfig;
 
 class Configuration
 {
-    const TAXJAR_VERSION                    = '1.7.1';
+    const TAXJAR_VERSION                    = '1.8.0';
     const TAXJAR_AUTH_URL                   = 'https://app.taxjar.com';
     const TAXJAR_API_URL                    = 'https://api.taxjar.com/v2';
     const TAXJAR_SANDBOX_API_URL            = 'https://api.sandbox.taxjar.com/v2';

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
     "name": "taxjar/module-taxjar",
     "description": "TaxJar Sales Tax Module for Magento 2",
     "type": "magento2-module",
-    "version": "1.7.1",
+    "version": "1.8.0",
     "license": "OSL-3.0",
     "require": {
-        "magento/framework": "^100.1.0|^101.0.0|^102.0.0|^103.0.0"
+        "magento/framework": "^102.0.0|^103.0.0"
     },
     "autoload": {
         "files": [ "registration.php" ],

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -44,4 +44,19 @@
     <type name="Magento\Sales\Block\Adminhtml\Order\View">
         <plugin name="taxjar_sales_order_view" type="Taxjar\SalesTax\Plugin\Sales\Block\Adminhtml\Order\View"/>
     </type>
+    <type name="Taxjar\SalesTax\Console\Command\SyncProductCategoriesCommand">
+        <arguments>
+            <argument name="state" xsi:type="object">Magento\Framework\App\State\Proxy</argument>
+            <argument name="logger" xsi:type="object">Taxjar\SalesTax\Model\Logger\Proxy</argument>
+            <argument name="importCategories" xsi:type="object">Taxjar\SalesTax\Observer\ImportCategories\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Taxjar\SalesTax\Console\Command\SyncTransactionsCommand">
+        <arguments>
+            <argument name="state" xsi:type="object">Magento\Framework\App\State\Proxy</argument>
+            <argument name="eventManager" xsi:type="object">Magento\Framework\Event\Manager\Proxy</argument>
+            <argument name="logger" xsi:type="object">Taxjar\SalesTax\Model\Logger\Proxy</argument>
+            <argument name="backfillTransactions" xsi:type="object">Taxjar\SalesTax\Observer\BackfillTransactions\Proxy</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Version 1.8.0

After contacting M2 support, it was confirmed that the use of Proxy classes in dependency injection XML config will correct issue with Magento Docker Cloud v2.3.7-p2. We were provided with a simple patch file containing the necessary DI specifications which was confirmed by M2 support to resolve the issue and those changes are included with this version bump.

While not immediately clear why this change is just now necessary, the use of Proxy classes in console command DI config is a standard practice as documented [here](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/proxies.html).

See M2 support reply below:

![image](https://user-images.githubusercontent.com/47947793/147957225-7d96160c-1c1d-461f-97dd-bd67c5a0cf1c.png)