### PR TITLE
XC-9: Checkout address phone numbers

### DIFF
--- a/view/adminhtml/web/js/suggested_addresses_admin.js
+++ b/view/adminhtml/web/js/suggested_addresses_admin.js
@@ -102,8 +102,8 @@ define([
                                 forms[x].find('input[name*="[street][0]"]').val(selectedAddress.street);
                                 forms[x].find('input[name*="[city]"]').val(selectedAddress.city);
                                 forms[x].find('select[name*="[region_id]"]').val(selectedAddress.regionId);
-                                forms[x].find('input[name*="[postcode]"]').val(selectedAddress.postcode);
                                 forms[x].find('select[name*="[country_id]"]').val(selectedAddress.countryId);
+                                forms[x].find('input[name*="[postcode]"]').val(selectedAddress.postcode);
                             }
 
                             if (uiRegistry.get(formScope)) {

--- a/view/base/web/js/address_validation.js
+++ b/view/base/web/js/address_validation.js
@@ -56,8 +56,8 @@ define([
                                 this.data.form.street_1.value = selectedAddress.street;
                                 this.data.form.city.value = selectedAddress.city;
                                 this.data.form.region_id.value = selectedAddress.regionId;
-                                this.data.form.postcode.value = selectedAddress.postcode;
                                 this.data.form.country_id.value = selectedAddress.countryId;
+                                this.data.form.postcode.value = selectedAddress.postcode;
                                 this.data.form.submit();
                             }
                         }

--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -105,11 +105,11 @@ function (ko, $) {
         isValidAddress: function (address) {
             return !!(
                 address &&
-                address.country_id &&
                 address.street &&
                 address.street[0] &&
                 address.city &&
                 address.region_id &&
+                address.country_id &&
                 address.postcode
             );
         },

--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -121,9 +121,9 @@ function (
                 var originalAddress = $.extend({}, checkoutProvider.get('shippingAddress'));
 
                 originalAddress.city = addrs[id].address.city;
+                originalAddress.region_id = addrs[id].address.regionId;
                 originalAddress.country_id = addrs[id].address.countryId;
                 originalAddress.postcode = addrs[id].address.postcode;
-                originalAddress.region_id = addrs[id].address.regionId;
 
                 if (originalAddress.telephone === null) {
                     originalAddress.telephone = addrs[id].address.telephone ?? quote.shippingAddress().telephone;

--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -124,7 +124,10 @@ function (
                 originalAddress.country_id = addrs[id].address.countryId;
                 originalAddress.postcode = addrs[id].address.postcode;
                 originalAddress.region_id = addrs[id].address.regionId;
-                originalAddress.telephone = addrs[id].address.telephone ?? quote.shippingAddress().telephone;
+
+                if (originalAddress.telephone === null) {
+                    originalAddress.telephone = addrs[id].address.telephone ?? quote.shippingAddress().telephone;
+                }
 
                 addrs[id].address.street.forEach(function(item, index) {
                    originalAddress.street[index] = item;


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Acceptance of TJ-validated address in some checkout scenarios will cause phone number to be wiped from JS address object, forcing user to re-input.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Because the same JS function is used in various checkout scenarios, function should first check if phone number is already set on existing address before attempting to update address from quote object.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Improve UX

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
#### Scenarios
- Guest Checkout, no existing addresses
- Existing user, no existing addresses
- Existing user, existing unvalidated address
- Existing user, validated address
- Admin, on behalf of existing user w/ unvalidated address
- Admin, on behalf of existing user w/ validated address

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
