### PR TITLE
fix: Invalid transaction backfill CLI command date parameters

### DIFF
--- a/Console/Command/SyncTransactionsCommand.php
+++ b/Console/Command/SyncTransactionsCommand.php
@@ -85,8 +85,8 @@ class SyncTransactionsCommand extends Command
             $this->state->setAreaCode('adminhtml');
             $this->logger->console($output);
             $this->backfillTransactions->execute(new Observer([
-                'from_date' => $input->getArgument(self::FROM_ARGUMENT),
-                'to_date' => $input->getArgument(self::TO_ARGUMENT),
+                'from' => $input->getArgument(self::FROM_ARGUMENT),
+                'to' => $input->getArgument(self::TO_ARGUMENT),
                 'force' => (bool) $input->getOption(self::OPTION_FORCE)
             ]));
         } catch (\Exception $e) {

--- a/Console/Command/SyncTransactionsCommand.php
+++ b/Console/Command/SyncTransactionsCommand.php
@@ -85,8 +85,8 @@ class SyncTransactionsCommand extends Command
             $this->state->setAreaCode('adminhtml');
             $this->logger->console($output);
             $this->backfillTransactions->execute(new Observer([
-                'from' => $input->getArgument(self::FROM_ARGUMENT),
-                'to' => $input->getArgument(self::TO_ARGUMENT),
+                'from_date' => $input->getArgument(self::FROM_ARGUMENT),
+                'to_date' => $input->getArgument(self::TO_ARGUMENT),
                 'force' => (bool) $input->getOption(self::OPTION_FORCE)
             ]));
         } catch (\Exception $e) {

--- a/Observer/BackfillTransactions.php
+++ b/Observer/BackfillTransactions.php
@@ -162,8 +162,8 @@ class BackfillTransactions implements \Magento\Framework\Event\ObserverInterface
 
     public function setDateRange(): BackfillTransactions
     {
-        $from = $this->getInput('from') ?? 'now';
-        $to = $this->getInput('to') ?? 'now';
+        $from = $this->getInput('from_date') ?? 'now';
+        $to = $this->getInput('to_date') ?? 'now';
         $fromDt = new \DateTime($from);
         $toDt = new \DateTime($to);
 

--- a/Test/Unit/Observer/BackfillTransactionsTest.php
+++ b/Test/Unit/Observer/BackfillTransactionsTest.php
@@ -531,8 +531,8 @@ class BackfillTransactionsTest extends UnitTestCase
         $exception = new Exception('test-error');
 
         $dataMap = [
-            ['from', null, '2021-01-01'],
-            ['to', null, '2021-01-31'],
+            ['from_date', null, '2021-01-01'],
+            ['to_date', null, '2021-01-31'],
             ['force', null, '0'],
         ];
 

--- a/view/adminhtml/templates/transaction_sync.phtml
+++ b/view/adminhtml/templates/transaction_sync.phtml
@@ -76,8 +76,8 @@ if ($block->isEnabled()) { ?>
                     url: '<?= $block->escapeUrl($block->getStoreUrl('taxjar/transaction/backfill')) ?>',
                     method: 'GET',
                     data: {
-                        from: fromDate,
-                        to: toDate,
+                        from_date: fromDate,
+                        to_date: toDate,
                         force: force,
                         store: '<?= $this->getRequest()->getParam('store') ?>',
                         website: '<?= $this->getRequest()->getParam('website') ?>',


### PR DESCRIPTION
### Context
When you call `bin/magento taxjar:transactions:sync -f 2022/02/10` the date argument is ignored (as it expects `from` and `to`, while `from_date` and `to_date` are provided)

https://github.com/taxjar/taxjar-magento2-extension/blob/2346140c538a5151441f07335e1e245a6785f433/Observer/BackfillTransactions.php#L163-L180

TaxJar developers forgot to test that command after "refactoring".

### Description
This Pull Request changes the property name to make source & target date supported

### Performance
No change to the performance

### Testing
1. Call `bin/magento taxjar:transactions:sync -f 2022/02/10`
2. Expect all the transactions since 2022/02/10 to be synchronized

#### Versions
<!-- What version(s) did you test this change on? -->
- [ ] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [ ] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [ ] PHP 7.x
