### PR TITLE
refactor: Ensure Magento 2.3 compatibility

### DIFF
--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
@@ -19,8 +19,6 @@ declare(strict_types=1);
 
 namespace Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View;
 
-use Magento\Directory\Helper\Data as DirectoryHelper;
-use Magento\Framework\Json\Helper\Data as JsonHelper;
 use Taxjar\SalesTax\Helper\Data as TaxjarHelper;
 
 class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\Block\Widget\Tab\TabInterface
@@ -35,25 +33,21 @@ class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\B
     /**
      * @var TaxjarHelper
      */
-    private TaxjarHelper $tjHelper;
+    private $tjHelper;
 
     /**
      * @param TaxjarHelper $tjHelper
      * @param \Magento\Backend\Block\Template\Context $context
      * @param array $data
-     * @param JsonHelper|null $jsonHelper
-     * @param DirectoryHelper|null $directoryHelper
      */
     public function __construct(
         TaxjarHelper $tjHelper,
         \Magento\Backend\Block\Template\Context $context,
-        array $data = [],
-        ?JsonHelper $jsonHelper = null,
-        ?DirectoryHelper $directoryHelper = null
+        array $data = []
     ) {
         $this->tjHelper = $tjHelper;
 
-        parent::__construct($context, $data, $jsonHelper, $directoryHelper);
+        parent::__construct($context, $data);
     }
 
     /**

--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Calculation.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Calculation.php
@@ -22,8 +22,6 @@ namespace Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View\Info;
 use Magento\Sales\Api\Data\OrderExtensionFactory;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Block\Adminhtml\Order\AbstractOrder;
-use Magento\Shipping\Helper\Data as ShippingHelper;
-use Magento\Tax\Helper\Data as TaxHelper;
 use Taxjar\SalesTax\Model\Sales\Order\Metadata;
 
 /**
@@ -50,36 +48,30 @@ class Calculation extends AbstractOrder
     /**
      * @var OrderExtensionFactory $extensionFactory
      */
-    private OrderExtensionFactory $extensionFactory;
+    private $extensionFactory;
 
     /**
      * Calculation constructor.
      *
+     * @param OrderExtensionFactory $extensionFactory
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Sales\Helper\Admin $adminHelper
      * @param array $data
-     * @param ShippingHelper|null $shippingHelper
-     * @param TaxHelper|null $taxHelper
-     * @param OrderExtensionFactory $extensionFactory
      */
     public function __construct(
+        OrderExtensionFactory $extensionFactory,
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Sales\Helper\Admin $adminHelper,
-        array $data = [],
-        ?ShippingHelper $shippingHelper = null,
-        ?TaxHelper $taxHelper = null,
-        OrderExtensionFactory $extensionFactory
+        array $data = []
     ) {
         $this->extensionFactory = $extensionFactory;
         parent::__construct(
             $context,
             $registry,
             $adminHelper,
-            $data,
-            $shippingHelper,
-            $taxHelper
+            $data
         );
     }
 

--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Sync.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Sync.php
@@ -19,9 +19,6 @@ declare(strict_types=1);
 
 namespace Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View\Info;
 
-use Magento\Shipping\Helper\Data as ShippingHelper;
-use Magento\Tax\Helper\Data as TaxHelper;
-
 class Sync extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
 {
     /**
@@ -50,26 +47,20 @@ class Sync extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Sales\Helper\Admin $adminHelper
      * @param array $data
-     * @param ShippingHelper|null $shippingHelper
-     * @param TaxHelper|null $taxHelper
      */
     public function __construct(
         \Taxjar\SalesTax\Helper\Data $taxjarHelper,
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Sales\Helper\Admin $adminHelper,
-        array $data = [],
-        ?ShippingHelper $shippingHelper = null,
-        ?TaxHelper $taxHelper = null
+        array $data = []
     ) {
         $this->taxjarHelper = $taxjarHelper;
         parent::__construct(
             $context,
             $registry,
             $adminHelper,
-            $data,
-            $shippingHelper,
-            $taxHelper
+            $data
         );
     }
 

--- a/Helper/Nexus.php
+++ b/Helper/Nexus.php
@@ -17,7 +17,10 @@ namespace Taxjar\SalesTax\Helper;
 
 class Nexus extends \Magento\Framework\App\Helper\AbstractHelper
 {
-    private \Taxjar\SalesTax\Model\Tax\NexusFactory $nexusFactory;
+    /**
+     * @var \Taxjar\SalesTax\Model\Tax\NexusFactory
+     */
+    private $nexusFactory;
 
     /**
      * Nexus constructor.
@@ -43,7 +46,9 @@ class Nexus extends \Magento\Framework\App\Helper\AbstractHelper
     {
         /** @var array|\Taxjar\SalesTax\Api\Data\Tax\NexusInterface[] $nexusArray */
         $nexusArray = array_values($this->getNexusCollection($storeId)->getItems());
-        return array_map(fn ($nexus) => $this->getNexusData($nexus), $nexusArray);
+        return array_map(function ($nexus) {
+            return $this->getNexusData($nexus);
+        }, $nexusArray);
     }
 
     /**

--- a/Helper/OrderMetadata.php
+++ b/Helper/OrderMetadata.php
@@ -27,12 +27,12 @@ class OrderMetadata extends AbstractHelper
     /**
      * @var OrderExtensionFactory $extensionFactory
      */
-    private OrderExtensionFactory $extensionFactory;
+    private $extensionFactory;
 
     /**
      * @var CollectionFactory $collectionFactory
      */
-    private CollectionFactory $collectionFactory;
+    private $collectionFactory;
 
     /**
      * OrderMetadata constructor.

--- a/Model/Sales/Order/Metadata.php
+++ b/Model/Sales/Order/Metadata.php
@@ -49,7 +49,7 @@ class Metadata extends AbstractModel implements MetadataInterface
     /**
      * @var DateTimeFactory
      */
-    private DateTimeFactory $dateFactory;
+    private $dateFactory;
 
     /**
      * Metadata constructor.

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -102,12 +102,12 @@ class Smartcalcs
     /**
      * @var int
      */
-    private int $storeId;
+    private $storeId;
 
     /**
      * @var \Taxjar\SalesTax\Helper\Nexus
      */
-    private \Taxjar\SalesTax\Helper\Nexus $nexusHelper;
+    private $nexusHelper;
 
     /**
      * Smartcalcs constructor.
@@ -124,6 +124,7 @@ class Smartcalcs
      * @param \Magento\Directory\Model\Country\Postcode\ConfigInterface $postCodesConfig
      * @param Logger $logger
      * @param TaxjarConfig $taxjarConfig
+     * @param \Taxjar\SalesTax\Helper\Nexus $nexusHelper
      */
     public function __construct(
         \Magento\Checkout\Model\Session $checkoutSession,

--- a/Observer/SaveOrderMetadata.php
+++ b/Observer/SaveOrderMetadata.php
@@ -38,17 +38,17 @@ class SaveOrderMetadata implements ObserverInterface
     /**
      * @var CheckoutSession $checkoutSession
      */
-    private CheckoutSession $checkoutSession;
+    private $checkoutSession;
 
     /**
      * @var OrderRepositoryInterface $orderRepository
      */
-    private OrderRepositoryInterface $orderRepository;
+    private $orderRepository;
 
     /**
      * @var OrderExtensionFactory $extensionFactory
      */
-    private OrderExtensionFactory $extensionFactory;
+    private $extensionFactory;
 
     /**
      * SaveOrderMetadata constructor.

--- a/Plugin/Quote/Model/QuoteManagement.php
+++ b/Plugin/Quote/Model/QuoteManagement.php
@@ -34,12 +34,12 @@ class QuoteManagement
     /**
      * @var Metadata $metadata
      */
-    private Metadata $metadata;
+    private $metadata;
 
     /**
      * @var MetadataRepositoryInterface $metadataRepository
      */
-    private MetadataRepositoryInterface $metadataRepository;
+    private $metadataRepository;
 
     /**
      * QuoteManagement constructor.

--- a/Plugin/Sales/Model/OrderRepository.php
+++ b/Plugin/Sales/Model/OrderRepository.php
@@ -32,7 +32,7 @@ class OrderRepository
     /**
      * @var OrderMetadataHelper $helper
      */
-    private OrderMetadataHelper $helper;
+    private $helper;
 
     /**
      * Get constructor.

--- a/Test/Unit/Block/Adminhtml/Order/View/SyncedTest.php
+++ b/Test/Unit/Block/Adminhtml/Order/View/SyncedTest.php
@@ -20,7 +20,7 @@ class SyncedTest extends UnitTestCase
     {
         $orderMock = $this->getMockBuilder(OrderInterface::class)
             ->disableOriginalConstructor()
-            ->addMethods(['getTjSalestaxSyncDate']) // added to DB in module's setup script
+            ->setMethods(['getTjSalestaxSyncDate']) // added to DB in module's setup script
             ->getMockForAbstractClass();
         $orderMock->expects(static::once())->method('getTjSalestaxSyncDate');
         $sut = $this->objectManager->getObject(Synced::class);

--- a/Test/Unit/Helper/NexusTest.php
+++ b/Test/Unit/Helper/NexusTest.php
@@ -19,7 +19,7 @@ class NexusTest extends \Taxjar\SalesTax\Test\Unit\UnitTestCase
     /**
      * @var Nexus
      */
-    private Nexus $sut;
+    private $sut;
 
     protected function setUp(): void
     {

--- a/Test/Unit/Model/Import/RuleModelTest.php
+++ b/Test/Unit/Model/Import/RuleModelTest.php
@@ -47,7 +47,7 @@ class RuleModelTest extends UnitTestCase
                 $this->createMock(AbstractResource::class),
                 $this->createMock(AbstractDb::class)
             ])
-            ->onlyMethods(['_init'])
+            ->setMethods(['_init'])
             ->getMock();
 
         $sut->method('_init')->will($this->returnValue(true));

--- a/Test/Unit/Model/Import/RuleTest.php
+++ b/Test/Unit/Model/Import/RuleTest.php
@@ -46,7 +46,7 @@ class RuleTest extends UnitTestCase
 
         $sut = $this->getMockBuilder(\Taxjar\SalesTax\Model\Import\Rule::class)
             ->setConstructorArgs([$mockRuleFactory, $mockRuleRepository])
-            ->onlyMethods(['saveCalculationData'])
+            ->setMethods(['saveCalculationData'])
             ->getMock();
 
         $sut->expects($this->any())->method('saveCalculationData')->willReturn(true);
@@ -60,8 +60,15 @@ class RuleTest extends UnitTestCase
     {
         $mockCalculation = $this->getMockBuilder(Calculation::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['setData', 'save', 'getCollection', 'getId', 'delete'])
-            ->addMethods(['addFieldToFilter', 'getFirstItem'])
+            ->setMethods([
+                'setData',
+                'save',
+                'getCollection',
+                'getId',
+                'delete',
+                'addFieldToFilter',
+                'getFirstItem'
+            ])
             ->getMock();
 
         $mockCalculation->expects($this->any())->method('getCollection')->willReturnSelf();

--- a/Test/Unit/Model/Transaction/RefundTest.php
+++ b/Test/Unit/Model/Transaction/RefundTest.php
@@ -35,7 +35,7 @@ class RefundTest extends UnitTestCase
 
         $result = $sut->build($this->mockOrder, $this->mockCreditMemo);
 
-        $this->assertIsArray($result);
+        $this->assertArrayHasKey('provider', $result);
     }
 
     public function testBuildPayloadContainsOrderAndCreditMemoData()
@@ -102,7 +102,6 @@ class RefundTest extends UnitTestCase
 
         $result = $sut->build($this->mockOrder, $this->mockCreditMemo);
 
-        $this->assertIsArray($result['line_items']);
         $this->assertEquals(2, count($result['line_items']));
     }
 
@@ -135,7 +134,6 @@ class RefundTest extends UnitTestCase
 
         $result = $sut->build($this->mockOrder, $this->mockCreditMemo);
 
-        $this->assertIsArray($result['line_items']);
         $this->assertEquals(2, count($result['line_items']));
 
         // Validate Adjustment Item data (NOTE: values are NOT cast to `float` like order item above)

--- a/Test/Unit/Model/TransactionTest.php
+++ b/Test/Unit/Model/TransactionTest.php
@@ -73,7 +73,7 @@ class TransactionTest extends UnitTestCase
         $mockOrder = $this->createMock(\Magento\Sales\Model\Order::class);
         $mockItem = $this->getMockBuilder(\Magento\Sales\Model\Order\Item::class)
             ->disableOriginalConstructor()
-            ->onlyMethods([
+            ->setMethods([
                 'getItemId',
                 'getProductType',
                 'getPrice',
@@ -81,8 +81,8 @@ class TransactionTest extends UnitTestCase
                 'getTaxInvoiced',
                 'getSku',
                 'getName',
+                'getTjPtc'
             ])
-            ->addMethods(['getTjPtc']) // The interface that provides this method signature is generated in compile
             ->getMock();
         $mockItem->expects($this->once())->method('getItemId')->willReturn(9);
         $mockItem->expects($this->once())->method('getPrice')->willReturn(60.0);

--- a/Test/Unit/Observer/BackfillTransactionsTest.php
+++ b/Test/Unit/Observer/BackfillTransactionsTest.php
@@ -375,8 +375,7 @@ class BackfillTransactionsTest extends UnitTestCase
     {
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->addMethods(['getTjSalestaxSyncDate'])
-            ->onlyMethods(['getUpdatedAt'])
+            ->setMethods(['getTjSalestaxSyncDate', 'getUpdatedAt'])
             ->getMock();
 
         if (!$forceSync) {
@@ -548,7 +547,7 @@ class BackfillTransactionsTest extends UnitTestCase
     {
         $searchCriteriaMock = $this->getMockBuilder(SearchCriteriaInterface::class)
             ->disableOriginalConstructor()
-            ->addMethods(['__toArray'])
+            ->setMethods(['__toArray'])
             ->getMockForAbstractClass();
         $searchCriteriaMock->expects($this->once())->method('__toArray')->willReturn((object)[]);
 

--- a/Test/Unit/Observer/SaveOrderMetadataTest.php
+++ b/Test/Unit/Observer/SaveOrderMetadataTest.php
@@ -72,7 +72,7 @@ class SaveOrderMetadataTest extends UnitTestCase
 
         $observerMock = $this->getMockBuilder(Observer::class)
             ->disableOriginalConstructor()
-            ->addMethods(['getOrder'])
+            ->setMethods(['getOrder'])
             ->getMock();
         $observerMock->expects(static::any())
             ->method('getOrder')
@@ -119,7 +119,7 @@ class SaveOrderMetadataTest extends UnitTestCase
 
         $observerMock = $this->getMockBuilder(Observer::class)
             ->disableOriginalConstructor()
-            ->addMethods(['getOrder'])
+            ->setMethods(['getOrder'])
             ->getMock();
         $observerMock->expects(static::any())
             ->method('getOrder')

--- a/Test/Unit/Plugin/Quote/Model/QuoteManagementTest.php
+++ b/Test/Unit/Plugin/Quote/Model/QuoteManagementTest.php
@@ -44,7 +44,7 @@ class QuoteManagementTest extends UnitTestCase
             ->getMock();
         $this->metadataMock = $this->getMockBuilder(Metadata::class)
             ->disableOriginalConstructor()
-            ->onlyMethods([
+            ->setMethods([
                 'getOrderId',
                 'setOrderId',
                 'setTaxCalculationStatus',


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Adobe extended security support for M2 v2.3 thru Q3 '22

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Removes typed properties (not supported in PHP 7.3)
- Removes arrow functions (not supported in PHP 7.3)
- Removes optional DI parameters `DirectoryHelper` and `JsonHelper` from classes extending `\Magento\Backend\Block\Template`
- Refactor for PHPUnit 6.5.14 backwards compatibility

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
No performance impact

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. [First Step]
2. [Second Step]
3. [and so on...]

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [x] PHP 7.4
- [x] PHP 7.3
