### PR TITLE
fix: Order repository plugin pass object by reference

### DIFF
--- a/Plugin/Sales/Model/OrderRepository.php
+++ b/Plugin/Sales/Model/OrderRepository.php
@@ -63,7 +63,9 @@ class OrderRepository
         OrderRepositoryInterface   $subject,
         OrderSearchResultInterface $searchResult
     ): OrderSearchResultInterface {
-        $items = array_map([$this->helper, 'setOrderExtensionAttributeData'], $searchResult->getItems());
-        return $searchResult->setItems($items);
+        foreach ($searchResult->getItems() as &$order) {
+            $this->helper->setOrderExtensionAttributeData($order);
+        }
+        return $searchResult;
     }
 }


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Encountered error while testing plugin method `OrderRepository::afterGetList()` in v2.3.7-p2 due to attempted overwrite of existing data array keys. 

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
We can avoid the need to retrieve/set items on collection entirely with for-loop/pass-object-by-reference to instead modify the underlying object.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->

Error is visible in Bulk Transaction Sync UI

#### Steps to recreate
1. Deploy Luma sample data
2. As admin, navigate to Stores->Configuration->Sales->Tax
3. Enable transaction sync
4. Click "Sync Transactions" button in config UI
5. Init transaction sync over current date range (as sample data created_at dates should match date of sample data deployment)
6. Without fix, v2.3 will emit error "Item with the same ID already exists "Magento\Sales\Model\Order\Interceptor" from `Taxjar\SalesTax\Plugin\Sales\Model\OrderRepository::class`.
7. With fix, no error observed.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
