### PR TITLE
refactor: Removes typed properties

### DIFF
--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
@@ -35,7 +35,7 @@ class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\B
     /**
      * @var TaxjarHelper
      */
-    private TaxjarHelper $tjHelper;
+    private $tjHelper;
 
     /**
      * @param TaxjarHelper $tjHelper

--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Calculation.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Calculation.php
@@ -48,9 +48,9 @@ class Calculation extends AbstractOrder
     protected $_template = 'Taxjar_SalesTax::order/view/tab/taxjar/info/calculation.phtml';
 
     /**
-     * @var OrderExtensionFactory $extensionFactory
+     * @var OrderExtensionFactory
      */
-    private OrderExtensionFactory $extensionFactory;
+    private $extensionFactory;
 
     /**
      * Calculation constructor.

--- a/Helper/Nexus.php
+++ b/Helper/Nexus.php
@@ -17,7 +17,10 @@ namespace Taxjar\SalesTax\Helper;
 
 class Nexus extends \Magento\Framework\App\Helper\AbstractHelper
 {
-    private \Taxjar\SalesTax\Model\Tax\NexusFactory $nexusFactory;
+    /**
+     * @var \Taxjar\SalesTax\Model\Tax\NexusFactory
+     */
+    private $nexusFactory;
 
     /**
      * Nexus constructor.

--- a/Helper/OrderMetadata.php
+++ b/Helper/OrderMetadata.php
@@ -25,14 +25,14 @@ use Taxjar\SalesTax\Model\ResourceModel\Sales\Order\Metadata\CollectionFactory;
 class OrderMetadata extends AbstractHelper
 {
     /**
-     * @var OrderExtensionFactory $extensionFactory
+     * @var OrderExtensionFactory
      */
-    private OrderExtensionFactory $extensionFactory;
+    private $extensionFactory;
 
     /**
-     * @var CollectionFactory $collectionFactory
+     * @var CollectionFactory
      */
-    private CollectionFactory $collectionFactory;
+    private $collectionFactory;
 
     /**
      * OrderMetadata constructor.

--- a/Model/Sales/Order/Metadata.php
+++ b/Model/Sales/Order/Metadata.php
@@ -24,7 +24,6 @@ use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Registry;
-use Magento\Framework\Stdlib\DateTime\DateTimeFactory;
 use Taxjar\SalesTax\Api\Data\Sales\Order\MetadataInterface;
 use Taxjar\SalesTax\Model\ResourceModel\Sales\Order\Metadata as MetadataResource;
 
@@ -47,16 +46,10 @@ class Metadata extends AbstractModel implements MetadataInterface
     protected $_eventPrefix = 'taxjar_salestax_order_metadata';
 
     /**
-     * @var DateTimeFactory
-     */
-    private DateTimeFactory $dateFactory;
-
-    /**
      * Metadata constructor.
      *
      * @param Context               $context
      * @param Registry              $registry
-     * @param DateTimeFactory       $dateFactory
      * @param AbstractResource|null $resource
      * @param AbstractDb|null       $resourceCollection
      * @param array                 $data
@@ -64,12 +57,10 @@ class Metadata extends AbstractModel implements MetadataInterface
     public function __construct(
         Context $context,
         Registry $registry,
-        DateTimeFactory $dateFactory,
         AbstractResource $resource = null,
         AbstractDb $resourceCollection = null,
         array $data = []
     ) {
-        $this->dateFactory = $dateFactory;
         parent::__construct(
             $context,
             $registry,

--- a/Model/Sales/Order/MetadataRepository.php
+++ b/Model/Sales/Order/MetadataRepository.php
@@ -50,6 +50,7 @@ class MetadataRepository implements MetadataRepositoryInterface
      * @var MetadataSearchResultInterfaceFactory
      */
     private $searchResultFactory;
+
     /**
      * @var CollectionProcessorInterface
      */

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -100,14 +100,14 @@ class Smartcalcs
     protected $taxjarConfig;
 
     /**
-     * @var int
-     */
-    private int $storeId;
-
-    /**
      * @var \Taxjar\SalesTax\Helper\Nexus
      */
-    private \Taxjar\SalesTax\Helper\Nexus $nexusHelper;
+    private $nexusHelper;
+
+    /**
+     * @var int
+     */
+    private $storeId;
 
     /**
      * Smartcalcs constructor.
@@ -124,6 +124,7 @@ class Smartcalcs
      * @param \Magento\Directory\Model\Country\Postcode\ConfigInterface $postCodesConfig
      * @param Logger $logger
      * @param TaxjarConfig $taxjarConfig
+     * @param \Taxjar\SalesTax\Helper\Nexus $nexusHelper
      */
     public function __construct(
         \Magento\Checkout\Model\Session $checkoutSession,

--- a/Observer/SaveOrderMetadata.php
+++ b/Observer/SaveOrderMetadata.php
@@ -36,19 +36,19 @@ class SaveOrderMetadata implements ObserverInterface
     const ORDER_METADATA = 'taxjar_salestax_order_metadata';
 
     /**
-     * @var CheckoutSession $checkoutSession
+     * @var CheckoutSession
      */
-    private CheckoutSession $checkoutSession;
+    private $checkoutSession;
 
     /**
-     * @var OrderRepositoryInterface $orderRepository
+     * @var OrderRepositoryInterface
      */
-    private OrderRepositoryInterface $orderRepository;
+    private $orderRepository;
 
     /**
-     * @var OrderExtensionFactory $extensionFactory
+     * @var OrderExtensionFactory
      */
-    private OrderExtensionFactory $extensionFactory;
+    private $extensionFactory;
 
     /**
      * SaveOrderMetadata constructor.

--- a/Plugin/Quote/Model/QuoteManagement.php
+++ b/Plugin/Quote/Model/QuoteManagement.php
@@ -32,14 +32,14 @@ use Taxjar\SalesTax\Model\Sales\Order\MetadataFactory;
 class QuoteManagement
 {
     /**
-     * @var Metadata $metadata
+     * @var Metadata
      */
-    private Metadata $metadata;
+    private $metadata;
 
     /**
-     * @var MetadataRepositoryInterface $metadataRepository
+     * @var MetadataRepositoryInterface
      */
-    private MetadataRepositoryInterface $metadataRepository;
+    private $metadataRepository;
 
     /**
      * QuoteManagement constructor.

--- a/Plugin/Sales/Model/OrderRepository.php
+++ b/Plugin/Sales/Model/OrderRepository.php
@@ -30,9 +30,9 @@ use Taxjar\SalesTax\Helper\OrderMetadata as OrderMetadataHelper;
 class OrderRepository
 {
     /**
-     * @var OrderMetadataHelper $helper
+     * @var OrderMetadataHelper
      */
-    private OrderMetadataHelper $helper;
+    private $helper;
 
     /**
      * Get constructor.

--- a/Test/Unit/Helper/NexusTest.php
+++ b/Test/Unit/Helper/NexusTest.php
@@ -19,7 +19,7 @@ class NexusTest extends \Taxjar\SalesTax\Test\Unit\UnitTestCase
     /**
      * @var Nexus
      */
-    private Nexus $sut;
+    private $sut;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Adobe extended security support for M2 v2.3 thru Q3 '22

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Removes typed properties for better PHP 7.3 compatibility, although PHP 7.3 is no longer supported.

- Removes unused constructor parameter `$dateFactory` from class `Model/Sales/Order/Metadata`. Usage was previously removed with removal of order metadata `created_at` and `updated_at` fields.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
