### PR TITLE
refactor: Legacy Backend block constructor compatibility

### DIFF
--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
@@ -19,8 +19,6 @@ declare(strict_types=1);
 
 namespace Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View;
 
-use Magento\Directory\Helper\Data as DirectoryHelper;
-use Magento\Framework\Json\Helper\Data as JsonHelper;
 use Taxjar\SalesTax\Helper\Data as TaxjarHelper;
 
 class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\Block\Widget\Tab\TabInterface
@@ -41,19 +39,15 @@ class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\B
      * @param TaxjarHelper $tjHelper
      * @param \Magento\Backend\Block\Template\Context $context
      * @param array $data
-     * @param JsonHelper|null $jsonHelper
-     * @param DirectoryHelper|null $directoryHelper
      */
     public function __construct(
         TaxjarHelper $tjHelper,
         \Magento\Backend\Block\Template\Context $context,
-        array $data = [],
-        ?JsonHelper $jsonHelper = null,
-        ?DirectoryHelper $directoryHelper = null
+        array $data = []
     ) {
         $this->tjHelper = $tjHelper;
 
-        parent::__construct($context, $data, $jsonHelper, $directoryHelper);
+        parent::__construct($context, $data);
     }
 
     /**

--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Calculation.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Calculation.php
@@ -22,8 +22,6 @@ namespace Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View\Info;
 use Magento\Sales\Api\Data\OrderExtensionFactory;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Block\Adminhtml\Order\AbstractOrder;
-use Magento\Shipping\Helper\Data as ShippingHelper;
-use Magento\Tax\Helper\Data as TaxHelper;
 use Taxjar\SalesTax\Model\Sales\Order\Metadata;
 
 /**
@@ -55,31 +53,25 @@ class Calculation extends AbstractOrder
     /**
      * Calculation constructor.
      *
+     * @param OrderExtensionFactory $extensionFactory
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Sales\Helper\Admin $adminHelper
      * @param array $data
-     * @param ShippingHelper|null $shippingHelper
-     * @param TaxHelper|null $taxHelper
-     * @param OrderExtensionFactory $extensionFactory
      */
     public function __construct(
+        OrderExtensionFactory $extensionFactory,
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Sales\Helper\Admin $adminHelper,
-        array $data = [],
-        ?ShippingHelper $shippingHelper = null,
-        ?TaxHelper $taxHelper = null,
-        OrderExtensionFactory $extensionFactory
+        array $data = []
     ) {
         $this->extensionFactory = $extensionFactory;
         parent::__construct(
             $context,
             $registry,
             $adminHelper,
-            $data,
-            $shippingHelper,
-            $taxHelper
+            $data
         );
     }
 

--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Sync.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Sync.php
@@ -19,9 +19,6 @@ declare(strict_types=1);
 
 namespace Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View\Info;
 
-use Magento\Shipping\Helper\Data as ShippingHelper;
-use Magento\Tax\Helper\Data as TaxHelper;
-
 class Sync extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
 {
     /**
@@ -50,26 +47,20 @@ class Sync extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Sales\Helper\Admin $adminHelper
      * @param array $data
-     * @param ShippingHelper|null $shippingHelper
-     * @param TaxHelper|null $taxHelper
      */
     public function __construct(
         \Taxjar\SalesTax\Helper\Data $taxjarHelper,
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Sales\Helper\Admin $adminHelper,
-        array $data = [],
-        ?ShippingHelper $shippingHelper = null,
-        ?TaxHelper $taxHelper = null
+        array $data = []
     ) {
         $this->taxjarHelper = $taxjarHelper;
         parent::__construct(
             $context,
             $registry,
             $adminHelper,
-            $data,
-            $shippingHelper,
-            $taxHelper
+            $data
         );
     }
 


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Adobe extended security support for M2 v2.3 thru Q3 '22

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Backend block constructor changed between M2.3 and M2.4.
Removes additional constructor parameters not present in M2.3 which prevent successful DI compilation.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Run `setup:di:compile`
2. Observe successful compilation

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [X] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
