### PR TITLE
fix: Casts null config value to boolean

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -69,7 +69,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
         $scopeCode = null
     ): bool {
-        return $this->scopeConfig->getValue(
+        return (bool) $this->scopeConfig->getValue(
             \Taxjar\SalesTax\Model\Configuration::TAXJAR_ENABLED,
             $scope,
             $scopeCode


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Latest pending M2 release failed manual QA. When extension is required, but not enabled, an absent config value causes helper function to return `null` instead of expected typed return of `boolean`. It appears that this is the same reason that most recent MFTF acceptance tests failed.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Fix error by casting function return value to boolean.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
#### Manual testing
1. Place an Order either via checkout or admin
2. Navigate to created Sales Order and observe no error
3. Require module Taxjar_SalesTax, but DO NOT enable
4. Navigate to same Sales Order
  - Before fix, observe return type error output
  - After fix, observe Sales Order page loads as expected

#### MFTF
1. Fix validated by `vendor/bin/mftf run:test AdminCreateOrderWithSimpleProductTest`
2. See log output: [output.log](https://github.com/taxjar/taxjar-magento2-extension/files/8163568/output.log)



#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
