### PR TITLE
draft: chore: Correct PHPCS generic sniffs

### DIFF
--- a/Api/AddressValidationInterface.php
+++ b/Api/AddressValidationInterface.php
@@ -30,5 +30,12 @@ interface AddressValidationInterface
      * @param string $postcode
      * @return mixed
      */
-    public function validateAddress($street0 = null, $street1 = null, $city = null, $region = null, $country = null, $postcode = null);
+    public function validateAddress(
+        $street0 = null,
+        $street1 = null,
+        $city = null,
+        $region = null,
+        $country = null,
+        $postcode = null
+    );
 }

--- a/Block/Adminhtml/Tax/Nexus/Edit/Form.php
+++ b/Block/Adminhtml/Tax/Nexus/Edit/Form.php
@@ -240,7 +240,10 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'required' => false,
                 'value' => isset($formValues['store_id']) ? $formValues['store_id'] : '',
                 'values' => $this->getStoreGroups(),
-                'note' => __('Calculate sales tax for this nexus address in a specific Magento store. Set to "All Store Views" to use this nexus address globally.')
+                'note' => __(
+                    'Calculate sales tax for this nexus address in a specific Magento store. ' .
+                    'Set to "All Store Views" to use this nexus address globally.'
+                )
             ]
         );
 

--- a/Block/Adminhtml/Tax/Taxclass/Customer/Edit/Form.php
+++ b/Block/Adminhtml/Tax/Taxclass/Customer/Edit/Form.php
@@ -91,7 +91,9 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     protected function _prepareForm()
     {
         $taxClassId = $this->_coreRegistry->registry('tax_class_id');
-        $url = \Taxjar\SalesTax\Model\Configuration::TAXJAR_MAGETWO_GUIDE_URL . '/#section-customer-sales-tax-exemptions';
+
+        $url = \Taxjar\SalesTax\Model\Configuration::TAXJAR_MAGETWO_GUIDE_URL;
+        $url .= '/#section-customer-sales-tax-exemptions';
 
         try {
             if ($taxClassId) {

--- a/Block/Adminhtml/Tax/Taxclass/Customer/Grid/Renderer/Exempt.php
+++ b/Block/Adminhtml/Tax/Taxclass/Customer/Grid/Renderer/Exempt.php
@@ -26,17 +26,6 @@ use Magento\Framework\DataObject;
 class Exempt extends AbstractRenderer
 {
     /**
-     * @param \Magento\Backend\Block\Context $context
-     * @param array $data
-     */
-    public function __construct(
-        \Magento\Backend\Block\Context $context,
-        array $data = []
-    ) {
-        parent::__construct($context, $data);
-    }
-
-    /**
      * Renders grid column
      *
      * @param DataObject $row

--- a/Block/Adminhtml/TransactionSync/Form.php
+++ b/Block/Adminhtml/TransactionSync/Form.php
@@ -38,21 +38,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     protected $_template = 'transaction_sync/form.phtml';
 
     /**
-     * @param \Magento\Backend\Block\Template\Context $context
-     * @param \Magento\Framework\Registry $registry
-     * @param \Magento\Framework\Data\FormFactory $formFactory
-     * @param array $data
-     */
-    public function __construct(
-        \Magento\Backend\Block\Template\Context $context,
-        \Magento\Framework\Registry $registry,
-        \Magento\Framework\Data\FormFactory $formFactory,
-        array $data = []
-    ) {
-        parent::__construct($context, $registry, $formFactory, $data);
-    }
-
-    /**
      * @return void
      */
     protected function _construct()

--- a/Console/Command/SyncProductCategoriesCommand.php
+++ b/Console/Command/SyncProductCategoriesCommand.php
@@ -85,7 +85,9 @@ class SyncProductCategoriesCommand extends Command
             $output->writeln(PHP_EOL . 'Successfully synced product tax categories.');
 
         } catch (\Exception $e) {
-            $output->writeln(PHP_EOL . '<error>Failed to sync product tax categories: ' . $e->getMessage() . '</error>');
+            $output->writeln(
+                PHP_EOL . '<error>Failed to sync product tax categories: ' . $e->getMessage() . '</error>'
+            );
         }
     }
 }

--- a/Controller/Adminhtml/Taxclass/Customer.php
+++ b/Controller/Adminhtml/Taxclass/Customer.php
@@ -20,21 +20,6 @@ namespace Taxjar\SalesTax\Controller\Adminhtml\Taxclass;
 abstract class Customer extends \Taxjar\SalesTax\Controller\Adminhtml\Taxclass
 {
     /**
-     * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\Framework\Registry $coreRegistry
-     * @param \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassService
-     * @param \Magento\Tax\Api\Data\TaxClassInterfaceFactory $taxClassDataObjectFactory
-     */
-    public function __construct(
-        \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Registry $coreRegistry,
-        \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassService,
-        \Magento\Tax\Api\Data\TaxClassInterfaceFactory $taxClassDataObjectFactory
-    ) {
-        parent::__construct($context, $coreRegistry, $taxClassService, $taxClassDataObjectFactory);
-    }
-
-    /**
      * Initialize action
      *
      * @return \Magento\Backend\Model\View\Result\Page

--- a/Controller/Adminhtml/Taxclass/Product.php
+++ b/Controller/Adminhtml/Taxclass/Product.php
@@ -20,21 +20,6 @@ namespace Taxjar\SalesTax\Controller\Adminhtml\Taxclass;
 abstract class Product extends \Taxjar\SalesTax\Controller\Adminhtml\Taxclass
 {
     /**
-     * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\Framework\Registry $coreRegistry
-     * @param \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassService
-     * @param \Magento\Tax\Api\Data\TaxClassInterfaceFactory $taxClassDataObjectFactory
-     */
-    public function __construct(
-        \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Registry $coreRegistry,
-        \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassService,
-        \Magento\Tax\Api\Data\TaxClassInterfaceFactory $taxClassDataObjectFactory
-    ) {
-        parent::__construct($context, $coreRegistry, $taxClassService, $taxClassDataObjectFactory);
-    }
-
-    /**
      * Initialize action
      *
      * @return \Magento\Backend\Model\View\Result\Page

--- a/Model/AddressValidation.php
+++ b/Model/AddressValidation.php
@@ -269,7 +269,10 @@ class AddressValidation implements AddressValidationInterface
             $errorMessage = json_decode($e->getMessage());
             $response = false;
 
-            $this->logger->log($errorMessage->status . ' ' . $errorMessage->error . ' - ' . $errorMessage->detail, 'error');
+            $this->logger->log(
+                $errorMessage->status . ' ' . $errorMessage->error . ' - ' . $errorMessage->detail,
+                'error'
+            );
         }
 
         return $response;

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -210,7 +210,9 @@ class Client implements ClientInterface
                 $apiUrl .= '/plugins/magento/configuration/' . $this->backupRateOriginAddress->getShippingRegionCode();
                 break;
             case 'rates':
-                $apiUrl .= '/plugins/magento/rates/' . $this->backupRateOriginAddress->getShippingRegionCode() . '/' . $this->backupRateOriginAddress->getShippingZipCode();
+                $apiUrl .= '/plugins/magento/rates/';
+                $apiUrl .= $this->backupRateOriginAddress->getShippingRegionCode() . '/';
+                $apiUrl .= $this->backupRateOriginAddress->getShippingZipCode();
                 break;
             case 'categories':
                 $apiUrl .= '/categories';

--- a/Model/Sales/Order/Metadata.php
+++ b/Model/Sales/Order/Metadata.php
@@ -45,31 +45,6 @@ class Metadata extends AbstractModel implements MetadataInterface
 
     protected $_eventPrefix = 'taxjar_salestax_order_metadata';
 
-    /**
-     * Metadata constructor.
-     *
-     * @param Context               $context
-     * @param Registry              $registry
-     * @param AbstractResource|null $resource
-     * @param AbstractDb|null       $resourceCollection
-     * @param array                 $data
-     */
-    public function __construct(
-        Context $context,
-        Registry $registry,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
-        array $data = []
-    ) {
-        parent::__construct(
-            $context,
-            $registry,
-            $resource,
-            $resourceCollection,
-            $data
-        );
-    }
-
     protected function _construct()
     {
         $this->_init(MetadataResource::class);

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -17,6 +17,8 @@
 
 namespace Taxjar\SalesTax\Model;
 
+use Magento\Bundle\Model\Product\Price;
+use Magento\Catalog\Model\Product\Type;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Directory\Model\RegionFactory;
@@ -215,7 +217,8 @@ class Smartcalcs
                     );
                     $metadata = [
                         MetadataInterface::TAX_CALCULATION_STATUS => Metadata::TAX_CALCULATION_STATUS_ERROR,
-                        MetadataInterface::TAX_CALCULATION_MESSAGE => $errorResponse->error . ' - ' . $errorResponse->detail,
+                        MetadataInterface::TAX_CALCULATION_MESSAGE =>
+                            $errorResponse->error . ' - ' . $errorResponse->detail,
                     ];
                 }
             } catch (\Zend_Http_Client_Exception $e) {
@@ -495,10 +498,10 @@ class Smartcalcs
                     $extensionAttributes = $item->getExtensionAttributes();
                     $taxCode = '';
 
-                    if ($extensionAttributes->getProductType() == \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE) {
+                    if ($extensionAttributes->getProductType() == Type::TYPE_BUNDLE) {
                         $parentQuantities[$id] = $quantity;
 
-                        if ($extensionAttributes->getPriceType() == \Magento\Bundle\Model\Product\Price::PRICE_TYPE_DYNAMIC) {
+                        if ($extensionAttributes->getPriceType() == Price::PRICE_TYPE_DYNAMIC) {
                             continue;
                         }
                     }
@@ -524,8 +527,12 @@ class Smartcalcs
                         $taxCode = $taxClass->getTjSalestaxCode();
                     }
 
-                    if ($this->productMetadata->getEdition() == 'Enterprise' || $this->productMetadata->getEdition() == 'B2B') {
-                        if ($extensionAttributes->getProductType() == \Magento\GiftCard\Model\Catalog\Product\Type\Giftcard::TYPE_GIFTCARD) {
+                    if ($this->productMetadata->getEdition() == 'Enterprise' ||
+                        $this->productMetadata->getEdition() == 'B2B'
+                    ) {
+                        if ($extensionAttributes->getProductType() ==
+                            \Magento\GiftCard\Model\Catalog\Product\Type\Giftcard::TYPE_GIFTCARD
+                        ) {
                             $giftTaxClassId = $this->scopeConfig->getValue('tax/classes/wrapping_tax_class',
                                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
                                 $quote->getStoreId()

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -527,24 +527,25 @@ class Smartcalcs
                         $taxCode = $taxClass->getTjSalestaxCode();
                     }
 
-                    if ($this->productMetadata->getEdition() == 'Enterprise' ||
+                    if ((
+                        $this->productMetadata->getEdition() == 'Enterprise' ||
                         $this->productMetadata->getEdition() == 'B2B'
-                    ) {
-                        if ($extensionAttributes->getProductType() ==
+                        ) && (
+                            $extensionAttributes->getProductType() ==
                             \Magento\GiftCard\Model\Catalog\Product\Type\Giftcard::TYPE_GIFTCARD
-                        ) {
-                            $giftTaxClassId = $this->scopeConfig->getValue('tax/classes/wrapping_tax_class',
-                                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                                $quote->getStoreId()
-                            );
+                        )
+                    ) {
+                        $giftTaxClassId = $this->scopeConfig->getValue('tax/classes/wrapping_tax_class',
+                            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                            $quote->getStoreId()
+                        );
 
-                            if ($giftTaxClassId) {
-                                $giftTaxClass = $this->taxClassRepository->get($giftTaxClassId);
-                                $giftTaxClassCode = $giftTaxClass->getTjSalestaxCode();
-                                $taxCode = $giftTaxClassCode;
-                            } else {
-                                $taxCode = TaxjarConfig::TAXJAR_GIFT_CARD_TAX_CODE;
-                            }
+                        if ($giftTaxClassId) {
+                            $giftTaxClass = $this->taxClassRepository->get($giftTaxClassId);
+                            $giftTaxClassCode = $giftTaxClass->getTjSalestaxCode();
+                            $taxCode = $giftTaxClassCode;
+                        } else {
+                            $taxCode = TaxjarConfig::TAXJAR_GIFT_CARD_TAX_CODE;
                         }
                     }
 

--- a/Model/Tax/Nexus/Repository.php
+++ b/Model/Tax/Nexus/Repository.php
@@ -246,9 +246,13 @@ class Repository implements \Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface
         && $nexus->getCountryId() != 'US'
         && $nexus->getCountryId() != 'CA') {
             if ($nexus->getStoreId() != 0) {
-                $exception->addError(__('Only one address per country (outside of US/CA) is currently supported per store.'));
+                $exception->addError(
+                    __('Only one address per country (outside of US/CA) is currently supported per store.')
+                );
             } else {
-                $exception->addError(__('Only one address per country (outside of US/CA) is currently supported across all stores.'));
+                $exception->addError(
+                    __('Only one address per country (outside of US/CA) is currently supported across all stores.')
+                );
             }
         }
 
@@ -258,7 +262,9 @@ class Repository implements \Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface
             if ($nexus->getStoreId() != 0) {
                 $exception->addError(__('Only one address per region / state is currently supported per store.'));
             } else {
-                $exception->addError(__('Only one address per region / state is currently supported across all stores.'));
+                $exception->addError(
+                    __('Only one address per region / state is currently supported across all stores.')
+                );
             }
         }
 

--- a/Model/Tax/NexusSync.php
+++ b/Model/Tax/NexusSync.php
@@ -168,7 +168,9 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
                     continue;
                 }
 
-                if (($address['country'] == 'US' || $address['country'] == 'CA') && (!isset($address['state']) || empty($address['state']))) {
+                if (($address['country'] == 'US' || $address['country'] == 'CA') &&
+                    (!isset($address['state']) || empty($address['state']))
+                ) {
                     continue;
                 }
 

--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -356,7 +356,11 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
                 $children = $item->getChildren();
 
                 if (is_array($children) && isset($children[0])) {
-                    $product = $this->productRepository->getById($children[0]->getProductId(), false, $item->getStoreId());
+                    $product = $this->productRepository->getById(
+                        $children[0]->getProductId(),
+                        false,
+                        $item->getStoreId()
+                    );
                 }
             }
 

--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -351,7 +351,9 @@ class Transaction
             if (isset($parentItemId)) {
                 switch ($attr) {
                     case 'discount':
-                        $amount = (float) (($type == 'order') ? $item->getDiscountAmount() : $item->getDiscountRefunded());
+                        $amount = (float) (
+                            ($type == 'order') ? $item->getDiscountAmount() : $item->getDiscountRefunded()
+                        );
                         break;
                     case 'tax':
                         $amount = (float) (($type == 'order') ? $item->getTaxAmount() : $item->getTaxRefunded());
@@ -424,7 +426,8 @@ class Transaction
             }
 
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
-            $msg = 'Product #' . $item->getProductId() . ' does not exist.  Order #' . $order->getIncrementId() . ' possibly missing product tax codes.';
+            $msg = 'Product #' . $item->getProductId() . ' does not exist.  ';
+            $msg .= 'Order #' . $order->getIncrementId() . ' possibly missing product tax codes.';
             $this->logger->log($msg, 'error');
         }
 

--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -99,7 +99,10 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
             if ($forceFlag) {
                 $this->logger->log('Forced update of Order #' . $this->request['transaction_id'], 'api');
             } else {
-                $this->logger->log('Order #' . $this->request['transaction_id'] . ' not updated since last sync', 'skip');
+                $this->logger->log(
+                    'Order #' . $this->request['transaction_id'] . ' not updated since last sync',
+                    'skip'
+                );
                 return;
             }
         }

--- a/Observer/Customer/Customer.php
+++ b/Observer/Customer/Customer.php
@@ -98,12 +98,16 @@ abstract class Customer implements ObserverInterface
 
                 if (isset($message->status) && $message->status == 422) {  //unprocessable
                     try {
-                        $this->logger->log('Could not create customer #' . $customerId . ', attempting to update instead',
-                            'fallback');
+                        $this->logger->log(
+                            'Could not create customer #' . $customerId . ', attempting to update instead',
+                            'fallback'
+                        );
                         $response = $this->client->putResource('customers', $customerId, $data);
                     } catch (LocalizedException $e) {
-                        $this->logger->log('Could not update customer #' . $customerId . ": " . $e->getMessage(),
-                            'error');
+                        $this->logger->log(
+                            'Could not update customer #' . $customerId . ": " . $e->getMessage(),
+                            'error'
+                        );
                     }
                 } else {
                     $this->logger->log('Could not create customer #' . $customerId . ': ' . $e->getMessage(), 'error');
@@ -117,12 +121,16 @@ abstract class Customer implements ObserverInterface
 
                 if (isset($message->status) && $message->status == 404) {  //unprocessable
                     try {
-                        $this->logger->log('Could not update customer #' . $customerId . ', attempting to create instead',
-                            'fallback');
+                        $this->logger->log(
+                            'Could not update customer #' . $customerId . ', attempting to create instead',
+                            'fallback'
+                        );
                         $response = $this->client->postResource('customers', $data);
                     } catch (LocalizedException $e) {
-                        $this->logger->log('Could not create customer #' . $customerId . ": " . $e->getMessage(),
-                            'error');
+                        $this->logger->log(
+                            'Could not create customer #' . $customerId . ": " . $e->getMessage(),
+                            'error'
+                        );
                     }
                 } else {
                     $this->logger->log('Could not update customer #' . $customerId . ': ' . $e->getMessage(), 'error');

--- a/Observer/ImportData.php
+++ b/Observer/ImportData.php
@@ -59,7 +59,7 @@ class ImportData implements ObserverInterface
     protected $apiKey;
 
     /**
-     * @var string
+     * @var \Taxjar\SalesTax\Model\Client
      */
     protected $client;
 
@@ -103,14 +103,12 @@ class ImportData implements ObserverInterface
      * @throws LocalizedException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    // @codingStandardsIgnoreStart
     public function execute(Observer $observer)
     {
-        // @codingStandardsIgnoreEnd
         if ($this->apiKey) {
             $this->client = $this->clientFactory->create();
 
-	        $region = $this->backupRateOriginAddress->getShippingRegionCode();
+            $region = $this->backupRateOriginAddress->getShippingRegionCode();
 
             if ($region) {
                 $this->_setConfiguration();
@@ -125,7 +123,7 @@ class ImportData implements ObserverInterface
     /**
      * Get TaxJar user account configuration
      *
-     * @return string
+     * @return array
      */
     private function _getConfigJson()
     {

--- a/Plugin/Sales/Model/Order/ItemRepository.php
+++ b/Plugin/Sales/Model/Order/ItemRepository.php
@@ -63,7 +63,8 @@ class ItemRepository
                 $ptc = $product->getTjPtc() ?: TaxjarConfig::TAXJAR_TAXABLE_TAX_CODE;
                 $item->setTjPtc($ptc);
             } catch (NoSuchEntityException $e) {
-                $msg = 'Product #' . $item->getProductId() . ' does not exist.  Order #' . $item->getOrderId() . ' possibly missing PTCs on OrderItems.';
+                $msg = 'Product #' . $item->getProductId() . ' does not exist.  ';
+                $msg .= 'Order #' . $item->getOrderId() . ' possibly missing PTCs on OrderItems.';
                 $this->logger->log($msg, 'error');
             }
         }

--- a/Test/Integration/Model/Tax/Sales/Total/Quote/TaxTest.php
+++ b/Test/Integration/Model/Tax/Sales/Total/Quote/TaxTest.php
@@ -141,7 +141,11 @@ class TaxTest extends \PHPUnit\Framework\TestCase
             if ($key == 'applied_taxes') {
                 $this->verifyAppliedTaxes($quoteAddress->getAppliedTaxes(), $value);
             } else {
-                $this->assertEquals($value, $quoteAddress->getData($key), 'Quote address ' . $key . ' is incorrect', 0.01);
+                $this->assertEquals(
+                    $value,
+                    $quoteAddress->getData($key),
+                    'Quote address ' . $key . ' is incorrect',
+                );
             }
         }
 

--- a/Test/Integration/_files/transaction/models/shipment.php
+++ b/Test/Integration/_files/transaction/models/shipment.php
@@ -12,7 +12,7 @@ if (!$order->canShip()) {
 $convertOrder = $objectManager->create(ConvertOrder::class);
 $shipment = $convertOrder->toShipment($order);
 
-foreach ($order->getAllItems() AS $orderItem) {
+foreach ($order->getAllItems() as $orderItem) {
     if (!$orderItem->getQtyToShip() || $orderItem->getIsVirtual()) {
         continue;
     }

--- a/Test/Unit/Model/Import/CreateRatesConsumerTest.php
+++ b/Test/Unit/Model/Import/CreateRatesConsumerTest.php
@@ -85,9 +85,18 @@ class CreateRatesConsumerTest extends UnitTestCase
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->entityManager = $this->createMock(EntityManager::class);
         $this->taxjarConfig = $this->createMock(TaxjarConfig::class);
-        $this->rateFactory = $this->getMockBuilder(RateFactory::class)->disableOriginalConstructor()->setMethods(['create'])->getMock();
-        $this->ruleFactory = $this->getMockBuilder(RuleFactory::class)->disableOriginalConstructor()->setMethods(['create'])->getMock();
-        $this->configCollection = $this->getMockBuilder(CollectionFactory::class)->disableOriginalConstructor()->setMethods(['create'])->getMock();
+        $this->rateFactory = $this->getMockBuilder(RateFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->ruleFactory = $this->getMockBuilder(RuleFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->configCollection = $this->getMockBuilder(CollectionFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
     }
 
     public function testValidatePayloadReturnsSelfWithValidPayload()

--- a/Test/Unit/Model/Tax/NexusSyncTest.php
+++ b/Test/Unit/Model/Tax/NexusSyncTest.php
@@ -118,10 +118,22 @@ class NexusSyncTest extends UnitTestCase
         $clientMock->expects(static::once())
             ->method('postResource')
             ->with('nexus', $dataMock, [
-                '400' => __('Your nexus address contains invalid data. Please verify the address in order to sync with TaxJar.'),
-                '409' => __('A nexus address already exists for this state/region. TaxJar currently supports one address per region.'),
-                '422' => __('Your nexus address is missing one or more required fields. Please verify the address in order to sync with TaxJar.'),
-                '500' => __('Something went wrong while syncing your address with TaxJar. Please verify the address and contact support@taxjar.com if the problem persists.')
+                '400' => __(
+                    'Your nexus address contains invalid data. ' .
+                    'Please verify the address in order to sync with TaxJar.'
+                ),
+                '409' => __(
+                    'A nexus address already exists for this state/region. ' .
+                    'TaxJar currently supports one address per region.'
+                ),
+                '422' => __(
+                    'Your nexus address is missing one or more required fields. ' .
+                    'Please verify the address in order to sync with TaxJar.'
+                ),
+                '500' => __(
+                    'Something went wrong while syncing your address with TaxJar. ' .
+                    'Please verify the address and contact support@taxjar.com if the problem persists.'
+                )
             ])
             ->willReturn(['id' => 101]);
 
@@ -155,10 +167,22 @@ class NexusSyncTest extends UnitTestCase
         $clientMock->expects(static::once())
             ->method('putResource')
             ->with('nexus', 'test_id', $dataMock, [
-                '400' => __('Your nexus address contains invalid data. Please verify the address in order to sync with TaxJar.'),
-                '409' => __('A nexus address already exists for this state/region. TaxJar currently supports one address per region.'),
-                '422' => __('Your nexus address is missing one or more required fields. Please verify the address in order to sync with TaxJar.'),
-                '500' => __('Something went wrong while syncing your address with TaxJar. Please verify the address and contact support@taxjar.com if the problem persists.')
+                '400' => __(
+                    'Your nexus address contains invalid data. ' .
+                    'Please verify the address in order to sync with TaxJar.'
+                ),
+                '409' => __(
+                    'A nexus address already exists for this state/region. ' .
+                    'TaxJar currently supports one address per region.'
+                ),
+                '422' => __(
+                    'Your nexus address is missing one or more required fields. ' .
+                    'Please verify the address in order to sync with TaxJar.'
+                ),
+                '500' => __(
+                    'Something went wrong while syncing your address with TaxJar. ' .
+                    'Please verify the address and contact support@taxjar.com if the problem persists.'
+                )
             ]);
 
         $this->clientFactoryMock->expects(static::once())->method('create')->willReturn($clientMock);
@@ -185,7 +209,10 @@ class NexusSyncTest extends UnitTestCase
             ->method('deleteResource')
             ->with('nexus', 'test_id', [
                 '409' => __('A nexus address with this ID could not be found in TaxJar.'),
-                '500' => __('Something went wrong while deleting your address in TaxJar. Please contact support@taxjar.com if the problem persists.')
+                '500' => __(
+                    'Something went wrong while deleting your address in TaxJar. ' .
+                    'Please contact support@taxjar.com if the problem persists.'
+                )
             ])
             ->willReturn(null);
 
@@ -237,7 +264,10 @@ class NexusSyncTest extends UnitTestCase
             ->withConsecutive(['TX', 'US'], ['', 'GB'])
             ->willReturnSelf();
         $regionMock->expects(static::once())->method('getId')->willReturn(99);
-        $this->regionFactoryMock->expects(static::atLeast(2))->method('create')->willReturn($regionMock);
+
+        $this->regionFactoryMock->expects(static::atLeast(2))
+            ->method('create')
+            ->willReturn($regionMock);
 
         $countryMock = $this->getMockBuilder(Country::class)->disableOriginalConstructor()->getMock();
         $countryMock->expects(static::exactly(2))
@@ -245,7 +275,11 @@ class NexusSyncTest extends UnitTestCase
             ->withConsecutive(['US'], ['GB'])
             ->willReturnSelf();
         $countryMock->expects(static::once())->method('getId')->willReturn(77);
-        $this->countryFactoryMock->expects(static::atLeast(2))->method('create')->willReturn($countryMock);
+
+        $this->countryFactoryMock->expects(static::atLeast(2))
+            ->method('create')
+            ->willReturn($countryMock);
+
         $this->nexusResourceMock->expects(static::any())->method('getIdFieldName')->willReturn('id');
 
         $nexusResult = $this->getMockBuilder(Nexus::class)->disableOriginalConstructor()->getMock();
@@ -254,14 +288,20 @@ class NexusSyncTest extends UnitTestCase
         $nexusResult->expects(static::atLeastOnce())->method('setData')->willReturnSelf();
         $nexusResult->expects(static::atLeastOnce())->method('save')->willReturnSelf();
 
-        $nexusCollectionMock = $this->getMockBuilder(Collection::class)->disableOriginalConstructor()->getMock();
+        $nexusCollectionMock = $this->getMockBuilder(Collection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $nexusCollectionMock->expects(static::once())->method('addRegionFilter')->willReturnSelf();
         $nexusCollectionMock->expects(static::once())->method('addCountryFilter')->willReturnSelf();
-        $nexusCollectionMock->expects(static::atLeast(2))->method('getFirstItem')->willReturn($nexusResult);
+        $nexusCollectionMock->expects(static::atLeast(2))
+            ->method('getFirstItem')
+            ->willReturn($nexusResult);
 
         $nexusMock = $this->getMockBuilder(Nexus::class)->disableOriginalConstructor()->getMock();
         $nexusMock->expects(static::any())->method('getIdFieldName')->willReturn('id');
-        $nexusMock->expects(static::exactly(2))->method('getCollection')->willReturn($nexusCollectionMock);
+        $nexusMock->expects(static::exactly(2))
+            ->method('getCollection')
+            ->willReturn($nexusCollectionMock);
 
         $this->nexusFactoryMock->expects(static::exactly(2))->method('create')->willReturn($nexusMock);
 

--- a/Test/Unit/Observer/BackfillTransactionsTest.php
+++ b/Test/Unit/Observer/BackfillTransactionsTest.php
@@ -393,11 +393,13 @@ class BackfillTransactionsTest extends UnitTestCase
         $this->setExpectations();
 
         $observerMock = $this->createMock(Observer::class);
-        $observerMock->expects($this->any())->method('getData')->willReturnMap([
-            ['from', null, null],
-            ['to', null, null],
-            ['force', null, $forceSync],
-        ],);
+        $observerMock->expects($this->any())
+            ->method('getData')
+            ->willReturnMap([
+                ['from', null, null],
+                ['to', null, null],
+                ['force', null, $forceSync],
+            ]);
         $this->sut->observer = $observerMock;
 
         $criteriaMock = $this->getMockForAbstractClass(SearchCriteriaInterface::class);

--- a/Test/Unit/Observer/ImportRatesTest.php
+++ b/Test/Unit/Observer/ImportRatesTest.php
@@ -109,15 +109,27 @@ class ImportRatesTest extends UnitTestCase
         $this->messageManager = $this->createMock(MessageManagerInterface::class);
         $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
         $this->resourceConfig = $this->createMock(Config::class);
-        $this->clientFactory = $this->getMockBuilder(ClientFactory::class)->disableOriginalConstructor()->setMethods(['create'])->getMock();
-        $this->rateFactory = $this->getMockBuilder(RateFactory::class)->disableOriginalConstructor()->setMethods(['create'])->getMock();
-        $this->ruleFactory = $this->getMockBuilder(RuleFactory::class)->disableOriginalConstructor()->setMethods(['create'])->getMock();
+        $this->clientFactory = $this->getMockBuilder(ClientFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->rateFactory = $this->getMockBuilder(RateFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->ruleFactory = $this->getMockBuilder(RuleFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
         $this->rateRepository = $this->createMock(RateRepository::class);
         $this->taxjarConfig = $this->createMock(TaxjarConfig::class);
         $this->backupRateOriginAddress = $this->createMock(BackupRateOriginAddress::class);
         $this->identityService = $this->createMock(IdentityGeneratorInterface::class);
         $this->serializer = $this->createMock(SerializerInterface::class);
-        $this->operationFactory = $this->getMockBuilder(OperationInterfaceFactory::class)->disableOriginalConstructor()->setMethods(['create'])->getMock();
+        $this->operationFactory = $this->getMockBuilder(OperationInterfaceFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            >getMock();
         $this->bulkManagement = $this->createMock(BulkManagementInterface::class);
         $this->userContext = $this->createMock(UserContextInterface::class);
         $this->cacheManager = $this->createMock(Manager::class);
@@ -156,7 +168,10 @@ class ImportRatesTest extends UnitTestCase
             $this->getMockClient($this->mockRates)
         );
         $this->taxjarConfig->expects($this->once())->method('getApiKey')->willReturn('valid-api-key');
-        $this->backupRateOriginAddress->expects($this->once())->method('getShippingZipCode')->willReturn('99999');
+
+        $this->backupRateOriginAddress->expects($this->once())
+            ->method('getShippingZipCode')
+            ->willReturn('99999');
 
         $sut = $this->getTestSubject();
         $result = $sut->execute(new Observer());
@@ -277,7 +292,9 @@ class ImportRatesTest extends UnitTestCase
                 '0'
             );
 
-        $this->clientFactory->expects($this->once())->method('create')->willReturn($this->getMockClient($this->mockRates));
+        $this->clientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->getMockClient($this->mockRates));
         $this->taxjarConfig->expects($this->once())->method('getApiKey')->willReturn('valid-api-key');
         $this->backupRateOriginAddress->expects($this->once())->method('getShippingZipCode')->willReturn('99999');
         $this->backupRateOriginAddress->expects($this->once())->method('isScopeCountryCodeUS')->willReturn(false);
@@ -301,7 +318,9 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithExistingRates()
     {
-        $this->eventManager->expects($this->once())->method('dispatch')->with('taxjar_salestax_import_rates_after');
+        $this->eventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('taxjar_salestax_import_rates_after');
         $this->messageManager->expects($this->once())->method('addSuccessMessage');
 
         $this->scopeConfig->expects($this->exactly(5))
@@ -321,7 +340,10 @@ class ImportRatesTest extends UnitTestCase
             );
 
         $this->resourceConfig->expects($this->exactly(2))->method('saveConfig');
-        $this->clientFactory->expects($this->once())->method('create')->willReturn($this->getMockClient($this->mockRates));
+
+        $this->clientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->getMockClient($this->mockRates));
 
         $mockRateModel = $this->createMock(Rate::class);
         $mockRateModel->expects($this->once())->method('getExistingRates')->willReturn(['old_rate_1', 'old_rate_2']);
@@ -337,9 +359,17 @@ class ImportRatesTest extends UnitTestCase
         $this->backupRateOriginAddress->expects($this->once())->method('getShippingZipCode')->willReturn('99999');
         $this->backupRateOriginAddress->expects($this->once())->method('isScopeCountryCodeUS')->willReturn(true);
         $this->identityService->expects($this->exactly(2))->method('generateId')->willReturn('unique-identifier');
-        $this->serializer->expects($this->exactly(2))->method('serialize')->willReturn(json_encode(['data' => 'payload']));
-        $this->operationFactory->expects($this->exactly(2))->method('create')->withAnyParameters()->willReturn($this->createMock(Operation::class));
-        $this->bulkManagement->expects($this->exactly(2))->method('scheduleBulk')->withAnyParameters()->willReturn(true);
+        $this->serializer->expects($this->exactly(2))
+            ->method('serialize')
+            ->willReturn(json_encode(['data' => 'payload']));
+        $this->operationFactory->expects($this->exactly(2))
+            ->method('create')
+            ->withAnyParameters()
+            ->willReturn($this->createMock(Operation::class));
+        $this->bulkManagement->expects($this->exactly(2))
+            ->method('scheduleBulk')
+            ->withAnyParameters()
+            ->willReturn(true);
         $this->userContext->expects($this->exactly(2))->method('getUserId')->willReturn('9999999');
         $this->cacheManager->expects($this->once())->method('flush')->withAnyParameters()->willReturn(true);
 
@@ -351,7 +381,9 @@ class ImportRatesTest extends UnitTestCase
 
     public function testExecuteWithoutExistingRates()
     {
-        $this->eventManager->expects($this->once())->method('dispatch')->with('taxjar_salestax_import_rates_after');
+        $this->eventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('taxjar_salestax_import_rates_after');
         $this->messageManager->expects($this->once())->method('addSuccessMessage');
 
         $this->scopeConfig->expects($this->exactly(5))
@@ -371,7 +403,9 @@ class ImportRatesTest extends UnitTestCase
             );
 
         $this->resourceConfig->expects($this->exactly(2))->method('saveConfig');
-        $this->clientFactory->expects($this->once())->method('create')->willReturn($this->getMockClient($this->mockRates));
+        $this->clientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->getMockClient($this->mockRates));
 
         $mockRateModel = $this->createMock(Rate::class);
         $mockRateModel->expects($this->once())->method('getExistingRates')->willReturn([]);
@@ -396,7 +430,9 @@ class ImportRatesTest extends UnitTestCase
 
     public function testCron()
     {
-        $this->eventManager->expects($this->once())->method('dispatch')->with('taxjar_salestax_import_rates_after');
+        $this->eventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('taxjar_salestax_import_rates_after');
         $this->messageManager->expects($this->once())->method('addSuccessMessage');
 
         $this->scopeConfig->expects($this->exactly(5))
@@ -416,7 +452,9 @@ class ImportRatesTest extends UnitTestCase
             );
 
         $this->resourceConfig->expects($this->any())->method('saveConfig');
-        $this->clientFactory->expects($this->once())->method('create')->willReturn($this->getMockClient($this->mockRates));
+        $this->clientFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->getMockClient($this->mockRates));
 
         $mockRateModel = $this->createMock(Rate::class);
         $mockRateModel->expects($this->once())->method('getExistingRates')->willReturn(['old_rate_1', 'old_rate_2']);
@@ -431,12 +469,17 @@ class ImportRatesTest extends UnitTestCase
         $this->backupRateOriginAddress->expects($this->once())->method('getShippingZipCode')->willReturn('99999');
         $this->backupRateOriginAddress->expects($this->once())->method('isScopeCountryCodeUS')->willReturn(true);
         $this->identityService->expects($this->exactly(2))->method('generateId')->willReturn('unique-identifier');
-        $this->serializer->expects($this->exactly(2))->method('serialize')->willReturn(json_encode(['data' => 'payload']));
+        $this->serializer->expects($this->exactly(2))
+            ->method('serialize')
+            ->willReturn(json_encode(['data' => 'payload']));
         $this->operationFactory->expects($this->exactly(2))->method('create')->withAnyParameters()->willReturn(
             $this->createMock(Operation::class)
         );
 
-        $this->bulkManagement->expects($this->exactly(2))->method('scheduleBulk')->withAnyParameters()->willReturn(true);
+        $this->bulkManagement->expects($this->exactly(2))
+            ->method('scheduleBulk')
+            ->withAnyParameters()
+            ->willReturn(true);
         $this->userContext->expects($this->exactly(2))->method('getUserId')->willReturn('9999999');
 
         $sut = $this->getTestSubject();

--- a/Ui/DataProvider/Product/Form/Modifier/TaxTip.php
+++ b/Ui/DataProvider/Product/Form/Modifier/TaxTip.php
@@ -28,7 +28,8 @@ class TaxTip extends AbstractModifier
     public function modifyMeta(array $meta)
     {
         if (isset($meta['product-details']['children']['container_tax_class_id']['children']['tax_class_id'])) {
-            $url = \Taxjar\SalesTax\Model\Configuration::TAXJAR_MAGETWO_GUIDE_URL . '/#section-product-sales-tax-exemptions';
+            $url = \Taxjar\SalesTax\Model\Configuration::TAXJAR_MAGETWO_GUIDE_URL;
+            $url .= '/#section-product-sales-tax-exemptions';
             $desc = 'TaxJar requires a product tax class assigned to a TaxJar category in order to exempt products from
                      sales tax. <a href="' . $url . '" target="_blank">Click here</a> to learn more.';
             $meta['product-details']['children']['container_tax_class_id']['children']['tax_class_id']['arguments']

--- a/view/adminhtml/templates/backup.phtml
+++ b/view/adminhtml/templates/backup.phtml
@@ -16,6 +16,9 @@
  */
 
 /** @var \Taxjar\SalesTax\Block\Adminhtml\Backup $block */
+
+$syncRatesUrl = $block->getStoreUrl('taxjar/config/syncRates');
+$systemTaxConfigUrl = $block->getStoreUrl('adminhtml/system_config/edit', ['section' => 'tax']);
 ?>
 
 <p class='note'>
@@ -25,7 +28,7 @@
     </span>
 </p>
 
-<?php if ($block->isEnabled()) { ?>
+<?php if ($block->isEnabled()): ?>
     <p class="success-msg" style="background: none !important; padding-left: 1rem; font-weight: 700;">
         <small>
             <?php echo $block->getActualRateCount() ?>
@@ -47,23 +50,18 @@
 
     <script>
         function syncBackupRates() {
-            new Ajax.Request(
-                '<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/syncRates')) ?>',
-                {
-                    method: 'get',
-                    onCreate: function(request) {
-                        varienLoaderHandler.handler.onCreate({
-                            options: { loaderArea: true }
-                        });
-                    },
-                    onComplete: function(data) {
-                        varienLoaderHandler.handler.onComplete();
-                        window.location = '<?php echo $block->escapeUrl(
-                            $block->getStoreUrl('adminhtml/system_config/edit', ['section' => 'tax'])
-                        )?>';
-                    }
+            new Ajax.Request('<?= $block->escapeUrl($syncRatesUrl) ?>', {
+                method: 'get',
+                onCreate: function(request) {
+                    varienLoaderHandler.handler.onCreate({
+                        options: { loaderArea: true }
+                    });
+                },
+                onComplete: function(data) {
+                    varienLoaderHandler.handler.onComplete();
+                    window.location = '<?= $block->escapeUrl($systemTaxConfigUrl) ?>';
                 }
-            );
+            });
         }
     </script>
-<?php } ?>
+<?php endif ?>

--- a/view/adminhtml/templates/messages/tjSandboxWarning.phtml
+++ b/view/adminhtml/templates/messages/tjSandboxWarning.phtml
@@ -17,7 +17,11 @@
 
 /** @var \Magento\Framework\View\Element\Template $block */
 
-$msg = __('Sandbox mode is enabled for sales tax calculations. We recommend only using this mode in a staging environment. Some features may not work as expected.');
+$msg = __(
+    'Sandbox mode is enabled for sales tax calculations. ' .
+    'We recommend only using this mode in a staging environment. ' .
+    'Some features may not work as expected.'
+);
 $url = 'https://developers.taxjar.com/api/reference/#sandbox-environment';
 $href = '<a href="%1" target="_blank" rel="noopener">' . __('Learn more') . '</a>';
 


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Implement GitHub actions workflow.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Corrects PHPCS sniffs for: 
- `Generic.CodeAnalysis.UselessOverridingMethod.Found`
- `Generic.Files.LineLength.TooLong`
- `Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma`
- `Generic.Metrics.NestingLevel.TooHigh`
- `Generic.PHP.LowerCaseKeyword.Found`
- `Generic.WhiteSpace.DisallowTabIndent.TabsUsed`
- `Generic.WhiteSpace.ScopeIndent.Incorrect`

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Search GH actions PHPCS output for `Generic.`
2. Observe no type `Generic` sniffs found

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
