### PR TITLE
chore: Correct PhpCS Generic FunctionCallArgumentSpacing sniffs

### DIFF
--- a/Test/Unit/Observer/BackfillTransactionsTest.php
+++ b/Test/Unit/Observer/BackfillTransactionsTest.php
@@ -393,11 +393,14 @@ class BackfillTransactionsTest extends UnitTestCase
         $this->setExpectations();
 
         $observerMock = $this->createMock(Observer::class);
-        $observerMock->expects($this->any())->method('getData')->willReturnMap([
-            ['from', null, null],
-            ['to', null, null],
-            ['force', null, $forceSync],
-        ],);
+        $observerMock->expects($this->any())
+            ->method('getData')
+            ->willReturnMap([
+                ['from', null, null],
+                ['to', null, null],
+                ['force', null, $forceSync],
+            ]);
+
         $this->sut->observer = $observerMock;
 
         $criteriaMock = $this->getMockForAbstractClass(SearchCriteriaInterface::class);


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Implement GitHub actions workflow.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Corrects PHPCS sniffs for: 
- `Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma`

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Search GH actions PHPCS output [here](https://github.com/taxjar/taxjar-magento2-extension/runs/5399391505) for `Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma`
2. Observe no type `Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma` sniffs found

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
