### PR TITLE
chore: Correct PhpCS Generic UselessOverridingMethod sniffs

### DIFF
--- a/Block/Adminhtml/Tax/Taxclass/Customer/Grid/Renderer/Exempt.php
+++ b/Block/Adminhtml/Tax/Taxclass/Customer/Grid/Renderer/Exempt.php
@@ -26,17 +26,6 @@ use Magento\Framework\DataObject;
 class Exempt extends AbstractRenderer
 {
     /**
-     * @param \Magento\Backend\Block\Context $context
-     * @param array $data
-     */
-    public function __construct(
-        \Magento\Backend\Block\Context $context,
-        array $data = []
-    ) {
-        parent::__construct($context, $data);
-    }
-
-    /**
      * Renders grid column
      *
      * @param DataObject $row

--- a/Block/Adminhtml/TransactionSync/Form.php
+++ b/Block/Adminhtml/TransactionSync/Form.php
@@ -38,21 +38,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     protected $_template = 'transaction_sync/form.phtml';
 
     /**
-     * @param \Magento\Backend\Block\Template\Context $context
-     * @param \Magento\Framework\Registry $registry
-     * @param \Magento\Framework\Data\FormFactory $formFactory
-     * @param array $data
-     */
-    public function __construct(
-        \Magento\Backend\Block\Template\Context $context,
-        \Magento\Framework\Registry $registry,
-        \Magento\Framework\Data\FormFactory $formFactory,
-        array $data = []
-    ) {
-        parent::__construct($context, $registry, $formFactory, $data);
-    }
-
-    /**
      * @return void
      */
     protected function _construct()

--- a/Controller/Adminhtml/Taxclass/Customer.php
+++ b/Controller/Adminhtml/Taxclass/Customer.php
@@ -20,21 +20,6 @@ namespace Taxjar\SalesTax\Controller\Adminhtml\Taxclass;
 abstract class Customer extends \Taxjar\SalesTax\Controller\Adminhtml\Taxclass
 {
     /**
-     * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\Framework\Registry $coreRegistry
-     * @param \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassService
-     * @param \Magento\Tax\Api\Data\TaxClassInterfaceFactory $taxClassDataObjectFactory
-     */
-    public function __construct(
-        \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Registry $coreRegistry,
-        \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassService,
-        \Magento\Tax\Api\Data\TaxClassInterfaceFactory $taxClassDataObjectFactory
-    ) {
-        parent::__construct($context, $coreRegistry, $taxClassService, $taxClassDataObjectFactory);
-    }
-
-    /**
      * Initialize action
      *
      * @return \Magento\Backend\Model\View\Result\Page

--- a/Controller/Adminhtml/Taxclass/Product.php
+++ b/Controller/Adminhtml/Taxclass/Product.php
@@ -20,21 +20,6 @@ namespace Taxjar\SalesTax\Controller\Adminhtml\Taxclass;
 abstract class Product extends \Taxjar\SalesTax\Controller\Adminhtml\Taxclass
 {
     /**
-     * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\Framework\Registry $coreRegistry
-     * @param \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassService
-     * @param \Magento\Tax\Api\Data\TaxClassInterfaceFactory $taxClassDataObjectFactory
-     */
-    public function __construct(
-        \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Registry $coreRegistry,
-        \Magento\Tax\Api\TaxClassRepositoryInterface $taxClassService,
-        \Magento\Tax\Api\Data\TaxClassInterfaceFactory $taxClassDataObjectFactory
-    ) {
-        parent::__construct($context, $coreRegistry, $taxClassService, $taxClassDataObjectFactory);
-    }
-
-    /**
      * Initialize action
      *
      * @return \Magento\Backend\Model\View\Result\Page

--- a/Model/Sales/Order/Metadata.php
+++ b/Model/Sales/Order/Metadata.php
@@ -45,31 +45,6 @@ class Metadata extends AbstractModel implements MetadataInterface
 
     protected $_eventPrefix = 'taxjar_salestax_order_metadata';
 
-    /**
-     * Metadata constructor.
-     *
-     * @param Context               $context
-     * @param Registry              $registry
-     * @param AbstractResource|null $resource
-     * @param AbstractDb|null       $resourceCollection
-     * @param array                 $data
-     */
-    public function __construct(
-        Context $context,
-        Registry $registry,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
-        array $data = []
-    ) {
-        parent::__construct(
-            $context,
-            $registry,
-            $resource,
-            $resourceCollection,
-            $data
-        );
-    }
-
     protected function _construct()
     {
         $this->_init(MetadataResource::class);


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Implement GitHub actions workflow.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Corrects PHPCS sniffs for: 
- `Generic.CodeAnalysis.UselessOverridingMethod.Found`

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Search GH actions PHPCS output [here](https://github.com/taxjar/taxjar-magento2-extension/runs/5399411849) for `Generic.CodeAnalysis.UselessOverridingMethod.Found`
2. Observe no type `Generic.CodeAnalysis.UselessOverridingMethod.Found` sniffs found

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
