### PR TITLE
chore: Correct PhpCS Generic WhiteSpace sniffs

### DIFF
--- a/Observer/ImportData.php
+++ b/Observer/ImportData.php
@@ -103,14 +103,12 @@ class ImportData implements ObserverInterface
      * @throws LocalizedException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    // @codingStandardsIgnoreStart
     public function execute(Observer $observer)
     {
-        // @codingStandardsIgnoreEnd
         if ($this->apiKey) {
             $this->client = $this->clientFactory->create();
 
-	        $region = $this->backupRateOriginAddress->getShippingRegionCode();
+            $region = $this->backupRateOriginAddress->getShippingRegionCode();
 
             if ($region) {
                 $this->_setConfiguration();

--- a/view/adminhtml/templates/backup.phtml
+++ b/view/adminhtml/templates/backup.phtml
@@ -16,6 +16,9 @@
  */
 
 /** @var \Taxjar\SalesTax\Block\Adminhtml\Backup $block */
+
+$syncRatesUrl = $block->getStoreUrl('taxjar/config/syncRates');
+$systemTaxConfigUrl = $block->getStoreUrl('adminhtml/system_config/edit', ['section' => 'tax']);
 ?>
 
 <p class='note'>
@@ -25,13 +28,10 @@
     </span>
 </p>
 
-<?php if ($block->isEnabled()) { ?>
+<?php if ($block->isEnabled()): ?>
     <p class="success-msg" style="background: none !important; padding-left: 1rem; font-weight: 700;">
         <small>
-            <?php echo $block->getActualRateCount() ?>
-            of
-            <?php echo $block->getExpectedRateCount() ?>
-            expected rates loaded.
+            <?= $block->getActualRateCount() ?> of <?= $block->getExpectedRateCount() ?> expected rates loaded.
         </small>
     </p>
 
@@ -47,23 +47,18 @@
 
     <script>
         function syncBackupRates() {
-            new Ajax.Request(
-                '<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/syncRates')) ?>',
-                {
-                    method: 'get',
-                    onCreate: function(request) {
-                        varienLoaderHandler.handler.onCreate({
-                            options: { loaderArea: true }
-                        });
-                    },
-                    onComplete: function(data) {
-                        varienLoaderHandler.handler.onComplete();
-                        window.location = '<?php echo $block->escapeUrl(
-                            $block->getStoreUrl('adminhtml/system_config/edit', ['section' => 'tax'])
-                        )?>';
-                    }
+            new Ajax.Request('<?= $block->escapeUrl($syncRatesUrl) ?>', {
+                method: 'get',
+                onCreate: function(request) {
+                    varienLoaderHandler.handler.onCreate({
+                        options: { loaderArea: true }
+                    });
+                },
+                onComplete: function(data) {
+                    varienLoaderHandler.handler.onComplete();
+                    window.location = '<?= $block->escapeUrl($systemTaxConfigUrl) ?>';
                 }
-            );
+            });
         }
     </script>
-<?php } ?>
+<?php endif ?>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Implement GitHub actions workflow.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Corrects PHPCS sniffs for: 
- `Generic.WhiteSpace.DisallowTabIndent.TabsUsed`
- `Generic.WhiteSpace.ScopeIndent.Incorrect`

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Search GH actions PHPCS output [here](https://github.com/taxjar/taxjar-magento2-extension/runs/5399419036) for `Generic.WhiteSpace`
2. Observe no type `Generic.WhiteSpace.*` sniffs found

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
