### PR TITLE
chore: Correct PhpCS Squiz SpaceAfterCloseParenthesis sniffs

### DIFF
--- a/Test/Integration/_files/transaction/models/order_bundle.php
+++ b/Test/Integration/_files/transaction/models/order_bundle.php
@@ -99,7 +99,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach($orderItems as $orderItem) {
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_giftcard.php
+++ b/Test/Integration/_files/transaction/models/order_giftcard.php
@@ -88,7 +88,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach($orderItems as $orderItem) {
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple.php
+++ b/Test/Integration/_files/transaction/models/order_simple.php
@@ -88,7 +88,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach($orderItems as $orderItem) {
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple_AU.php
+++ b/Test/Integration/_files/transaction/models/order_simple_AU.php
@@ -89,7 +89,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach($orderItems as $orderItem) {
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple_AUD.php
+++ b/Test/Integration/_files/transaction/models/order_simple_AUD.php
@@ -89,7 +89,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach($orderItems as $orderItem) {
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple_creditmemo_partial.php
+++ b/Test/Integration/_files/transaction/models/order_simple_creditmemo_partial.php
@@ -88,7 +88,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach($orderItems as $orderItem) {
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple_ptc.php
+++ b/Test/Integration/_files/transaction/models/order_simple_ptc.php
@@ -88,7 +88,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach($orderItems as $orderItem) {
     $order->addItem($orderItem);
 }
 


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Implement GitHub actions workflow.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Corrects PHPCS sniffs for: 
- `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis`

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Search GH actions PHPCS output [here](https://github.com/taxjar/taxjar-magento2-extension/runs/5399977665) for `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis`
2. Observe no type `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis` sniffs found

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
