### PR TITLE
chore: Correct PhpCS Squiz SpaceAfterKeyword sniffs

### DIFF
--- a/Observer/ImportRates.php
+++ b/Observer/ImportRates.php
@@ -287,7 +287,7 @@ class ImportRates implements ObserverInterface
         $rateCount = count($rates);
 
         if ($rateCount) {
-            foreach($rates as $rate) {
+            foreach ($rates as $rate) {
                 $codes[] = self::getRateCode($rate);
             }
         }

--- a/Observer/SyncRefund.php
+++ b/Observer/SyncRefund.php
@@ -95,7 +95,7 @@ class SyncRefund implements ObserverInterface
                 $refundTransaction = $this->refundFactory->create();
                 $refundTransaction->build($order, $creditmemo);
                 $refundTransaction->push();
-            } catch(\Exception $e) {
+            } catch (\Exception $e) {
                 $this->messageManager->addErrorMessage($e->getMessage());
             }
         }

--- a/Test/Integration/_files/transaction/models/creditmemo_order_simple.php
+++ b/Test/Integration/_files/transaction/models/creditmemo_order_simple.php
@@ -33,7 +33,7 @@ $creditmemo = $creditmemoFactory->createByOrder($order, $order->getData());
 
 $items = $creditmemo->getAllItems();
 
-foreach($items as $item) {
+foreach ($items as $item) {
     $item->setQty(1);
 }
 

--- a/Test/Integration/_files/transaction/models/creditmemo_order_simple_adjustment.php
+++ b/Test/Integration/_files/transaction/models/creditmemo_order_simple_adjustment.php
@@ -33,7 +33,7 @@ $creditmemo = $creditmemoFactory->createByOrder($order, $order->getData());
 
 $items = $creditmemo->getAllItems();
 
-foreach($items as $item) {
+foreach ($items as $item) {
     $item->setQty(3);
 }
 

--- a/Test/Integration/_files/transaction/models/creditmemo_order_simple_partial.php
+++ b/Test/Integration/_files/transaction/models/creditmemo_order_simple_partial.php
@@ -33,7 +33,7 @@ $creditmemo = $creditmemoFactory->createByOrder($order, $order->getData());
 
 $items = $creditmemo->getAllItems();
 
-foreach($items as $item) {
+foreach ($items as $item) {
     $item->setQty(1);
 }
 

--- a/Test/Integration/_files/transaction/models/creditmemo_order_simple_shipping.php
+++ b/Test/Integration/_files/transaction/models/creditmemo_order_simple_shipping.php
@@ -33,7 +33,7 @@ $creditmemo = $creditmemoFactory->createByOrder($order, $order->getData());
 
 $items = $creditmemo->getAllItems();
 
-foreach($items as $item) {
+foreach ($items as $item) {
     $item->setQty(3);
 }
 

--- a/Test/Integration/_files/transaction/models/order_bundle.php
+++ b/Test/Integration/_files/transaction/models/order_bundle.php
@@ -62,7 +62,7 @@ $orderBundleItem->setProductId($bundleProduct->getId())
 $orderItems[] = $orderBundleItem;
 
 // Create the remaining simple items
-foreach($products as $product) {
+foreach ($products as $product) {
     /** @var OrderItem $orderItem */
     $orderItem = $objectManager->create(OrderItem::class);
     $orderItem->setProductId($product->getId())
@@ -99,7 +99,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach ($orderItems as $orderItem){
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_giftcard.php
+++ b/Test/Integration/_files/transaction/models/order_giftcard.php
@@ -52,7 +52,7 @@ $payment->setMethod('checkmo')
 $orderItems = [];
 
 // Create the remaining simple items
-foreach($products as $product) {
+foreach ($products as $product) {
     /** @var OrderItem $orderItem */
     $orderItem = $objectManager->create(OrderItem::class);
     $orderItem->setProductId($product->getId())
@@ -88,7 +88,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach ($orderItems as $orderItem){
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple.php
+++ b/Test/Integration/_files/transaction/models/order_simple.php
@@ -52,7 +52,7 @@ $payment->setMethod('checkmo')
 $orderItems = [];
 
 // Create the remaining simple items
-foreach($products as $product) {
+foreach ($products as $product) {
     /** @var OrderItem $orderItem */
     $orderItem = $objectManager->create(OrderItem::class);
     $orderItem->setProductId($product->getId())
@@ -88,7 +88,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach ($orderItems as $orderItem){
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple_AU.php
+++ b/Test/Integration/_files/transaction/models/order_simple_AU.php
@@ -52,7 +52,7 @@ $payment->setMethod('checkmo')
 $orderItems = [];
 
 // Create the remaining simple items
-foreach($products as $product) {
+foreach ($products as $product) {
     /** @var OrderItem $orderItem */
     $orderItem = $objectManager->create(OrderItem::class);
     $orderItem->setProductId($product->getId())
@@ -89,7 +89,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach ($orderItems as $orderItem){
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple_AUD.php
+++ b/Test/Integration/_files/transaction/models/order_simple_AUD.php
@@ -52,7 +52,7 @@ $payment->setMethod('checkmo')
 $orderItems = [];
 
 // Create the remaining simple items
-foreach($products as $product) {
+foreach ($products as $product) {
     /** @var OrderItem $orderItem */
     $orderItem = $objectManager->create(OrderItem::class);
     $orderItem->setProductId($product->getId())
@@ -89,7 +89,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach ($orderItems as $orderItem){
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple_creditmemo_partial.php
+++ b/Test/Integration/_files/transaction/models/order_simple_creditmemo_partial.php
@@ -52,7 +52,7 @@ $payment->setMethod('checkmo')
 $orderItems = [];
 
 // Create the remaining simple items
-foreach($products as $product) {
+foreach ($products as $product) {
     /** @var OrderItem $orderItem */
     $orderItem = $objectManager->create(OrderItem::class);
     $orderItem->setProductId($product->getId())
@@ -88,7 +88,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach ($orderItems as $orderItem){
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple_ptc.php
+++ b/Test/Integration/_files/transaction/models/order_simple_ptc.php
@@ -52,7 +52,7 @@ $payment->setMethod('checkmo')
 $orderItems = [];
 
 // Create the remaining simple items
-foreach($products as $product) {
+foreach ($products as $product) {
     /** @var OrderItem $orderItem */
     $orderItem = $objectManager->create(OrderItem::class);
     $orderItem->setProductId($product->getId())
@@ -88,7 +88,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach ($orderItems as $orderItem){
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/order_simple_shipping.php
+++ b/Test/Integration/_files/transaction/models/order_simple_shipping.php
@@ -52,7 +52,7 @@ $payment->setMethod('checkmo')
 $orderItems = [];
 
 // Create the remaining simple items
-foreach($products as $product) {
+foreach ($products as $product) {
     /** @var OrderItem $orderItem */
     $orderItem = $objectManager->create(OrderItem::class);
     $orderItem->setProductId($product->getId())
@@ -90,7 +90,7 @@ $order->setIncrementId($orderData['increment_id'])
     ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
     ->setPayment($payment);
 
-foreach($orderItems as $orderItem){
+foreach ($orderItems as $orderItem){
     $order->addItem($orderItem);
 }
 

--- a/Test/Integration/_files/transaction/models/product_bundle.php
+++ b/Test/Integration/_files/transaction/models/product_bundle.php
@@ -31,7 +31,7 @@ $productData = [
 $objectManager = ObjectManager::getInstance();
 $id = 0;
 
-foreach($productData as $data) {
+foreach ($productData as $data) {
     /** @var $bundleProduct \Magento\Catalog\Model\Product */
     $bundleProduct = $objectManager->create(\Magento\Catalog\Model\Product::class);
 

--- a/Test/Integration/_files/transaction/models/product_simple.php
+++ b/Test/Integration/_files/transaction/models/product_simple.php
@@ -58,7 +58,7 @@ $productData = [
 $x = 1;
 $products = [];
 
-foreach($productData as $data) {
+foreach ($productData as $data) {
     /** @var $product \Magento\Catalog\Model\Product */
     $product = $objectManager->create(\Magento\Catalog\Model\Product::class);
 

--- a/Test/Integration/_files/transaction/models/product_simple_ptc.php
+++ b/Test/Integration/_files/transaction/models/product_simple_ptc.php
@@ -33,7 +33,7 @@ $productData = [
 $x = 1;
 $products = [];
 
-foreach($productData as $data) {
+foreach ($productData as $data) {
     /** @var $product \Magento\Catalog\Model\Product */
     $product = $objectManager->create(\Magento\Catalog\Model\Product::class);
 

--- a/view/adminhtml/templates/enabled.phtml
+++ b/view/adminhtml/templates/enabled.phtml
@@ -56,7 +56,7 @@
                 } else {
                     throw 'Invalid data';
                 }
-            } catch(e) {
+            } catch (e) {
                 alert('Invalid API token or email provided. Please try connecting to TaxJar again or contact support@taxjar.com.');
             }
         }, false);

--- a/view/adminhtml/templates/order/view/tab/taxjar/info/sync.phtml
+++ b/view/adminhtml/templates/order/view/tab/taxjar/info/sync.phtml
@@ -32,8 +32,8 @@ $allowedTags = ['br', 'pre'];
 
 <div class="admin__page-section-item">
     <div class="admin__page-section-item-content taxjar-order-sync-information">
-    <?php if($block->featureEnabled()): ?>
-        <?php if(isset($orderAdminDate)): ?>
+    <?php if ($block->featureEnabled()): ?>
+        <?php if (isset($orderAdminDate)): ?>
             <p><i>Last synced at <?= $orderAdminDate ?></i></p>
         <?php else: ?>
             <span><?= $block->escapeHtml($block->getOrderStateText($orderState), $allowedTags) ?></span>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Implement GitHub actions workflow.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Corrects PHPCS sniffs for: 
- `Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword`

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Search GH actions PHPCS output [here](https://github.com/taxjar/taxjar-magento2-extension/runs/5400001049) for `Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword`
2. Observe no type `Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword` sniffs found

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
