### PR TITLE
fix: Cast values for PHP 8.1 compatibility

### DIFF
--- a/Block/Adminhtml/Enabled.php
+++ b/Block/Adminhtml/Enabled.php
@@ -101,7 +101,7 @@ class Enabled extends PopupField
      */
     protected function _getElementHtml(AbstractElement $element)
     {
-        $this->apiEmail = trim($this->scopeConfig->getValue(TaxjarConfig::TAXJAR_EMAIL));
+        $this->apiEmail = trim((string) $this->scopeConfig->getValue(TaxjarConfig::TAXJAR_EMAIL));
 
         if (!$this->apiKey) {
             $element->setDisabled('disabled');

--- a/Controller/Adminhtml/Taxclass.php
+++ b/Controller/Adminhtml/Taxclass.php
@@ -83,7 +83,7 @@ abstract class Taxclass extends \Magento\Backend\App\Action
      */
     protected function _processClassName($className)
     {
-        $className = trim($className);
+        $className = trim((string) $className);
         if ($className == '') {
             throw new \Magento\Framework\Exception\InputException(__('Invalid name of tax class specified.'));
         }

--- a/Model/AddressValidation.php
+++ b/Model/AddressValidation.php
@@ -386,7 +386,7 @@ class AddressValidation implements AddressValidationInterface
         $pattern = "/[\s]+/";
 
         // Explode $old and $new into arrays based on whitespace
-        $simplediff = $this->simplediff(preg_split($pattern, $old), preg_split($pattern, $new));
+        $simplediff = $this->simplediff(preg_split($pattern, (string) $old), preg_split($pattern, (string) $new));
 
         // Wrap each difference in a span for highlighting
         foreach ($simplediff as $diff) {

--- a/Model/BackupRateOriginAddress.php
+++ b/Model/BackupRateOriginAddress.php
@@ -88,7 +88,7 @@ class BackupRateOriginAddress
      */
     private function getShippingZipCodeFromScope()
     {
-        return trim($this->scopeConfig->getValue('shipping/origin/postcode'));
+        return trim((string) $this->scopeConfig->getValue('shipping/origin/postcode'));
     }
 
     /**

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -101,11 +101,13 @@ class Configuration
      */
     public function getApiKey(?int $storeId = null): string
     {
-        return preg_replace('/\s+/', '', $this->scopeConfig->getValue(
+        $apiKey = (string) $this->scopeConfig->getValue(
             $this->isSandboxEnabled() ? self::TAXJAR_SANDBOX_APIKEY : self::TAXJAR_APIKEY,
             is_null($storeId) ? ScopeConfigInterface::SCOPE_TYPE_DEFAULT : ScopeInterface::SCOPE_STORE,
             $storeId
-        ));
+        );
+
+        return preg_replace('/\s+/', '', $apiKey);
     }
 
     /**

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -438,7 +438,7 @@ class Smartcalcs
             $patterns = $postCodes[$countryId];
 
             foreach ($patterns as $pattern) {
-                preg_match('/' . $pattern['pattern'] . '/', $postcode, $matches);
+                preg_match('/' . $pattern['pattern'] . '/', (string) $postcode, $matches);
 
                 if (count($matches)) {
                     return true;

--- a/Model/Tax/Nexus/Repository.php
+++ b/Model/Tax/Nexus/Repository.php
@@ -183,7 +183,7 @@ class Repository implements \Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface
         $exception = new InputException();
         // @codingStandardsIgnoreEnd
 
-        if (!\Zend_Validate::is(trim($nexus->getCountryId()), 'NotEmpty')) {
+        if (!\Zend_Validate::is(trim((string) $nexus->getCountryId()), 'NotEmpty')) {
             $exception->addError(__('%fieldName is a required field.', ['fieldName' => Nexus::KEY_COUNTRY_ID]));
         }
 

--- a/Model/Tax/TaxCalculation.php
+++ b/Model/Tax/TaxCalculation.php
@@ -245,9 +245,9 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
                 continue;
             }
 
-            // @codingStandardsIgnoreStart
-            $jurisdictionTitle = (in_array($jurisdiction, ['gst', 'pst', 'qst'])) ? strtoupper($jurisdiction) : ucfirst($jurisdiction) . ' Tax';
-            // @codingStandardsIgnoreEnd
+            $jurisdictionTitle = in_array($jurisdiction, ['gst', 'pst', 'qst'])
+                ? strtoupper((string) $jurisdiction)
+                : ucfirst((string) $jurisdiction) . ' Tax';
 
             // Display "Special District Tax" instead of "Special Tax"
             if ($jurisdiction == 'special') {

--- a/Observer/ImportRates.php
+++ b/Observer/ImportRates.php
@@ -612,7 +612,7 @@ class ImportRates implements ObserverInterface
     private function zipCodeIsValid(): bool
     {
         if ($this->backupRateOriginAddress->isScopeCountryCodeUS()) {
-            return $this->zipCode && preg_match("/^\d{5}(-?\d{4})?$/", $this->zipCode);
+            return $this->zipCode && preg_match("/^\d{5}(-?\d{4})?$/", (string) $this->zipCode);
         }
 
         return (bool) $this->zipCode;


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Refactor for Magento 2.4.4 compatibility and PHP 8.1 support.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Casts potentially null values to expected type

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
While testing Magento 2.4.4-beta4, encountered errors in the following instances due to null config values:
- `bin/magento setup:upgrade`
- Viewing `<BASE_URL>/admin/admin/system_config/edit/section/tax`
- Viewing Sales Order

Issues have been corrected by casting config values to expected types.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
