### PR TITLE
fix: Setup Data patch EAV attribute group names

### DIFF
--- a/Setup/Patch/Data/AddExtensionAttributesPatch.php
+++ b/Setup/Patch/Data/AddExtensionAttributesPatch.php
@@ -19,6 +19,8 @@ class AddExtensionAttributesPatch implements DataPatchInterface
 
     public const TJ_LAST_SYNC_CODE = 'tj_last_sync';
 
+    private const EAV_ATTRIBUTE_GROUP_GENERAL = 'General';
+
     /**
      * @var ModuleDataSetupInterface
      */
@@ -81,6 +83,10 @@ class AddExtensionAttributesPatch implements DataPatchInterface
         return [];
     }
 
+    /**
+     * @param \Magento\Eav\Setup\EavSetup $eavSetup
+     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Zend_Validate_Exception
+     */
     protected function createTjExemptionTypeAttribute($eavSetup)
     {
         $tjExemptionTypeAttribute = $eavSetup->getAttribute(
@@ -93,7 +99,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface
                 CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER,
                 self::TJ_EXEMPTION_TYPE_CODE,
                 [
-                    'group' => 'General',
+                    'group' => self::EAV_ATTRIBUTE_GROUP_GENERAL,
                     'type' => 'varchar',
                     'label' => 'TaxJar Exemption Type',
                     'input' => 'select',
@@ -120,7 +126,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface
             $eavSetup->addAttributeToSet(
                 CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER,
                 CustomerMetadataInterface::ATTRIBUTE_SET_ID_CUSTOMER,
-                null,
+                self::EAV_ATTRIBUTE_GROUP_GENERAL,
                 self::TJ_EXEMPTION_TYPE_CODE
             );
 
@@ -134,6 +140,10 @@ class AddExtensionAttributesPatch implements DataPatchInterface
         }
     }
 
+    /**
+     * @param \Magento\Eav\Setup\EavSetup $eavSetup
+     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Zend_Validate_Exception
+     */
     protected function createTjRegionsAttribute($eavSetup)
     {
         $tjRegionsAttribute = $eavSetup->getAttribute(
@@ -146,7 +156,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface
                 CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER,
                 self::TJ_REGIONS_CODE,
                 [
-                    'group' => 'General',
+                    'group' => self::EAV_ATTRIBUTE_GROUP_GENERAL,
                     'type' => 'text',
                     'label' => 'TaxJar Exempt Regions',
                     'input' => 'multiselect',
@@ -173,7 +183,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface
             $eavSetup->addAttributeToSet(
                 CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER,
                 CustomerMetadataInterface::ATTRIBUTE_SET_ID_CUSTOMER,
-                null,
+                self::EAV_ATTRIBUTE_GROUP_GENERAL,
                 self::TJ_REGIONS_CODE
             );
 
@@ -187,6 +197,10 @@ class AddExtensionAttributesPatch implements DataPatchInterface
         }
     }
 
+    /**
+     * @param \Magento\Eav\Setup\EavSetup $eavSetup
+     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Zend_Validate_Exception
+     */
     protected function createTjLastSyncAttribute($eavSetup)
     {
         $tjLastSync = $this->eavConfig->getAttribute(
@@ -199,7 +213,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface
                 CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER,
                 self::TJ_LAST_SYNC_CODE,
                 [
-                    'group' => 'General',
+                    'group' => self::EAV_ATTRIBUTE_GROUP_GENERAL,
                     'type' => 'datetime',
                     'label' => 'TaxJar Last Sync Date',
                     'input' => 'date',
@@ -224,7 +238,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface
             $eavSetup->addAttributeToSet(
                 CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER,
                 CustomerMetadataInterface::ATTRIBUTE_SET_ID_CUSTOMER,
-                null,
+                self::EAV_ATTRIBUTE_GROUP_GENERAL,
                 self::TJ_LAST_SYNC_CODE
             );
 


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Refactor for Magento 2.4.4 compatibility and PHP 8.1 support.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Current setup data patches previously passed `null` group name in EAV attribute setup. Passing a null value to this internal function is no longer supported in PHP 8.1. Default group name `General` will be used instead.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Create a Magento 2.3 or 2.4 instance
2. Clone repository in to `<magento_root>/app/code/Taxjar/SalesTax/`
3. Run `bin/magento module:enable Taxjar_SalesTax --clear-static-content`
4. Run `bin/magento setup:upgrade`
5. Observe upgrade command completes successfully, data patches are applied

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
