### PR TITLE
refactor: Show TaxJar Order info with transaction sync enabled

### DIFF
--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info.php
@@ -71,7 +71,7 @@ class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\B
      */
     public function canShowTab()
     {
-        return $this->tjHelper->isEnabled();
+        return $this->tjHelper->isEnabled() || $this->tjHelper->isTransactionSyncEnabled();
     }
 
     /**
@@ -79,6 +79,6 @@ class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\B
      */
     public function isHidden()
     {
-        return !$this->tjHelper->isEnabled();
+        return !$this->tjHelper->isEnabled() && !$this->tjHelper->isTransactionSyncEnabled();
     }
 }


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Users may want to use TaxJar for filing, but not calculation and should still be able to view Order metadata.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Show tax calculation info on Sales Order view with only transaction sync enabled. Currently visibility relies on tax calculations being enabled.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. With TaxJar module enabled, deploy sample data
2. Navigate to store tax config at `<BASE_URL>/admin/admin/system_config/edit/section/tax`
3. Ensure Tax Calculation and Transaction Sync are disabled
4. Navigate to Sales Order view for sample closed order
5. Observe "TaxJar Information" section is not visible
6. Enable Tax Calculations
7. Observe "TaxJar Information" section is now visible
8. Disable Tax Calculations and enable Transaction Sync
9. Observe "TaxJar Information" section is still visible

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
