### PR TITLE
fix: PhpMD unused parameters

### DIFF
--- a/Console/Command/SyncProductCategoriesCommand.php
+++ b/Console/Command/SyncProductCategoriesCommand.php
@@ -70,8 +70,8 @@ class SyncProductCategoriesCommand extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     *
-     * @return string
+     * @return void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function execute(
         InputInterface $input,

--- a/Controller/Adminhtml/Config/Disconnect.php
+++ b/Controller/Adminhtml/Config/Disconnect.php
@@ -99,7 +99,7 @@ class Disconnect extends \Magento\Backend\App\AbstractAction
 
         // Erase config values with the "websites" scope
         $scope = \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES;
-        foreach ($this->storeManager->getWebsites() as $websiteId => $website) {
+        foreach (array_keys($this->storeManager->getWebsites()) as $websiteId) {
             $this->resourceConfig->deleteConfig(TaxjarConfig::TAXJAR_APIKEY, $scope, $websiteId);
             $this->resourceConfig->deleteConfig(TaxjarConfig::TAXJAR_BACKUP, $scope, $websiteId);
             $this->resourceConfig->deleteConfig(TaxjarConfig::TAXJAR_CONNECTED, $scope, $websiteId);
@@ -109,7 +109,7 @@ class Disconnect extends \Magento\Backend\App\AbstractAction
 
         // Erase config values with the "stores" scope
         $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORES;
-        foreach ($this->storeManager->getStores() as $storeId => $store) {
+        foreach (array_keys($this->storeManager->getStores()) as $storeId) {
             $this->resourceConfig->deleteConfig(TaxjarConfig::TAXJAR_APIKEY, $scope, $storeId);
             $this->resourceConfig->deleteConfig(TaxjarConfig::TAXJAR_BACKUP, $scope, $storeId);
             $this->resourceConfig->deleteConfig(TaxjarConfig::TAXJAR_CONNECTED, $scope, $storeId);

--- a/Controller/Adminhtml/Nexus/Delete.php
+++ b/Controller/Adminhtml/Nexus/Delete.php
@@ -30,10 +30,6 @@ class Delete extends \Taxjar\SalesTax\Controller\Adminhtml\Nexus
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $addressId = (int)$this->getRequest()->getParam('address');
         try {
-            $nexus = $this->nexusSyncFactory->create()->load($addressId);
-            // if ($nexus->getCountryId() == 'US') {
-            //     $nexus->syncDelete();
-            // }
             $this->nexusService->deleteById($addressId);
             $this->messageManager->addSuccessMessage(__('The nexus address has been deleted.'));
             return $resultRedirect->setPath('taxjar/*/');

--- a/Model/AddressValidation.php
+++ b/Model/AddressValidation.php
@@ -319,7 +319,7 @@ class AddressValidation implements AddressValidationInterface
         $changes = $new;
         $changesMade = false;
 
-        foreach ($original as $k => $v) {
+        foreach (array_keys($original) as $k) {
             if (isset($new[$k]) && $original[$k] !== $new[$k]) {
                 $changesMade = true;
                 if (is_array($original[$k])) {

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -23,7 +23,6 @@ use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\HTTP\ZendClientFactory;
 use Magento\Store\Model\ScopeInterface;
 use Taxjar\SalesTax\Api\Data\Sales\Order\MetadataInterface;
-use Taxjar\SalesTax\Api\Data\Tax\NexusInterface;
 use Taxjar\SalesTax\Model\Sales\Order\Metadata;
 use Taxjar\SalesTax\Model\Tax\NexusFactory;
 use Taxjar\SalesTax\Model\Configuration as TaxjarConfig;

--- a/Model/Tax/TaxCalculation.php
+++ b/Model/Tax/TaxCalculation.php
@@ -224,14 +224,10 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
      * Set applied taxes for tax summary based on SmartCalcs response breakdown
      *
      * @param QuoteDetailsItemInterface $item
-     * @param \Magento\Framework\App\ScopeInterface $scope
-     * @return \Magento\Tax\Api\Data\AppliedTaxInterface
-     * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @return array
      */
-    protected function getAppliedTaxes(
-        QuoteDetailsItemInterface $item,
-        $scope
-    ) {
+    protected function getAppliedTaxes(QuoteDetailsItemInterface $item)
+    {
         $extensionAttributes = $item->getExtensionAttributes();
         $jurisdictionTaxRates = $extensionAttributes ? $extensionAttributes->getJurisdictionTaxRates() : [];
         $appliedTaxes = [];

--- a/Observer/ImportRates.php
+++ b/Observer/ImportRates.php
@@ -268,6 +268,7 @@ class ImportRates implements ObserverInterface
 
     /**
      * @throws LocalizedException
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function execute(Observer $observer)
     {

--- a/Plugin/AddTjSyncDateToGrid.php
+++ b/Plugin/AddTjSyncDateToGrid.php
@@ -44,6 +44,7 @@ class AddTjSyncDateToGrid
      * @param CollectionFactory $subject
      * @param $collection
      * @return \Magento\Framework\Data\Collection
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterGetReport(
         CollectionFactory $subject,

--- a/Plugin/Quote/Model/QuoteManagement.php
+++ b/Plugin/Quote/Model/QuoteManagement.php
@@ -62,6 +62,7 @@ class QuoteManagement
      * @param OrderInterface $order
      * @return OrderInterface
      * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterSubmit(
         QuoteManagementEntity $subject,

--- a/Plugin/RequireJs/AfterFiles.php
+++ b/Plugin/RequireJs/AfterFiles.php
@@ -42,9 +42,9 @@ class AfterFiles
     /**
      * @param Aggregated $subject
      * @param array $result
-     * @param Theme $theme
+     * @param Theme|null $theme
      * @return mixed
-     * @throws LocalizedException
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterGetFiles(
         Aggregated $subject,

--- a/Plugin/Sales/Model/Order/ItemRepository.php
+++ b/Plugin/Sales/Model/Order/ItemRepository.php
@@ -51,6 +51,7 @@ class ItemRepository
      *
      * @param \Magento\Sales\Model\Order\ItemRepository $subject
      * @param \Magento\Sales\Api\Data\OrderItemInterface $item
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeSave(
         \Magento\Sales\Model\Order\ItemRepository $subject,

--- a/Plugin/Sales/Model/OrderRepository.php
+++ b/Plugin/Sales/Model/OrderRepository.php
@@ -48,6 +48,7 @@ class OrderRepository
      * @param OrderRepositoryInterface $subject
      * @param OrderInterface $order
      * @return OrderInterface
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterGet(OrderRepositoryInterface $subject, OrderInterface $order): OrderInterface
     {
@@ -58,6 +59,7 @@ class OrderRepository
      * @param OrderRepositoryInterface $subject
      * @param OrderSearchResultInterface $searchResult
      * @return OrderSearchResultInterface
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterGetList(
         OrderRepositoryInterface   $subject,

--- a/Test/Unit/Observer/BackfillTransactionsTest.php
+++ b/Test/Unit/Observer/BackfillTransactionsTest.php
@@ -459,7 +459,7 @@ class BackfillTransactionsTest extends UnitTestCase
     /**
      * @dataProvider syncTransactionDataProvider
      */
-    public function testSyncTransactionMethod($orders, $count, $force)
+    public function testSyncTransactionMethod($orders, $count)
     {
         $this->bulkManagementMock->expects($this->once())->method('scheduleBulk')->willReturn(true);
 
@@ -474,26 +474,14 @@ class BackfillTransactionsTest extends UnitTestCase
     public function syncTransactionDataProvider(): array
     {
         return [
-            'single_operation_without_force' => [
+            'single_operation' => [
                 'orders' => array_map([$this, 'getOrderStub'], range(1, 100)),
-                'count' => 1,
-                'force' => false,
+                'count' => 1
             ],
-            'single_operation_with_force' => [
-                'orders' => array_map([$this, 'getOrderStub'], range(1, 100)),
-                'count' => 1,
-                'force' => true,
-            ],
-            'multiple_operations_without_force' => [
+            'multiple_operations' => [
                 'orders' => array_map([$this, 'getOrderStub'], range(1, 500)),
-                'count' => 5,
-                'force' => false,
-            ],
-            'multiple_operations_with_force' => [
-                'orders' => array_map([$this, 'getOrderStub'], range(1, 500)),
-                'count' => 5,
-                'force' => true,
-            ],
+                'count' => 5
+            ]
         ];
     }
 


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Implement GitHub actions workflow.

PHP Mess Detector alerted to multiple unused parameters and methods.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Removes unnecessary unused parameters
- Ignores necessary unused parameters (usages such as plugin methods)
- Refactors array callback functions (PhpMD cannot detect array callbacks)

Does not refactor `Test/Fixture/` usages... Those should be resolved in a separate PR for all integration test fixtures.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Improves PhpMD coverage

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
Manual tests:
1. Extension connect to/disconnect from TaxJar
2. Checkout address validation
3. Checkout tax calculation
4. Admin order address validation
5. Admin order tax calculation
6. Nexus Sync/Delete
7. Admin UI transaction backfill

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
