### PR TITLE
fix: Admin sales order view without order state

### DIFF
--- a/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Sync.php
+++ b/Block/Adminhtml/Order/View/Tab/Taxjar/View/Info/Sync.php
@@ -86,7 +86,7 @@ class Sync extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
     /**
      * Get status text for sales orders
      *
-     * @param string $state
+     * @param string|null $state
      * @return \Magento\Framework\Phrase
      */
     public function getOrderStateText($state)
@@ -95,13 +95,17 @@ class Sync extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
             return __('This order has not been synced to TaxJar.');
         }
 
-        return __('Current order state of %1 cannot be synced to TaxJar.', $this->insertPre($state));
+        if ($state && is_string($state)) {
+            return __('Current order state of %1 cannot be synced to TaxJar.', $this->insertPre($state));
+        }
+
+        return __('Unable to determine order state. Cannot sync order to TaxJar.');
     }
 
     /**
      * Get actionable text for sales orders
      *
-     * @param string $state
+     * @param string|null $state
      * @return \Magento\Framework\Phrase
      */
     public function getOrderActionableText($state)


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Customer reported an issue w/ broken page render due to null order state

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Adds UI message for case when state value is not present on sales order entity.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Bug fix

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
Since I was unsure how to recreate an order without a state value, I manually removed the value from the sales order entity in the DB and viewed the sales order in M2 admin sales order view.
<img width="1252" alt="image" src="https://user-images.githubusercontent.com/47947793/159084546-abfa8ab0-287c-411f-b107-3340b830e17f.png">

Worth noting that the following is what the same entry looks like on my machine with current release. I was unable to recreate the customer's error, but the fix implemented is based on customer-provided response.
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/47947793/159085354-f9beac61-edba-4568-bebb-da52aeca6449.png">

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
