### PR TITLE
ISSUE-Telephone-Number-Missing After Logged In

### DIFF
--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -125,7 +125,7 @@ function (
                 originalAddress.country_id = addrs[id].address.countryId;
                 originalAddress.postcode = addrs[id].address.postcode;
 
-                if (originalAddress.telephone === null || originalAddress.telephone == '') {
+                if (originalAddress.telephone == null || originalAddress.telephone === '') {
                     originalAddress.telephone = addrs[id].address.telephone ?? quote.shippingAddress().telephone;
                 }
 

--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -125,7 +125,7 @@ function (
                 originalAddress.country_id = addrs[id].address.countryId;
                 originalAddress.postcode = addrs[id].address.postcode;
 
-                if (originalAddress.telephone === null) {
+                if (originalAddress.telephone === null || originalAddress.telephone == '') {
                     originalAddress.telephone = addrs[id].address.telephone ?? quote.shippingAddress().telephone;
                 }
 


### PR DESCRIPTION
### Context
Shipping telephone is empty once customer choose suggested address after logged in

### Description
Once customer logged in to his/her account and choose the existing shipping address and then select the taxjar suggested address. On the checkout payment page telephone number not showing and payment gateway does not allow the user make payment without telephone.

<img width="1371" alt="1" src="https://user-images.githubusercontent.com/89576243/159447505-308290f8-68ad-40ac-a65e-9343abe18ad8.png">

<img width="1427" alt="2" src="https://user-images.githubusercontent.com/89576243/159447566-e8aecc2a-8dc2-4910-8dbd-1830da8b5b48.png">

<img width="1345" alt="3" src="https://user-images.githubusercontent.com/89576243/159447615-99f5826f-56dd-4d8d-8a49-7edd8d4c3b41.png">

### Environment
**Magento** 2.4.3
**Taxjar Module** 1.9.1

### Fix
I have added a check in the s**uggested_address_checkout_step.js** file to validate **originalAddress.telephone** if empty and now it is working fine.
