### PR TITLE
fix: Nexus sync address duplication

### DIFF
--- a/Model/Tax/NexusSync.php
+++ b/Model/Tax/NexusSync.php
@@ -160,7 +160,9 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
         $nexusJson = $client->getResource('nexus');
 
         if ($nexusJson['addresses']) {
-            $this->nexusFactory->create()->getCollection()->each('delete');
+            $this->nexusFactory->create()->getCollection()
+                ->addFieldToFilter('api_id', ['neq' => 'NULL'])
+                ->each('delete');
 
             foreach ($nexusJson['addresses'] as $address) {
                 if (!isset($address['country']) || empty($address['country'])) {
@@ -192,6 +194,12 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
         }
     }
 
+    /**
+     * Maps non-standard TaxJar ISO-2 country code to universal ISO-2 country code if necessary.
+     *
+     * @param string $countryCode
+     * @return string
+     */
     private function parseCountryCode($countryCode)
     {
         return static::COUNTRY_CODE_MAP[$countryCode] ?? $countryCode;

--- a/Model/Tax/NexusSync.php
+++ b/Model/Tax/NexusSync.php
@@ -22,7 +22,6 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Directory\Model\CountryFactory;
 use Magento\Directory\Model\RegionFactory;
 use Taxjar\SalesTax\Model\ClientFactory;
-use Taxjar\SalesTax\Model\Tax\NexusFactory;
 
 class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
 {
@@ -161,9 +160,9 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
         $nexusJson = $client->getResource('nexus');
 
         if ($nexusJson['addresses']) {
-            $addresses = $nexusJson['addresses'];
+            $this->nexusFactory->create()->getCollection()->each('delete');
 
-            foreach ($addresses as $address) {
+            foreach ($nexusJson['addresses'] as $address) {
                 if (!isset($address['country']) || empty($address['country'])) {
                     continue;
                 }
@@ -176,34 +175,18 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
                 $countryCode = $this->parseCountryCode($address['country']);
                 $addressRegion = $this->regionFactory->create()->loadByCode($address['state'], $countryCode);
                 $addressCountry = $this->countryFactory->create()->loadByCode($countryCode);
-                $addressCollection = $this->nexusFactory->create()->getCollection();
 
-                // Find existing address by region if US, otherwise country
-                // @codingStandardsIgnoreStart
-                if ($countryCode == 'US') {
-                    $existingAddress = $addressCollection->addRegionFilter($addressRegion->getId())->getFirstItem();
-                } else {
-                    $existingAddress = $addressCollection->addCountryFilter($addressCountry->getId())->getFirstItem();
-                }
-
-                $data = [
-                    'api_id'     => $address['id'],
-                    'street'     => $address['street'],
-                    'city'       => $address['city'],
-                    'postcode'   => $address['zip']
-                ];
-
-                if (!$existingAddress->getId()) {
-                    $data = array_merge($data, [
-                        'country_id'  => $addressCountry->getId(),
-                        'region'      => $addressRegion->getName(),
-                        'region_id'   => $addressRegion->getId(),
-                        'region_code' => $addressRegion->getCode()
-                    ]);
-                }
-
-                $nexusAddress = $existingAddress->getId() ? $existingAddress : $this->nexusFactory->create();
-                $nexusAddress->setData($data);
+                $nexusAddress = $this->nexusFactory->create();
+                $nexusAddress->setData([
+                    'api_id'      => $address['id'],
+                    'street'      => $address['street'],
+                    'city'        => $address['city'],
+                    'postcode'    => $address['zip'],
+                    'country_id'  => $addressCountry->getId(),
+                    'region'      => $addressRegion->getName(),
+                    'region_id'   => $addressRegion->getId(),
+                    'region_code' => $addressRegion->getCode()
+                ]);
                 $nexusAddress->save();
             }
         }


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Bug was discovered where existing nexus addresses are not being overwritten causing additional incomplete entries to be written.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
When syncing nexus addresses, all existing addresses will now be removed before writing the addresses from API response.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Attempting to re-sync nexus from TaxJar creates expected entries

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
