### PR TITLE
refactor: Transaction child classes with request setter methods

### DIFF
--- a/Model/Transaction/Order.php
+++ b/Model/Transaction/Order.php
@@ -42,6 +42,19 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
     protected $request;
 
     /**
+     * Set request value
+     *
+     * @param array $value
+     * @return $this
+     */
+    public function setRequest($value)
+    {
+        $this->request = $value;
+
+        return $this;
+    }
+
+    /**
      * Build an order transaction
      *
      * @param OrderInterface $order
@@ -69,13 +82,15 @@ class Order extends \Taxjar\SalesTax\Model\Transaction
             'sales_tax' => $salesTax
         ];
 
-        $this->request = array_merge(
+        $requestBody = array_merge(
             $newOrder,
             $this->buildFromAddress($order),
             $this->buildToAddress($order),
             $this->buildLineItems($order, $order->getAllItems()),
             $this->buildCustomerExemption($order)
         );
+
+        $this->setRequest($requestBody);
 
         return $this->request;
     }


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Closes #294 

Although the `Order::build` method is public and we are able to modify the return value with a plugin/interceptor, the class's  `$request` attribute is protected and set within `Order::build`, so any modification to the return result in an after plugin has no effect on the API request body.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Adds public request body setter method to Transaction child classes.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
Tested syncing order and validated solution to issue #294 with additional after plugin to modify transaction details.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
