### PR TITLE
chore: Update OrderRepositoryTest

### DIFF
--- a/Test/Unit/Plugin/Sales/Model/OrderRepositoryTest.php
+++ b/Test/Unit/Plugin/Sales/Model/OrderRepositoryTest.php
@@ -66,10 +66,6 @@ class OrderRepositoryTest extends UnitTestCase
         $searchResultMock->expects(static::once())
             ->method('getItems')
             ->willReturn([$orderMock]);
-        $searchResultMock->expects(static::once())
-            ->method('setItems')
-            ->with([$orderMock])
-            ->willReturnSelf();
 
         $this->orderMetadataHelperMock->expects(static::once())
             ->method('setOrderExtensionAttributeData')


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Previous refactor of `Plugin/Sales/Model/OrderRepository.php` refactored afterGetList method to use helper, so setter method is no longer called.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Remove assertion to expect setter method call.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
All unit tests now passing.
<img width="1619" alt="image" src="https://user-images.githubusercontent.com/47947793/161650384-fdf67315-b70c-4085-bc97-b8b9cb86bd04.png">

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
