### PR TITLE
chore: Fix line length limit sniffs

### DIFF
--- a/Block/Adminhtml/Enabled.php
+++ b/Block/Adminhtml/Enabled.php
@@ -150,4 +150,16 @@ class Enabled extends PopupField
         $popupUrl .= '&plugin=magento2&version=' . TaxjarConfig::TAXJAR_VERSION;
         return $popupUrl;
     }
+
+    /**
+     * Get disconnect confirmation message.
+     *
+     * @return string
+     */
+    public function getDisconnectMessage()
+    {
+        return "Are you sure you want to disconnect from TaxJar? " .
+            "This will remove all TaxJar rates from your Magento store. " .
+            "If you have a paid TaxJar subscription, manage your account at https://app.taxjar.com.";
+    }
 }

--- a/Controller/Adminhtml/Config/Connect.php
+++ b/Controller/Adminhtml/Config/Connect.php
@@ -110,9 +110,9 @@ class Connect extends AbstractAction
             $this->messageManager->addSuccessMessage(__('TaxJar account for %1 is now connected.', $apiEmail));
             $this->eventManager->dispatch('taxjar_salestax_import_categories');
         } else {
-            // @codingStandardsIgnoreStart
-            $this->messageManager->addErrorMessage(__('Could not connect your TaxJar account. Please make sure you have a valid API token and try again.'));
-            // @codingStandardsIgnoreEnd
+            $this->messageManager->addErrorMessage(
+                __('Could not connect your TaxJar account. Please make sure you have a valid API token and try again.')
+            );
         }
 
         $this->_redirect('adminhtml/system_config/edit', ['section' => 'tax']);

--- a/Controller/Adminhtml/Nexus.php
+++ b/Controller/Adminhtml/Nexus.php
@@ -120,9 +120,12 @@ abstract class Nexus extends \Magento\Backend\App\Action
         $nexusMissingPostcode = $nexus->getCollection()->addFieldToFilter('postcode', ['null' => true]);
 
         if ($nexusMissingPostcode->getSize()) {
-            // @codingStandardsIgnoreStart
-            return $this->messageManager->addNoticeMessage(__('One or more of your nexus addresses are missing a zip/post code. Please provide accurate data for each nexus address.'));
-            // @codingStandardsIgnoreEnd
+            return $this->messageManager->addNoticeMessage(
+                __(
+                    'One or more of your nexus addresses are missing a zip/post code. ' .
+                    'Please provide accurate data for each nexus address.'
+                )
+            );
         }
     }
 

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -273,12 +273,16 @@ class Client implements ClientInterface
      */
     private function _defaultErrors()
     {
-        // @codingStandardsIgnoreStart
         return [
-            '401' => __('Your TaxJar API token is invalid. Please review your TaxJar account at %1.', TaxjarConfig::TAXJAR_AUTH_URL),
-            '403' => __('Your TaxJar trial or subscription may have expired. Please review your TaxJar account at %1.', TaxjarConfig::TAXJAR_AUTH_URL),
+            '401' => __(
+                'Your TaxJar API token is invalid. Please review your TaxJar account at %1.',
+                TaxjarConfig::TAXJAR_AUTH_URL
+            ),
+            '403' => __(
+                'Your TaxJar trial or subscription may have expired. Please review your TaxJar account at %1.',
+                TaxjarConfig::TAXJAR_AUTH_URL
+            ),
             'default' => __('Could not connect to TaxJar.')
         ];
-        // @codingStandardsIgnoreEnd
     }
 }

--- a/Model/Tax/NexusSync.php
+++ b/Model/Tax/NexusSync.php
@@ -111,14 +111,24 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
             'country' => $this->getCountryId()
         ];
 
-        // @codingStandardsIgnoreStart
         $responseErrors = [
-            '400' => __('Your nexus address contains invalid data. Please verify the address in order to sync with TaxJar.'),
-            '409' => __('A nexus address already exists for this state/region. TaxJar currently supports one address per region.'),
-            '422' => __('Your nexus address is missing one or more required fields. Please verify the address in order to sync with TaxJar.'),
-            '500' => __('Something went wrong while syncing your address with TaxJar. Please verify the address and contact support@taxjar.com if the problem persists.')
+            '400' => __(
+                'Your nexus address contains invalid data. ' .
+                'Please verify the address in order to sync with TaxJar.'
+            ),
+            '409' => __(
+                'A nexus address already exists for this state/region. ' .
+                'TaxJar currently supports one address per region.'
+            ),
+            '422' => __(
+                'Your nexus address is missing one or more required fields. ' .
+                'Please verify the address in order to sync with TaxJar.'
+            ),
+            '500' => __(
+                'Something went wrong while syncing your address with TaxJar. ' .
+                'Please verify the address and contact support@taxjar.com if the problem persists.'
+            )
         ];
-        // @codingStandardsIgnoreEnd
 
         if ($this->getId()) {
             $client->putResource('nexus', $this->getApiId(), $data, $responseErrors);
@@ -137,12 +147,15 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
     {
         $client = $this->clientFactory->create();
 
-        // @codingStandardsIgnoreStart
         $responseErrors = [
-            '409' => __('A nexus address with this ID could not be found in TaxJar.'),
-            '500' => __('Something went wrong while deleting your address in TaxJar. Please contact support@taxjar.com if the problem persists.')
+            '409' => __(
+                'A nexus address with this ID could not be found in TaxJar.'
+            ),
+            '500' => __(
+                'Something went wrong while deleting your address in TaxJar. ' .
+                'Please contact support@taxjar.com if the problem persists.'
+            )
         ];
-        // @codingStandardsIgnoreEnd
 
         if ($this->getId()) {
             $client->deleteResource('nexus', $this->getApiId(), $responseErrors);

--- a/Observer/ConfigReview.php
+++ b/Observer/ConfigReview.php
@@ -114,22 +114,23 @@ class ConfigReview implements ObserverInterface
 
     /**
      * @return void
-     * @SuppressWarnings(Generic.Files.LineLength.TooLong)
      */
     private function _reviewNexusAddresses()
     {
         $nexusAddresses = $this->nexusFactory->create()->getCollection();
 
         if (!$nexusAddresses->getSize()) {
-            // @codingStandardsIgnoreStart
-            $this->messageManager->addErrorMessage(__('You have no nexus addresses loaded in Magento. Go to Stores > Nexus Addresses to sync from your TaxJar account or add a new address.'));
-            // @codingStandardsIgnoreEnd
+            $this->messageManager->addErrorMessage(
+                __(
+                    'You have no nexus addresses loaded in Magento. ' .
+                    'Go to Stores > Nexus Addresses to sync from your TaxJar account or add a new address.'
+                )
+            );
         }
     }
 
     /**
      * @return void
-     * @SuppressWarnings(Generic.Files.LineLength.TooLong)
      */
     private function _reviewSandboxMode()
     {

--- a/Test/Integration/Model/Tax/Sales/Total/Quote/SetupUtil.php
+++ b/Test/Integration/Model/Tax/Sales/Total/Quote/SetupUtil.php
@@ -15,11 +15,12 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
-// @codingStandardsIgnoreStart
-
 namespace Taxjar\SalesTax\Test\Integration\Model\Tax\Sales\Total\Quote;
 
+use Magento\Customer\Api\AccountManagementInterface;
+use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Tax\Model\Calculation\Rate;
 use Magento\Tax\Model\Config;
 use Magento\Tax\Model\Calculation;
 
@@ -248,12 +249,12 @@ class SetupUtil
     public $objectManager;
 
     /**
-     * @var \Magento\Customer\Api\CustomerRepositoryInterface
+     * @var CustomerRepositoryInterface
      */
     private $customerRepository;
 
     /**
-     * @var \Magento\Customer\Api\AccountManagementInterface
+     * @var AccountManagementInterface
      */
     private $accountManagement;
 
@@ -263,8 +264,8 @@ class SetupUtil
     public function __construct($objectManager)
     {
         $this->objectManager = $objectManager;
-        $this->customerRepository = $this->objectManager->create(\Magento\Customer\Api\CustomerRepositoryInterface::class);
-        $this->accountManagement = $this->objectManager->create(\Magento\Customer\Api\AccountManagementInterface::class);
+        $this->customerRepository = $this->objectManager->create(CustomerRepositoryInterface::class);
+        $this->accountManagement = $this->objectManager->create(AccountManagementInterface::class);
     }
 
     /**
@@ -356,7 +357,7 @@ class SetupUtil
             if (isset($taxRateOverrides[$taxRateCode])) {
                 $this->taxRates[$taxRateCode]['data']['rate'] = $taxRateOverrides[$taxRateCode];
             }
-            $this->taxRates[$taxRateCode]['id'] = $this->objectManager->create(\Magento\Tax\Model\Calculation\Rate::class)
+            $this->taxRates[$taxRateCode]['id'] = $this->objectManager->create(Rate::class)
                 ->setData($this->taxRates[$taxRateCode]['data'])
                 ->save()
                 ->getId();
@@ -628,7 +629,9 @@ class SetupUtil
                 'value_index' => $option->getValue(),
             ];
 
-            $associatedProductIds[] = $this->createSimpleProduct($optionSku, $price, $taxClassId, $optionAttribute)->getId();
+            $associatedProductIds[] = $this
+                ->createSimpleProduct($optionSku, $price, $taxClassId, $optionAttribute)
+                ->getId();
         }
 
         /** @var $product \Magento\Catalog\Model\Product */
@@ -956,7 +959,9 @@ class SetupUtil
      */
     protected function createNexusAddresses($overrides)
     {
-        $addresses = empty($overrides[self::NEXUS_OVERRIDES]) ? $this->nexusAddresses : $overrides[self::NEXUS_OVERRIDES];
+        $addresses = empty($overrides[self::NEXUS_OVERRIDES])
+            ? $this->nexusAddresses
+            : $overrides[self::NEXUS_OVERRIDES];
 
         foreach ($addresses as $address) {
             $nexusModel = $this->objectManager->create('Taxjar\SalesTax\Model\Tax\Nexus')

--- a/view/adminhtml/templates/address_validation.phtml
+++ b/view/adminhtml/templates/address_validation.phtml
@@ -15,13 +15,15 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
-// @codingStandardsIgnoreFile
+/** @var \Taxjar\SalesTax\Block\Adminhtml\AddressValidation $block */
 
 ?>
 <p class='note'>
-    <span>Validate shipping addresses and return back suggested addresses at checkout. Ensures the customer data sent to TaxJar is accurate for calculations.</span>
+    <span>Validate shipping addresses and return back suggested addresses at checkout.
+        Ensures the customer data sent to TaxJar is accurate for calculations.</span>
     <?php if (!$block->isAuthorized()) { ?>
-        <span>Address validation requires a TaxJar Professional subscription. <a href="https://www.taxjar.com/how-it-works/" target="_blank">Learn more.</a></span>
+        <span>Address validation requires a TaxJar Professional subscription.
+            <a href="https://www.taxjar.com/how-it-works/" target="_blank">Learn more.</a></span>
     <?php } ?>
 </p>
 

--- a/view/adminhtml/templates/debug.phtml
+++ b/view/adminhtml/templates/debug.phtml
@@ -15,10 +15,13 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
-// @codingStandardsIgnoreFile
+/** @var \Taxjar\SalesTax\Block\Adminhtml\Debug $block */
 
 ?>
-<p class='note'><span>If enabled, does not alter your tax rates or database and instead prints debug messages for use with TaxJar support.</span></p>
+<p class='note'>
+    <span>If enabled, does not alter your tax rates or database and instead prints debug messages for use
+        with TaxJar support.</span>
+</p>
 
 <?php if ($block->isEnabled()) { ?>
     <br/>
@@ -30,5 +33,9 @@
         <li><strong>Backup States:</strong> <?php echo $block->escapeHtml($block->getBackupStates()) ?></li>
         <li><strong>Backup Last Updated:</strong> <?php echo $block->escapeHtml($block->getBackupUpdate()) ?></li>
     </ul>
-    <p><small><strong>Include the above information when emailing TaxJar support at support@taxjar.com.</strong><small></p>
+    <p>
+        <small>
+            <strong>Include the above information when emailing TaxJar support at support@taxjar.com.</strong>
+        </small>
+    </p>
 <?php } ?>

--- a/view/adminhtml/templates/enabled.phtml
+++ b/view/adminhtml/templates/enabled.phtml
@@ -15,30 +15,83 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
-// @codingStandardsIgnoreFile
+/** @var \Taxjar\SalesTax\Block\Adminhtml\Enabled $block */
 
 ?>
-<p class='note'><span>Sales tax calculations at checkout for improved accuracy and product exemptions. Magento's zip-based rates can be used as a fallback.</span></p><br/>
+<p class='note'>
+    <span>Sales tax calculations at checkout for improved accuracy and product exemptions.
+        Magento's zip-based rates can be used as a fallback.</span>
+</p>
+
+<br/>
 
 <?php if ($block->isConnected()) { ?>
-  <p><b>TaxJar Account</b></p>
-  <div class='messages'>
+    <p><b>TaxJar Account</b></p>
+
+    <div class='messages'>
       <div class='message message-success success'>
           <span style='font-size: 1.2em'>
             <?php echo $block->escapeHtml($block->getApiEmail()) ?>
           </span>
       </div>
-  </div>
+    </div>
 
-  <p><b>Getting Started</b></p>
-  <p><a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/nexus/index')) ?>'>Nexus Addresses</a><br/><span style='font-size: 0.9em'>Before enabling TaxJar for calculations, set up your nexus addresses so TaxJar knows where to collect sales tax.</span></p>
-  <p><a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/taxclass_product')) ?>'>Product Exemptions</a><br/><span style='font-size: 0.9em'>If some of your products are tax exempt, assign a TaxJar product tax code to new or existing product tax classes.</span></p>
-  <p><a href='<?php echo $block->escapeUrl($block->getStoreUrl('customer/index')) ?>'>Customer Exemptions</a><br/><span style='font-size: 0.9em'>If some of your customers are tax exempt, assign a TaxJar exemption type to each customer individually or multiple customers at once.</span></p>
-  <p><a href='http://www.taxjar.com/contact/' target='_blank'>Help & Support</a><br/><span style='font-size: 0.9em'>Need help setting up TaxJar? Get in touch with our Magento sales tax experts.</span></p><br/>
+    <p><b>Getting Started</b></p>
+    <p>
+        <a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/nexus/index')) ?>'>Nexus Addresses</a>
+        <br/>
+        <span style='font-size: 0.9em'>Before enabling TaxJar for calculations, set up your nexus addresses so TaxJar knows where
+            to collect sales tax.</span>
+    </p>
+    <p>
+        <a href='<?= $block->escapeUrl($block->getStoreUrl('taxjar/taxclass_product')) ?>'>Product Exemptions</a>
+        <br/>
+        <span style='font-size: 0.9em'>If some of your products are tax exempt, assign a TaxJar product tax code to new
+            or existing product tax classes.</span>
+    </p>
+    <p>
+        <a href='<?php echo $block->escapeUrl($block->getStoreUrl('customer/index')) ?>'>Customer Exemptions</a>
+        <br/>
+        <span style='font-size: 0.9em'>If some of your customers are tax exempt, assign a TaxJar exemption type to each
+            customer individually or multiple customers at once.</span>
+    </p>
+    <p>
+        <a href='http://www.taxjar.com/contact/' target='_blank'>Help & Support</a>
+        <br/>
+        <span style='font-size: 0.9em'>Need help setting up TaxJar? Get in touch with our Magento sales tax experts.</span>
+    </p>
 
-  <p><button type='button' class='scalable delete' onclick='if (window.confirm("Are you sure you want to disconnect from TaxJar? This will remove all TaxJar rates from your Magento store. If you have a paid TaxJar subscription, manage your account at https://app.taxjar.com.")) window.location="<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/disconnect')) ?>"'><span>Disconnect TaxJar</span></button>&nbsp;&nbsp;<button type='button' class='scalable' onclick='window.open("http://www.taxjar.com/guides/integrations/magento/", "_blank")'><span>Learn More</span></button></p><br/>
+    <br/>
+
+    <p>
+        <button type='button'
+                class='scalable delete'
+                onclick='if (window.confirm("<?= $block->escapeHtml($block->getDisconnectMessage()) ?>")) {
+                    window.location="<?= $block->escapeUrl($block->getStoreUrl('taxjar/config/disconnect')) ?>"
+                }'>
+            <span>Disconnect TaxJar</span>
+        </button>
+        <button type='button'
+                class='scalable'
+                onclick='window.open("http://www.taxjar.com/guides/integrations/magento/", "_blank")'>
+            <span>Learn More</span>
+        </button>
+    </p>
+
+    <br/>
 <?php } else { ?>
-  <p><button type='button' class='scalable primary' onclick='openPopup("<?php echo $block->escapeUrl($block->getPopupUrl()) ?>", "Connect to TaxJar", 400, 500)'><span>Connect to TaxJar</span></button>&nbsp;&nbsp;<button type='button' class='scalable' onclick='window.open("http://www.taxjar.com/guides/integrations/magento/", "_blank")'><span>Learn More</span></button></p>
+    <p>
+        <button type='button'
+                class='scalable primary'
+                onclick='openPopup("<?= $block->escapeUrl($block->getPopupUrl()) ?>", "Connect to TaxJar", 400, 500)'>
+            <span>Connect to TaxJar</span>
+        </button>
+        <button type='button'
+                class='scalable'
+                onclick='window.open("http://www.taxjar.com/guides/integrations/magento/", "_blank")'>
+            <span>Learn More</span>
+        </button>
+    </p>
 
   <script>
     require([
@@ -51,13 +104,18 @@
             try {
                 var data = JSON.parse(e.data);
                 if (data.api_token && data.email) {
-                    window.popup.postMessage('Data received', '<?php echo $block->escapeUrl($block->getAuthUrl()) ?>');
-                    window.location = encodeURI('<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/connect')) ?>?api_key=' + data.api_token + '&api_email=' + data.email);
+                    window.popup.postMessage('Data received', '<?= $block->escapeUrl($block->getAuthUrl()) ?>');
+                    window.location = encodeURI('<?= $block->escapeUrl(
+                        $block->getStoreUrl('taxjar/config/connect')
+                    ) ?>?api_key=' + data.api_token + '&api_email=' + data.email);
                 } else {
                     throw 'Invalid data';
                 }
             } catch (e) {
-                alert('Invalid API token or email provided. Please try connecting to TaxJar again or contact support@taxjar.com.');
+                alert(
+                    'Invalid API token or email provided. ' +
+                    'Please try connecting to TaxJar again or contact support@taxjar.com.'
+                );
             }
         }, false);
     });

--- a/view/adminhtml/templates/transaction_sync.phtml
+++ b/view/adminhtml/templates/transaction_sync.phtml
@@ -15,15 +15,23 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
-// @codingStandardsIgnoreFile
+/** @var \Taxjar\SalesTax\Block\Adminhtml\TransactionSync $block */
 
 ?>
-<p class='note'><span>Sync orders and refunds with TaxJar for automated sales tax reporting and filing. Complete and closed transactions sync automatically on update.</span></p><br/>
+<p class='note'>
+    <span>Sync orders and refunds with TaxJar for automated sales tax reporting and filing.
+        Complete and closed transactions sync automatically on update.</span>
+</p>
 
-<?php
-/** @var \Taxjar\SalesTax\Block\Adminhtml\TransactionSync $block */
-if ($block->isEnabled()) { ?>
-    <p><button type="button" class="scalable" onclick="openTransactionSyncModal()"><span>Sync Transactions</span></button></p>
+<br/>
+
+<?php if ($block->isEnabled()) { ?>
+    <p>
+        <button type="button" class="scalable" onclick="openTransactionSyncModal()">
+            <span>Sync Transactions</span>
+        </button>
+    </p>
+
     <script>
         require([
             'jquery',
@@ -114,7 +122,13 @@ if ($block->isEnabled()) { ?>
                     <div id="transaction-sync-log" style="overflow: auto; max-height: 500px; margin-bottom: 1em; padding: 0 1em; border: 1px solid #e3e3e3; background: #f8f8f8">
                         <pre style="overflow: visible">Awaiting sync! Click "Sync to TaxJar" to start syncing transactions.</pre>
                     </div>
-                    <p><button type="button" class="copy-button scalable" data-clipboard-target="#transaction-sync-log"><span>Copy Output</span></button></p>
+                    <p>
+                        <button type="button"
+                                class="copy-button scalable"
+                                data-clipboard-target="#transaction-sync-log">
+                            <span>Copy Output</span>
+                        </button>
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Latest submission `magento-coding-standards:19` sniffs.

`@codingStandardsIgnore` annotations are respected by IDE, but not by Adobe acceptance testing.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Refactors remaining excessively long lines to 120 characters or less. 

Note: GH action for PHP_CodeSniffer expected to fail with removal of `@codingStandardsIgnore` annotations.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Connect to TaxJar / Disconnect from TaxJar
2. Learn more button (Integration guide)
3. Debug mode enable/disable and related JS
4. "No Nexus Addresses" error message when enabling tax calculations
5. Transaction sync UI copy-to-clipboard

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
