### PR TITLE
fix: Transaction sync config check in refunds

### DIFF
--- a/Observer/SyncRefund.php
+++ b/Observer/SyncRefund.php
@@ -84,7 +84,7 @@ class SyncRefund implements ObserverInterface
         $eventName = $observer->getEvent()->getName();
         $orderTransaction = $this->orderFactory->create();
 
-        if ($orderTransaction->isSyncable($order)) {
+        if ($this->helper->isTransactionSyncEnabled($order->getStoreId()) && $orderTransaction->isSyncable($order)) {
             if (!$this->registry->registry('taxjar_sync_' . $eventName)) {
                 $this->registry->register('taxjar_sync_' . $eventName, true);
             } else {


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Customer reported issue that refunds were being unexpectedly imported.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
A check was previously added in `SyncTransaction::class` to validate that our transaction sync feature was enabled for the current order's scope, but the same check was not added to `SyncRefund::class`. When refunds are updated in Magento, the credit memo updated event will trigger our sync refund observer, which should also check that transaction sync is enabled for the related order scope.

This PR adds the same "feature enabled" check in `SyncRefund::class` observer.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Bug fix

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. [First Step]
2. [Second Step]
3. [and so on...]

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [X] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
