### PR TITLE
Can not validate address postal code when postcode validation rules are disabled

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -444,6 +444,8 @@ class Smartcalcs
                     return true;
                 }
             }
+        } elseif (!isset($postCodes[$countryId])) {
+            return true;
         }
 
         return false;


### PR DESCRIPTION
### Context

Customer reported issue that postcode is not valid when all rules in zip_codes.xml are disabled for country.

### Description

When all rules for postcodes are disabled TaxJar show message in order calculation section: SKIPPED - Could not validate address postal code.
This error is caused because the module expects the country has at least one rule for the postcode. When all rules for the country are disabled it can not validate postcode.

### Performance

Bug fix

### Testing

- Disable all rules in etc/zip_codes.xml for the US;
- Make an order with a valid US zip code;
- Go to Admin Panel and check the TaxJar Calculation section in Order

#### Versions
[x] Magento 2.4
[ ] Magento 2.3

[x] Magento Open Source (CE)
[x] Magento Commerce (EE)
[ ] Magento B2B
[ ] Magento Cloud

[x] PHP 7.x
