### PR TITLE
fix: SyncRefund config check

### DIFF
--- a/Observer/SyncRefund.php
+++ b/Observer/SyncRefund.php
@@ -84,7 +84,9 @@ class SyncRefund implements ObserverInterface
         $eventName = $observer->getEvent()->getName();
         $orderTransaction = $this->orderFactory->create();
 
-        if ($orderTransaction->isSyncable($order)) {
+        if ($this->helper->isTransactionSyncEnabled($order->getStoreId()) &&
+            $orderTransaction->isSyncable($order)
+        ) {
             if (!$this->registry->registry('taxjar_sync_' . $eventName)) {
                 $this->registry->register('taxjar_sync_' . $eventName, true);
             } else {


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Merchant reported issue with out-of-scope refunds syncing to TaxJar

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
A check that was previously added to the Order sync observer has now been added to the refund sync observer.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Enable transaction sync globally and disable transaction sync for a website scope
2. Place an order with a customer under the disabled site's scope. 
3. Observe order does not sync
4. Create credit memo
5. Observer credit memo does not sync

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
