### PR TITLE
fix: Generic line length too long sniffs

### DIFF
--- a/Block/Adminhtml/Enabled.php
+++ b/Block/Adminhtml/Enabled.php
@@ -31,9 +31,7 @@ class Enabled extends PopupField
     /**
      * @var string
      */
-    // @codingStandardsIgnoreStart
     protected $_template = 'Taxjar_SalesTax::enabled.phtml';
-    // @codingStandardsIgnoreEnd
 
     /**
      * @var \Magento\Backend\Model\UrlInterface
@@ -149,5 +147,17 @@ class Enabled extends PopupField
         $popupUrl = $this->getAuthUrl() . '/smartcalcs/connect/magento/?store=' . urlencode($this->getStoreOrigin());
         $popupUrl .= '&plugin=magento2&version=' . TaxjarConfig::TAXJAR_VERSION;
         return $popupUrl;
+    }
+
+    /**
+     * Get disconnect confirmation message.
+     *
+     * @return string
+     */
+    public function getDisconnectMessage()
+    {
+        return "Are you sure you want to disconnect from TaxJar? " .
+            "This will remove all TaxJar rates from your Magento store. " .
+            "If you have a paid TaxJar subscription, manage your account at https://app.taxjar.com.";
     }
 }

--- a/Block/Adminhtml/TransactionSync.php
+++ b/Block/Adminhtml/TransactionSync.php
@@ -29,9 +29,7 @@ class TransactionSync extends PopupField
     /**
      * @var string
      */
-    // @codingStandardsIgnoreStart
     protected $_template = 'Taxjar_SalesTax::transaction_sync.phtml';
-    // @codingStandardsIgnoreEnd
 
     /**
      * @var \Magento\Backend\Model\UrlInterface
@@ -51,6 +49,7 @@ class TransactionSync extends PopupField
     /**
      * @param Context $context
      * @param UrlInterface $backendUrl
+     * @param TaxjarHelper $helper
      * @param array $data
      */
     public function __construct(
@@ -126,5 +125,19 @@ class TransactionSync extends PopupField
         $popupUrl .= '&plugin=magento2&version=' . TaxjarConfig::TAXJAR_VERSION;
 
         return $popupUrl;
+    }
+
+    /**
+     * Get modal body form block element
+     *
+     * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getTransactionSyncFormHtml()
+    {
+        return $this->getLayout()
+            ->createBlock(\Taxjar\SalesTax\Block\Adminhtml\TransactionSync\Form::class)
+            ->setTemplate('Taxjar_SalesTax::transaction_sync/form.phtml')
+            ->toHtml();
     }
 }

--- a/Controller/Adminhtml/Config/Connect.php
+++ b/Controller/Adminhtml/Config/Connect.php
@@ -110,9 +110,9 @@ class Connect extends AbstractAction
             $this->messageManager->addSuccessMessage(__('TaxJar account for %1 is now connected.', $apiEmail));
             $this->eventManager->dispatch('taxjar_salestax_import_categories');
         } else {
-            // @codingStandardsIgnoreStart
-            $this->messageManager->addErrorMessage(__('Could not connect your TaxJar account. Please make sure you have a valid API token and try again.'));
-            // @codingStandardsIgnoreEnd
+            $this->messageManager->addErrorMessage(
+                __('Could not connect your TaxJar account. Please make sure you have a valid API token and try again.')
+            );
         }
 
         $this->_redirect('adminhtml/system_config/edit', ['section' => 'tax']);

--- a/Controller/Adminhtml/Nexus.php
+++ b/Controller/Adminhtml/Nexus.php
@@ -120,9 +120,12 @@ abstract class Nexus extends \Magento\Backend\App\Action
         $nexusMissingPostcode = $nexus->getCollection()->addFieldToFilter('postcode', ['null' => true]);
 
         if ($nexusMissingPostcode->getSize()) {
-            // @codingStandardsIgnoreStart
-            return $this->messageManager->addNoticeMessage(__('One or more of your nexus addresses are missing a zip/post code. Please provide accurate data for each nexus address.'));
-            // @codingStandardsIgnoreEnd
+            return $this->messageManager->addNoticeMessage(
+                __(
+                    'One or more of your nexus addresses are missing a zip/post code.
+                    Please provide accurate data for each nexus address.'
+                )
+            );
         }
     }
 

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -154,9 +154,7 @@ class Client implements ClientInterface
      */
     private function getClient($url, $method = \Zend_Http_Client::GET)
     {
-        // @codingStandardsIgnoreStart
         $client = new \Zend_Http_Client($url, ['timeout' => 30]);
-        // @codingStandardsIgnoreEnd
         $client->setUri($url);
         $client->setMethod($method);
         $client->setConfig([
@@ -273,12 +271,16 @@ class Client implements ClientInterface
      */
     private function _defaultErrors()
     {
-        // @codingStandardsIgnoreStart
         return [
-            '401' => __('Your TaxJar API token is invalid. Please review your TaxJar account at %1.', TaxjarConfig::TAXJAR_AUTH_URL),
-            '403' => __('Your TaxJar trial or subscription may have expired. Please review your TaxJar account at %1.', TaxjarConfig::TAXJAR_AUTH_URL),
+            '401' => __(
+                'Your TaxJar API token is invalid. Please review your TaxJar account at %1.',
+                TaxjarConfig::TAXJAR_AUTH_URL
+            ),
+            '403' => __(
+                'Your TaxJar trial or subscription may have expired. Please review your TaxJar account at %1.',
+                TaxjarConfig::TAXJAR_AUTH_URL
+            ),
             'default' => __('Could not connect to TaxJar.')
         ];
-        // @codingStandardsIgnoreEnd
     }
 }

--- a/Model/Tax/NexusSync.php
+++ b/Model/Tax/NexusSync.php
@@ -111,14 +111,24 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
             'country' => $this->getCountryId()
         ];
 
-        // @codingStandardsIgnoreStart
         $responseErrors = [
-            '400' => __('Your nexus address contains invalid data. Please verify the address in order to sync with TaxJar.'),
-            '409' => __('A nexus address already exists for this state/region. TaxJar currently supports one address per region.'),
-            '422' => __('Your nexus address is missing one or more required fields. Please verify the address in order to sync with TaxJar.'),
-            '500' => __('Something went wrong while syncing your address with TaxJar. Please verify the address and contact support@taxjar.com if the problem persists.')
+            '400' => __(
+                'Your nexus address contains invalid data.
+                Please verify the address in order to sync with TaxJar.'
+            ),
+            '409' => __(
+                'A nexus address already exists for this state/region.
+                TaxJar currently supports one address per region.'
+            ),
+            '422' => __(
+                'Your nexus address is missing one or more required fields.
+                Please verify the address in order to sync with TaxJar.'
+            ),
+            '500' => __(
+                'Something went wrong while syncing your address with TaxJar.
+                Please verify the address and contact support@taxjar.com if the problem persists.'
+            )
         ];
-        // @codingStandardsIgnoreEnd
 
         if ($this->getId()) {
             $client->putResource('nexus', $this->getApiId(), $data, $responseErrors);
@@ -137,12 +147,13 @@ class NexusSync extends \Taxjar\SalesTax\Model\Tax\Nexus
     {
         $client = $this->clientFactory->create();
 
-        // @codingStandardsIgnoreStart
         $responseErrors = [
             '409' => __('A nexus address with this ID could not be found in TaxJar.'),
-            '500' => __('Something went wrong while deleting your address in TaxJar. Please contact support@taxjar.com if the problem persists.')
+            '500' => __(
+                'Something went wrong while deleting your address in TaxJar.
+                Please contact support@taxjar.com if the problem persists.'
+            )
         ];
-        // @codingStandardsIgnoreEnd
 
         if ($this->getId()) {
             $client->deleteResource('nexus', $this->getApiId(), $responseErrors);

--- a/Observer/ConfigReview.php
+++ b/Observer/ConfigReview.php
@@ -94,10 +94,8 @@ class ConfigReview implements ObserverInterface
      * @return $this
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    // @codingStandardsIgnoreStart
     public function execute(Observer $observer)
     {
-        // @codingStandardsIgnoreEnd
         $configSection = $this->request->getParam('section');
 
         if ($configSection == 'tax') {
@@ -114,29 +112,28 @@ class ConfigReview implements ObserverInterface
 
     /**
      * @return void
-     * @SuppressWarnings(Generic.Files.LineLength.TooLong)
      */
     private function _reviewNexusAddresses()
     {
         $nexusAddresses = $this->nexusFactory->create()->getCollection();
 
         if (!$nexusAddresses->getSize()) {
-            // @codingStandardsIgnoreStart
-            $this->messageManager->addErrorMessage(__('You have no nexus addresses loaded in Magento. Go to Stores > Nexus Addresses to sync from your TaxJar account or add a new address.'));
-            // @codingStandardsIgnoreEnd
+            $this->messageManager->addErrorMessage(
+                __(
+                    'You have no nexus addresses loaded in Magento.
+                    Go to Stores > Nexus Addresses to sync from your TaxJar account or add a new address.'
+                )
+            );
         }
     }
 
     /**
      * @return void
-     * @SuppressWarnings(Generic.Files.LineLength.TooLong)
      */
     private function _reviewSandboxMode()
     {
         if ($this->taxjarConfig->isSandboxEnabled()) {
-            // @codingStandardsIgnoreStart
             $this->messageManager->addComplexWarningMessage('tjSandboxWarning');
-            // @codingStandardsIgnoreEnd
         }
     }
 }

--- a/Test/Integration/Model/Tax/Sales/Total/Quote/SetupUtil.php
+++ b/Test/Integration/Model/Tax/Sales/Total/Quote/SetupUtil.php
@@ -503,7 +503,7 @@ class SetupUtil
             foreach ($overrides[self::TAX_RULE_OVERRIDES] as $taxRuleOverrideData) {
                 //convert code to id for productTaxClass, customerTaxClass and taxRate
                 $taxRuleOverrideData = $this->processTaxRuleOverrides($taxRuleOverrideData, $taxRateIds);
-                $mergedTaxRuleData = array_merge($taxRuleDefaultData, $taxRuleOverrideData);
+                $mergedTaxRuleData = $taxRuleDefaultData + $taxRuleOverrideData;
                 $this->taxRules[$mergedTaxRuleData['code']] = $this->objectManager
                     ->create(\Magento\Tax\Model\Calculation\Rule::class)
                     ->setData($mergedTaxRuleData)

--- a/Test/Integration/Model/Tax/Sales/Total/Quote/SetupUtil.php
+++ b/Test/Integration/Model/Tax/Sales/Total/Quote/SetupUtil.php
@@ -15,8 +15,6 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
-// @codingStandardsIgnoreStart
-
 namespace Taxjar\SalesTax\Test\Integration\Model\Tax\Sales\Total\Quote;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -263,8 +261,12 @@ class SetupUtil
     public function __construct($objectManager)
     {
         $this->objectManager = $objectManager;
-        $this->customerRepository = $this->objectManager->create(\Magento\Customer\Api\CustomerRepositoryInterface::class);
-        $this->accountManagement = $this->objectManager->create(\Magento\Customer\Api\AccountManagementInterface::class);
+        $this->customerRepository = $this->objectManager->create(
+            \Magento\Customer\Api\CustomerRepositoryInterface::class
+        );
+        $this->accountManagement = $this->objectManager->create(
+            \Magento\Customer\Api\AccountManagementInterface::class
+        );
     }
 
     /**
@@ -356,7 +358,8 @@ class SetupUtil
             if (isset($taxRateOverrides[$taxRateCode])) {
                 $this->taxRates[$taxRateCode]['data']['rate'] = $taxRateOverrides[$taxRateCode];
             }
-            $this->taxRates[$taxRateCode]['id'] = $this->objectManager->create(\Magento\Tax\Model\Calculation\Rate::class)
+            $this->taxRates[$taxRateCode]['id'] = $this->objectManager
+                ->create(\Magento\Tax\Model\Calculation\Rate::class)
                 ->setData($this->taxRates[$taxRateCode]['data'])
                 ->save()
                 ->getId();
@@ -628,7 +631,9 @@ class SetupUtil
                 'value_index' => $option->getValue(),
             ];
 
-            $associatedProductIds[] = $this->createSimpleProduct($optionSku, $price, $taxClassId, $optionAttribute)->getId();
+            $associatedProductIds[] = $this
+                ->createSimpleProduct($optionSku, $price, $taxClassId, $optionAttribute)
+                ->getId();
         }
 
         /** @var $product \Magento\Catalog\Model\Product */
@@ -956,7 +961,9 @@ class SetupUtil
      */
     protected function createNexusAddresses($overrides)
     {
-        $addresses = empty($overrides[self::NEXUS_OVERRIDES]) ? $this->nexusAddresses : $overrides[self::NEXUS_OVERRIDES];
+        $addresses = empty($overrides[self::NEXUS_OVERRIDES])
+            ? $this->nexusAddresses
+            : $overrides[self::NEXUS_OVERRIDES];
 
         foreach ($addresses as $address) {
             $nexusModel = $this->objectManager->create('Taxjar\SalesTax\Model\Tax\Nexus')

--- a/view/adminhtml/templates/address_validation.phtml
+++ b/view/adminhtml/templates/address_validation.phtml
@@ -14,18 +14,18 @@
  * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-
-// @codingStandardsIgnoreFile
-
+/** @var \Taxjar\SalesTax\Block\Adminhtml\AddressValidation $block */
 ?>
 <p class='note'>
-    <span>Validate shipping addresses and return back suggested addresses at checkout. Ensures the customer data sent to TaxJar is accurate for calculations.</span>
-    <?php if (!$block->isAuthorized()) { ?>
-        <span>Address validation requires a TaxJar Professional subscription. <a href="https://www.taxjar.com/how-it-works/" target="_blank">Learn more.</a></span>
-    <?php } ?>
+    <span>Validate shipping addresses and return back suggested addresses at checkout.
+        Ensures the customer data sent to TaxJar is accurate for calculations.</span>
+    <?php if (!$block->isAuthorized()): ?>
+        <span>Address validation requires a TaxJar Professional subscription.
+            <a href="https://www.taxjar.com/how-it-works/" target="_blank">Learn more.</a></span>
+    <?php endif; ?>
 </p>
 
-<?php if (!$block->isAuthorized()) { ?>
+<?php if (!$block->isAuthorized()): ?>
     <script>
         require([
             'jquery'
@@ -35,4 +35,4 @@
             });
         });
     </script>
-<?php } ?>
+<?php endif; ?>

--- a/view/adminhtml/templates/debug.phtml
+++ b/view/adminhtml/templates/debug.phtml
@@ -15,25 +15,30 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 /** @var \Taxjar\SalesTax\Block\Adminhtml\Debug $block */
+/** @var \Magento\Framework\Escaper $escaper */
 ?>
 <p class='note'>
-    <span>If enabled, does not alter your tax rates or database and instead prints debug messages for use with
-        TaxJar support.</span>
+    <span>
+        If enabled, does not alter your tax rates or database and instead prints debug messages for use with
+        TaxJar support.
+    </span>
 </p>
 
 <?php if ($block->isEnabled()): ?>
     <br/>
     <ul>
-        <li><strong>Magento Version:</strong> <?php echo $block->escapeHtml($block->getMagentoVersion()) ?></li>
-        <li><strong>TaxJar Version:</strong> <?php echo $block->escapeHtml($block->getVersion()) ?></li>
-        <li><strong>PHP Version:</strong> <?php echo $block->escapeHtml($block->getPhpVersion()) ?></li>
-        <li><strong>PHP Memory Limit:</strong> <?php echo $block->escapeHtml($block->getMemoryLimit()) ?></li>
-        <li><strong>Backup States:</strong> <?php echo $block->escapeHtml($block->getBackupStates()) ?></li>
-        <li><strong>Backup Last Updated:</strong> <?php echo $block->escapeHtml($block->getBackupUpdate()) ?></li>
+        <li><strong>Magento Version:</strong> <?= $escaper->escapeHtml($block->getMagentoVersion()) ?></li>
+        <li><strong>TaxJar Version:</strong> <?= $escaper->escapeHtml($block->getVersion()) ?></li>
+        <li><strong>PHP Version:</strong> <?= $escaper->escapeHtml($block->getPhpVersion()) ?></li>
+        <li><strong>PHP Memory Limit:</strong> <?= $escaper->escapeHtml($block->getMemoryLimit()) ?></li>
+        <li><strong>Backup States:</strong> <?= $escaper->escapeHtml($block->getBackupStates()) ?></li>
+        <li><strong>Backup Last Updated:</strong> <?= $escaper->escapeHtml($block->getBackupUpdate()) ?></li>
     </ul>
     <p>
         <small>
-            <strong>Include the above information when emailing TaxJar support at support@taxjar.com.</strong>
+            <strong>
+                Include the above information when emailing TaxJar support at support@taxjar.com.
+            </strong>
         <small>
     </p>
 <?php endif; ?>

--- a/view/adminhtml/templates/debug.phtml
+++ b/view/adminhtml/templates/debug.phtml
@@ -14,13 +14,14 @@
  * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-
-// @codingStandardsIgnoreFile
-
+/** @var \Taxjar\SalesTax\Block\Adminhtml\Debug $block */
 ?>
-<p class='note'><span>If enabled, does not alter your tax rates or database and instead prints debug messages for use with TaxJar support.</span></p>
+<p class='note'>
+    <span>If enabled, does not alter your tax rates or database and instead prints debug messages for use with
+        TaxJar support.</span>
+</p>
 
-<?php if ($block->isEnabled()) { ?>
+<?php if ($block->isEnabled()): ?>
     <br/>
     <ul>
         <li><strong>Magento Version:</strong> <?php echo $block->escapeHtml($block->getMagentoVersion()) ?></li>
@@ -30,5 +31,9 @@
         <li><strong>Backup States:</strong> <?php echo $block->escapeHtml($block->getBackupStates()) ?></li>
         <li><strong>Backup Last Updated:</strong> <?php echo $block->escapeHtml($block->getBackupUpdate()) ?></li>
     </ul>
-    <p><small><strong>Include the above information when emailing TaxJar support at support@taxjar.com.</strong><small></p>
-<?php } ?>
+    <p>
+        <small>
+            <strong>Include the above information when emailing TaxJar support at support@taxjar.com.</strong>
+        <small>
+    </p>
+<?php endif; ?>

--- a/view/adminhtml/templates/enabled.phtml
+++ b/view/adminhtml/templates/enabled.phtml
@@ -15,6 +15,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 /** @var \Taxjar\SalesTax\Block\Adminhtml\Enabled $block */
+/** @var \Magento\Framework\Escaper $escaper */
 ?>
 <p class='note'>
     <span>Sales tax calculations at checkout for improved accuracy and product exemptions. Magento's zip-based rates
@@ -27,36 +28,44 @@
     <div class='messages'>
         <div class='message message-success success'>
             <span style='font-size: 1.2em'>
-                <?php echo $block->escapeHtml($block->getApiEmail()) ?>
+                <?= $escaper->escapeHtml($block->getApiEmail()) ?>
             </span>
         </div>
     </div>
 
     <p><b>Getting Started</b></p>
     <p>
-        <a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/nexus/index')) ?>'>Nexus Addresses</a>
+        <a href='<?= $escaper->escapeUrl($block->getStoreUrl('taxjar/nexus/index')) ?>'>Nexus Addresses</a>
         <br/>
-        <span style='font-size: 0.9em'>Before enabling TaxJar for calculations, set up your nexus addresses so TaxJar knows where
-            to collect sales tax.</span>
+        <span style='font-size: 0.9em'>
+            Before enabling TaxJar for calculations, set up your nexus addresses so TaxJar knows where to collect
+            sales tax.
+        </span>
     </p>
     <p>
-        <a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/taxclass_product')) ?>'>
+        <a href='<?= $escaper->escapeUrl($block->getStoreUrl('taxjar/taxclass_product')) ?>'>
             Product Exemptions
         </a>
         <br/>
-        <span style='font-size: 0.9em'>If some of your products are tax exempt, assign a TaxJar product tax code to new or existing
-            product tax classes.</span>
+        <span style='font-size: 0.9em'>
+            If some of your products are tax exempt, assign a TaxJar product tax code to new or existing product
+            tax classes.
+        </span>
     </p>
     <p>
-        <a href='<?php echo $block->escapeUrl($block->getStoreUrl('customer/index')) ?>'>Customer Exemptions</a>
+        <a href='<?= $escaper->escapeUrl($block->getStoreUrl('customer/index')) ?>'>Customer Exemptions</a>
         <br/>
-        <span style='font-size: 0.9em'>If some of your customers are tax exempt, assign a TaxJar exemption type to each customer
-            individually or multiple customers at once.</span>
+        <span style='font-size: 0.9em'>
+            If some of your customers are tax exempt, assign a TaxJar exemption type to each customer individually or
+            multiple customers at once.
+        </span>
     </p>
     <p>
         <a href='http://www.taxjar.com/contact/' target='_blank'>Help & Support</a>
         <br/>
-        <span style='font-size: 0.9em'>Need help setting up TaxJar? Get in touch with our Magento sales tax experts.</span>
+        <span style='font-size: 0.9em'>
+            Need help setting up TaxJar? Get in touch with our Magento sales tax experts.
+        </span>
     </p>
     <br/>
     <p>
@@ -67,9 +76,7 @@
                         "Are you sure you want to disconnect from TaxJar? " +
                         "This will remove all TaxJar rates from your Magento store. " +
                         "If you have a paid TaxJar subscription, manage your account at https://app.taxjar.com."
-                    )) window.location="<?php
-                        echo $block->escapeUrl($block->getStoreUrl('taxjar/config/disconnect'))
-                    ?>"
+                    )) window.location="<?= $escaper->escapeUrl($block->getStoreUrl('taxjar/config/disconnect'))?>"
                 '>
             <span>Disconnect TaxJar</span>
         </button>
@@ -86,7 +93,7 @@
                 class='scalable primary'
                 onclick='
                     openPopup(
-                        "<?php echo $block->escapeUrl($block->getPopupUrl()) ?>",
+                        "<?= $escaper->escapeUrl($block->getPopupUrl()) ?>",
                         "Connect to TaxJar",
                         400,
                         500
@@ -106,7 +113,7 @@
             'taxjarPopup'
         ], function(popup) {
             window.addEventListener('message', function(e) {
-                if (e.origin !== '<?php echo $block->escapeUrl($block->getAuthUrl()) ?>')
+                if (e.origin !== '<?= $escaper->escapeUrl($block->getAuthUrl()) ?>')
                     return;
 
                 try {
@@ -114,10 +121,10 @@
                     if (data.api_token && data.email) {
                         window.popup.postMessage(
                             'Data received',
-                            '<?php echo $block->escapeUrl($block->getAuthUrl()) ?>'
+                            '<?= $escaper->escapeUrl($block->getAuthUrl()) ?>'
                         );
                         window.location = encodeURI(
-                            '<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/connect')) ?>' +
+                            '<?= $escaper->escapeUrl($block->getStoreUrl('taxjar/config/connect')) ?>' +
                             '?api_key=' + data.api_token +
                             '&api_email=' + data.email
                         );

--- a/view/adminhtml/templates/enabled.phtml
+++ b/view/adminhtml/templates/enabled.phtml
@@ -18,8 +18,10 @@
 /** @var \Magento\Framework\Escaper $escaper */
 ?>
 <p class='note'>
-    <span>Sales tax calculations at checkout for improved accuracy and product exemptions. Magento's zip-based rates
-        can be used as a fallback.</span>
+    <span>
+        Sales tax calculations at checkout for improved accuracy and product exemptions. Magento's zip-based rates
+        can be used as a fallback.
+    </span>
 </p>
 <br/>
 
@@ -71,13 +73,8 @@
     <p>
         <button type='button'
                 class='scalable delete'
-                onclick='
-                    if (window.confirm(
-                        "Are you sure you want to disconnect from TaxJar? " +
-                        "This will remove all TaxJar rates from your Magento store. " +
-                        "If you have a paid TaxJar subscription, manage your account at https://app.taxjar.com."
-                    )) window.location="<?= $escaper->escapeUrl($block->getStoreUrl('taxjar/config/disconnect'))?>"
-                '>
+                onclick='if (window.confirm("<?= $escaper->escapeHtml($block->getDisconnectMessage()) ?>"))
+                    window.location="<?= $escaper->escapeUrl($block->getStoreUrl('taxjar/config/disconnect'))?>"'>
             <span>Disconnect TaxJar</span>
         </button>
         <button type='button'

--- a/view/adminhtml/templates/enabled.phtml
+++ b/view/adminhtml/templates/enabled.phtml
@@ -14,52 +14,123 @@
  * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-
-// @codingStandardsIgnoreFile
-
+/** @var \Taxjar\SalesTax\Block\Adminhtml\Enabled $block */
 ?>
-<p class='note'><span>Sales tax calculations at checkout for improved accuracy and product exemptions. Magento's zip-based rates can be used as a fallback.</span></p><br/>
+<p class='note'>
+    <span>Sales tax calculations at checkout for improved accuracy and product exemptions. Magento's zip-based rates
+        can be used as a fallback.</span>
+</p>
+<br/>
 
-<?php if ($block->isConnected()) { ?>
-  <p><b>TaxJar Account</b></p>
-  <div class='messages'>
-      <div class='message message-success success'>
-          <span style='font-size: 1.2em'>
-            <?php echo $block->escapeHtml($block->getApiEmail()) ?>
-          </span>
-      </div>
-  </div>
+<?php if ($block->isConnected()): ?>
+    <p><b>TaxJar Account</b></p>
+    <div class='messages'>
+        <div class='message message-success success'>
+            <span style='font-size: 1.2em'>
+                <?php echo $block->escapeHtml($block->getApiEmail()) ?>
+            </span>
+        </div>
+    </div>
 
-  <p><b>Getting Started</b></p>
-  <p><a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/nexus/index')) ?>'>Nexus Addresses</a><br/><span style='font-size: 0.9em'>Before enabling TaxJar for calculations, set up your nexus addresses so TaxJar knows where to collect sales tax.</span></p>
-  <p><a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/taxclass_product')) ?>'>Product Exemptions</a><br/><span style='font-size: 0.9em'>If some of your products are tax exempt, assign a TaxJar product tax code to new or existing product tax classes.</span></p>
-  <p><a href='<?php echo $block->escapeUrl($block->getStoreUrl('customer/index')) ?>'>Customer Exemptions</a><br/><span style='font-size: 0.9em'>If some of your customers are tax exempt, assign a TaxJar exemption type to each customer individually or multiple customers at once.</span></p>
-  <p><a href='http://www.taxjar.com/contact/' target='_blank'>Help & Support</a><br/><span style='font-size: 0.9em'>Need help setting up TaxJar? Get in touch with our Magento sales tax experts.</span></p><br/>
+    <p><b>Getting Started</b></p>
+    <p>
+        <a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/nexus/index')) ?>'>Nexus Addresses</a>
+        <br/>
+        <span style='font-size: 0.9em'>Before enabling TaxJar for calculations, set up your nexus addresses so TaxJar knows where
+            to collect sales tax.</span>
+    </p>
+    <p>
+        <a href='<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/taxclass_product')) ?>'>
+            Product Exemptions
+        </a>
+        <br/>
+        <span style='font-size: 0.9em'>If some of your products are tax exempt, assign a TaxJar product tax code to new or existing
+            product tax classes.</span>
+    </p>
+    <p>
+        <a href='<?php echo $block->escapeUrl($block->getStoreUrl('customer/index')) ?>'>Customer Exemptions</a>
+        <br/>
+        <span style='font-size: 0.9em'>If some of your customers are tax exempt, assign a TaxJar exemption type to each customer
+            individually or multiple customers at once.</span>
+    </p>
+    <p>
+        <a href='http://www.taxjar.com/contact/' target='_blank'>Help & Support</a>
+        <br/>
+        <span style='font-size: 0.9em'>Need help setting up TaxJar? Get in touch with our Magento sales tax experts.</span>
+    </p>
+    <br/>
+    <p>
+        <button type='button'
+                class='scalable delete'
+                onclick='
+                    if (window.confirm(
+                        "Are you sure you want to disconnect from TaxJar? " +
+                        "This will remove all TaxJar rates from your Magento store. " +
+                        "If you have a paid TaxJar subscription, manage your account at https://app.taxjar.com."
+                    )) window.location="<?php
+                        echo $block->escapeUrl($block->getStoreUrl('taxjar/config/disconnect'))
+                    ?>"
+                '>
+            <span>Disconnect TaxJar</span>
+        </button>
+        <button type='button'
+                class='scalable'
+                onclick='window.open("http://www.taxjar.com/guides/integrations/magento/", "_blank")'>
+            <span>Learn More</span>
+        </button>
+    </p>
+    <br/>
+<?php else: ?>
+    <p>
+        <button type='button'
+                class='scalable primary'
+                onclick='
+                    openPopup(
+                        "<?php echo $block->escapeUrl($block->getPopupUrl()) ?>",
+                        "Connect to TaxJar",
+                        400,
+                        500
+                    )
+                '>
+            <span>Connect to TaxJar</span>
+        </button>
+        <button type='button'
+                class='scalable'
+                onclick='window.open("http://www.taxjar.com/guides/integrations/magento/", "_blank")'>
+            <span>Learn More</span>
+        </button>
+    </p>
 
-  <p><button type='button' class='scalable delete' onclick='if (window.confirm("Are you sure you want to disconnect from TaxJar? This will remove all TaxJar rates from your Magento store. If you have a paid TaxJar subscription, manage your account at https://app.taxjar.com.")) window.location="<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/disconnect')) ?>"'><span>Disconnect TaxJar</span></button>&nbsp;&nbsp;<button type='button' class='scalable' onclick='window.open("http://www.taxjar.com/guides/integrations/magento/", "_blank")'><span>Learn More</span></button></p><br/>
-<?php } else { ?>
-  <p><button type='button' class='scalable primary' onclick='openPopup("<?php echo $block->escapeUrl($block->getPopupUrl()) ?>", "Connect to TaxJar", 400, 500)'><span>Connect to TaxJar</span></button>&nbsp;&nbsp;<button type='button' class='scalable' onclick='window.open("http://www.taxjar.com/guides/integrations/magento/", "_blank")'><span>Learn More</span></button></p>
+    <script>
+        require([
+            'taxjarPopup'
+        ], function(popup) {
+            window.addEventListener('message', function(e) {
+                if (e.origin !== '<?php echo $block->escapeUrl($block->getAuthUrl()) ?>')
+                    return;
 
-  <script>
-    require([
-        'taxjarPopup'
-    ], function(popup) {
-        window.addEventListener('message', function(e) {
-            if (e.origin !== '<?php echo $block->escapeUrl($block->getAuthUrl()) ?>')
-                return;
-
-            try {
-                var data = JSON.parse(e.data);
-                if (data.api_token && data.email) {
-                    window.popup.postMessage('Data received', '<?php echo $block->escapeUrl($block->getAuthUrl()) ?>');
-                    window.location = encodeURI('<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/connect')) ?>?api_key=' + data.api_token + '&api_email=' + data.email);
-                } else {
-                    throw 'Invalid data';
+                try {
+                    var data = JSON.parse(e.data);
+                    if (data.api_token && data.email) {
+                        window.popup.postMessage(
+                            'Data received',
+                            '<?php echo $block->escapeUrl($block->getAuthUrl()) ?>'
+                        );
+                        window.location = encodeURI(
+                            '<?php echo $block->escapeUrl($block->getStoreUrl('taxjar/config/connect')) ?>' +
+                            '?api_key=' + data.api_token +
+                            '&api_email=' + data.email
+                        );
+                    } else {
+                        throw 'Invalid data';
+                    }
+                } catch (e) {
+                    alert(
+                        'Invalid API token or email provided. ' +
+                        'Please try connecting to TaxJar again or contact support@taxjar.com.'
+                    );
                 }
-            } catch (e) {
-                alert('Invalid API token or email provided. Please try connecting to TaxJar again or contact support@taxjar.com.');
-            }
-        }, false);
-    });
-  </script>
-<?php } ?>
+            }, false);
+        });
+    </script>
+<?php endif; ?>

--- a/view/adminhtml/templates/transaction_sync.phtml
+++ b/view/adminhtml/templates/transaction_sync.phtml
@@ -110,10 +110,7 @@
     </script>
 
     <div id="transaction-sync-modal" style="display: none">
-        <?= $block->getLayout()
-                ->createBlock(\Taxjar\SalesTax\Block\Adminhtml\TransactionSync\Form::class)
-                ->setTemplate('Taxjar_SalesTax::transaction_sync/form.phtml')
-                ->toHtml(); ?>
+        <?= $block->getTransactionSyncFormHtml(); ?>
         <div class="admin__fieldset">
             <div class="admin__field">
                 <label class="label admin__field-label">Output Log</label>

--- a/view/adminhtml/templates/transaction_sync.phtml
+++ b/view/adminhtml/templates/transaction_sync.phtml
@@ -15,10 +15,13 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 /** @var \Taxjar\SalesTax\Block\Adminhtml\TransactionSync $block */
+/** @var \Magento\Framework\Escaper $escaper */
 ?>
 <p class='note'>
-    <span>Sync orders and refunds with TaxJar for automated sales tax reporting and filing. Complete and closed
-        transactions sync automatically on update.</span>
+    <span>
+        Sync orders and refunds with TaxJar for automated sales tax reporting and filing.
+        Complete and closed transactions sync automatically on update.
+    </span>
 </p>
 <br/>
 
@@ -79,14 +82,14 @@
                 $('#transaction-sync-log').find('> pre').html('Syncing transactions to TaxJar, please wait...');
 
                 $.ajax({
-                    url: '<?= $block->escapeUrl($block->getStoreUrl('taxjar/transaction/backfill')) ?>',
+                    url: '<?= $escaper->escapeUrl($block->getStoreUrl('taxjar/transaction/backfill')) ?>',
                     method: 'GET',
                     data: {
                         from_date: fromDate,
                         to_date: toDate,
                         force: force,
-                        store: '<?= $this->getRequest()->getParam('store') ?>',
-                        website: '<?= $this->getRequest()->getParam('website') ?>',
+                        store: '<?= $escaper->escapeHtmlAttr($block->getRequest()->getParam('store')) ?>',
+                        website: '<?= $escaper->escapeHtmlAttr($block->getRequest()->getParam('website')) ?>',
                     }
                 }).done(function(data) {
                     if (data.result) {
@@ -107,18 +110,26 @@
     </script>
 
     <div id="transaction-sync-modal" style="display: none">
-        <?php
-            echo $block->getLayout()
-                       ->createBlock('Taxjar\SalesTax\Block\Adminhtml\TransactionSync\Form')
-                       ->setTemplate('Taxjar_SalesTax::transaction_sync/form.phtml')
-                       ->toHtml();
-        ?>
+        <?= $block->getLayout()
+                ->createBlock(\Taxjar\SalesTax\Block\Adminhtml\TransactionSync\Form::class)
+                ->setTemplate('Taxjar_SalesTax::transaction_sync/form.phtml')
+                ->toHtml(); ?>
         <div class="admin__fieldset">
             <div class="admin__field">
                 <label class="label admin__field-label">Output Log</label>
                 <div class="admin__field-control" style="width: 70%;">
-                    <div id="transaction-sync-log" style="overflow: auto; max-height: 500px; margin-bottom: 1em; padding: 0 1em; border: 1px solid #e3e3e3; background: #f8f8f8">
-                        <pre style="overflow: visible">Awaiting sync! Click "Sync to TaxJar" to start syncing transactions.</pre>
+                    <div id="transaction-sync-log"
+                         style="
+                            overflow: auto;
+                            max-height: 500px;
+                            margin-bottom: 1em;
+                            padding: 0 1em;
+                            border: 1px solid #e3e3e3;
+                            background: #f8f8f8
+                        ">
+                        <pre style="overflow: visible">
+                            Awaiting sync! Click "Sync to TaxJar" to start syncing transactions.
+                        </pre>
                     </div>
                     <p>
                         <button type="button"

--- a/view/adminhtml/templates/transaction_sync.phtml
+++ b/view/adminhtml/templates/transaction_sync.phtml
@@ -14,16 +14,22 @@
  * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-
-// @codingStandardsIgnoreFile
-
-?>
-<p class='note'><span>Sync orders and refunds with TaxJar for automated sales tax reporting and filing. Complete and closed transactions sync automatically on update.</span></p><br/>
-
-<?php
 /** @var \Taxjar\SalesTax\Block\Adminhtml\TransactionSync $block */
-if ($block->isEnabled()) { ?>
-    <p><button type="button" class="scalable" onclick="openTransactionSyncModal()"><span>Sync Transactions</span></button></p>
+?>
+<p class='note'>
+    <span>Sync orders and refunds with TaxJar for automated sales tax reporting and filing. Complete and closed
+        transactions sync automatically on update.</span>
+</p>
+<br/>
+
+<?php if ($block->isEnabled()): ?>
+    <p>
+        <button type="button"
+                class="scalable"
+                onclick="openTransactionSyncModal()">
+            <span>Sync Transactions</span>
+        </button>
+    </p>
     <script>
         require([
             'jquery',
@@ -114,9 +120,15 @@ if ($block->isEnabled()) { ?>
                     <div id="transaction-sync-log" style="overflow: auto; max-height: 500px; margin-bottom: 1em; padding: 0 1em; border: 1px solid #e3e3e3; background: #f8f8f8">
                         <pre style="overflow: visible">Awaiting sync! Click "Sync to TaxJar" to start syncing transactions.</pre>
                     </div>
-                    <p><button type="button" class="copy-button scalable" data-clipboard-target="#transaction-sync-log"><span>Copy Output</span></button></p>
+                    <p>
+                        <button type="button"
+                                class="copy-button scalable"
+                                data-clipboard-target="#transaction-sync-log">
+                            <span>Copy Output</span>
+                        </button>
+                    </p>
                 </div>
             </div>
         </div>
     </div>
-<?php } ?>
+<?php endif; ?>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Unlike our GitHub actions PHPCS stage, Adobe Commerce marketplace's PHPCS test ignores `@codingStandardsIgnore` annotations causing many lower-level standards errors.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Fixes line length too long sniffs (and any remaining sniffs in touched files so that PHPCS passes)