### PR TITLE
fix: Config scoped address validation

### DIFF
--- a/Api/AddressValidationInterface.php
+++ b/Api/AddressValidationInterface.php
@@ -28,6 +28,7 @@ interface AddressValidationInterface
      * @param string $region
      * @param string $country
      * @param string $postcode
+     * @param string $storeCode
      * @return mixed
      */
     public function validateAddress(
@@ -36,6 +37,7 @@ interface AddressValidationInterface
         $city = null,
         $region = null,
         $country = null,
-        $postcode = null
+        $postcode = null,
+        $storeCode = null
     );
 }

--- a/view/base/web/js/model/address_validation_core.js
+++ b/view/base/web/js/model/address_validation_core.js
@@ -50,6 +50,7 @@ function (ko, $) {
             }
 
             var formattedAddr = self.formatAddress(addr);
+            var scopedAddr = self.formatScopedAddress(addr);
 
             if (self.isSuggestedAddress(addr)) {
                 if (typeof onDone === 'function') {
@@ -61,7 +62,7 @@ function (ko, $) {
             $.ajax({
                 type: 'POST',
                 url: this.getAddressValidationUrl(),
-                data: JSON.stringify($.extend({}, {form_key: window.FORM_KEY}, formattedAddr)),
+                data: JSON.stringify($.extend({}, {form_key: window.FORM_KEY}, scopedAddr)),
                 contentType: 'application/json; charset=utf-8',
                 dataType: 'json',
                 beforeSend: function (xhr) {
@@ -122,6 +123,15 @@ function (ko, $) {
                 'country': address.country_id,
                 'postcode': address.postcode
             };
+        },
+
+        formatScopedAddress: function (address) {
+            var self = this;
+            var addr = self.formatAddress(address);
+            if (address.store_code !== undefined) {
+                addr.store_code = address.store_code;
+            }
+            return addr;
         },
 
         formatSuggestedAddress: function (suggestedAddress) {

--- a/view/frontend/web/js/view/shipping.js
+++ b/view/frontend/web/js/view/shipping.js
@@ -41,7 +41,8 @@ define([
                     city: self.source.get('shippingAddress.city'),
                     region_id: self.source.get('shippingAddress.region_id'),
                     postcode: self.source.get('shippingAddress.postcode'),
-                    country_id: self.source.get('shippingAddress.country_id')
+                    country_id: self.source.get('shippingAddress.country_id'),
+                    store_code: quote.getStoreCode()
                 });
             });
         },

--- a/view/frontend/web/js/view/suggested_address_checkout_step.js
+++ b/view/frontend/web/js/view/suggested_address_checkout_step.js
@@ -68,17 +68,18 @@ function (
             this.subscribeToSuggestedAddesses();
             this.subscribeToSuggestedAddressRadio();
 
-            quote.shippingAddress.subscribe(function (address) {
+            quote.shippingAddress.subscribe(function () {
                 var quote_address = quote.shippingAddress();
-                var address = {
+                var store_code = quote.getStoreCode();
+
+                avCore.getSuggestedAddresses({
                     country_id: quote_address.countryId,
                     region_id: quote_address.regionId,
                     postcode: quote_address.postcode,
                     city: quote_address.city,
-                    street: quote_address.street
-                };
-
-                avCore.getSuggestedAddresses(address);
+                    street: quote_address.street,
+                    store_code: store_code
+                });
             });
 
             quote.shippingMethod.subscribe(function () {


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
EU-based merchant with US storeview observed an issue with address validation. Address validation feature was disabled globally, but should've been enabled for the US storeview's scope.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Adds request parameter value for address validation scope configuration. Address validation requests in checkout will pass the current store code to the backend which is used to find the current store scope ID in a WebAPI request.

Customer address validation in Adminhtml will still defer to the global scope's configuration value.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Bug fix

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Observed successful checkout address validation for store with address validation enabled while global address validation disabled.
2. Observed bypassed checkout address validation for store with disabled global address validation config
3. Observed bypassed customer address validation in adminhtml due to feature being disabled in global config 

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
