### PR TITLE
fix: Scope sales order transaction sync button

### DIFF
--- a/Plugin/Sales/Block/Adminhtml/Order/View.php
+++ b/Plugin/Sales/Block/Adminhtml/Order/View.php
@@ -54,7 +54,7 @@ class View
      */
     protected function shouldRender(\Magento\Sales\Api\Data\OrderInterface $order): bool
     {
-        return $this->_tjSalesTaxData->isTransactionSyncEnabled()
+        return $this->_tjSalesTaxData->isTransactionSyncEnabled($order->getStoreId())
             && $this->_tjSalesTaxData->isSyncableOrder($order);
     }
 }

--- a/view/adminhtml/templates/order/view/tab/taxjar/info/sync.phtml
+++ b/view/adminhtml/templates/order/view/tab/taxjar/info/sync.phtml
@@ -18,30 +18,21 @@
 /** @var $block \Taxjar\SalesTax\Block\Adminhtml\Order\View\Tab\Taxjar\View\Info\Sync */
 
 $order = $block->getOrder();
-$orderState = $order->getState();
-$syncDate = $order->getData('tj_salestax_sync_date');
-if ($syncDate) {
-    $orderAdminDate = $block->formatDate(
-        $block->getOrderSyncedAtDate($syncDate),
-        \IntlDateFormatter::MEDIUM,
-        true
-    );
-}
-$allowedTags = ['br', 'pre'];
+$formattedDate = $block->getFormattedSyncDate($order);
 ?>
 
 <div class="admin__page-section-item">
     <div class="admin__page-section-item-content taxjar-order-sync-information">
     <?php if ($block->featureEnabled()): ?>
-        <?php if (isset($orderAdminDate)): ?>
-            <p><i>Last synced at <?= $block->escapeHtml($orderAdminDate) ?></i></p>
+        <?php if ($formattedDate): ?>
+            <p><i>Last synced at <?= $block->escapeHtml($formattedDate) ?></i></p>
         <?php else: ?>
-            <span><?= $block->escapeHtml($block->getOrderStateText($orderState), $allowedTags) ?></span>
+            <span><?= $block->escapeHtml($block->getOrderStateText($order), ['br', 'pre']) ?></span>
             <br><br>
-            <span><?= $block->escapeHtml($block->getOrderActionableText($orderState), $allowedTags) ?></span>
+            <span><?= $block->escapeHtml($block->getOrderActionableText($order), ['br', 'pre']) ?></span>
         <?php endif; ?>
     <?php else: ?>
-        <span><?= $block->escapeHtml($block->getFeatureDisabledText(), $allowedTags) ?></span>
+        <span><?= $block->escapeHtml($block->getFeatureDisabledText(), ['br', 'pre']) ?></span>
     <?php endif; ?>
     </div>
 </div>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Bug found in previous testing that some Transaction Sync UI elements were visible while transaction sync feature was disabled for the current scope.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Fix rendering of "Sync to TaxJar" button based on current order scope's configuration.
- Updates language rendered in sales order metadata view's transaction sync section based on scope configuration.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
Tested with transaction sync configuration:
```
[
    'default' => 1,
    'main_website' => 0,
    'secondary_website' => 1,
]
```

1. Order in main website
<img width="1351" alt="Screen Shot 2022-04-25 at 1 42 26 PM" src="https://user-images.githubusercontent.com/47947793/165155367-581be40b-2edc-4b98-90a1-70a1bf657379.png">

2. Order in secondary website
<img width="1355" alt="Screen Shot 2022-04-25 at 1 41 33 PM" src="https://user-images.githubusercontent.com/47947793/165155279-6c8ad5cf-c3ea-4047-ae13-a24a41245a37.png">

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
