### PR TITLE
Fix: Check for missing order metadata

### DIFF
--- a/Observer/SaveOrderMetadata.php
+++ b/Observer/SaveOrderMetadata.php
@@ -75,22 +75,25 @@ class SaveOrderMetadata implements ObserverInterface
     public function execute(Observer $observer)
     {
         $encodedMetadata = $this->checkoutSession->getData(self::ORDER_METADATA);
-        $metadata = json_decode($encodedMetadata, true);
 
-        /** @var OrderInterface $order */
-        $order = $observer->getOrder();
-        $extensionAttributes = $order->getExtensionAttributes() ?? $this->extensionFactory->create();
+        if ($encodedMetadata) {
+            $metadata = json_decode($encodedMetadata, true);
 
-        if (isset($metadata[MetadataInterface::TAX_CALCULATION_STATUS])) {
-            $extensionAttributes->setTjTaxCalculationStatus($metadata[MetadataInterface::TAX_CALCULATION_STATUS]);
+            /** @var OrderInterface $order */
+            $order = $observer->getOrder();
+            $extensionAttributes = $order->getExtensionAttributes() ?? $this->extensionFactory->create();
+
+            if (isset($metadata[MetadataInterface::TAX_CALCULATION_STATUS])) {
+                $extensionAttributes->setTjTaxCalculationStatus($metadata[MetadataInterface::TAX_CALCULATION_STATUS]);
+            }
+
+            if (isset($metadata[MetadataInterface::TAX_CALCULATION_MESSAGE])) {
+                $extensionAttributes->setTjTaxCalculationMessage($metadata[MetadataInterface::TAX_CALCULATION_MESSAGE]);
+            }
+
+            $order->setExtensionAttributes($extensionAttributes);
+
+            $this->orderRepository->save($order);
         }
-
-        if (isset($metadata[MetadataInterface::TAX_CALCULATION_MESSAGE])) {
-            $extensionAttributes->setTjTaxCalculationMessage($metadata[MetadataInterface::TAX_CALCULATION_MESSAGE]);
-        }
-
-        $order->setExtensionAttributes($extensionAttributes);
-
-        $this->orderRepository->save($order);
     }
 }


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
#319 

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
As of PHP 8.1, should check for encoded metadata before attempting to decode. 

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [ ] PHP 7.x
- [X] PHP 8.1
