### PR TITLE
fix: Trim smart calcs address postcode

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -432,21 +432,14 @@ class Smartcalcs
      */
     private function _validatePostcode($postcode, $countryId)
     {
+        $matches = [];
         $postCodes = $this->postCodesConfig->getPostCodes();
-
         if (isset($postCodes[$countryId]) && is_array($postCodes[$countryId])) {
-            $patterns = $postCodes[$countryId];
-
-            foreach ($patterns as $pattern) {
-                preg_match('/' . $pattern['pattern'] . '/', (string) $postcode, $matches);
-
-                if (count($matches)) {
-                    return true;
-                }
+            foreach ($postCodes[$countryId] as $pattern) {
+                preg_match('/' . $pattern['pattern'] . '/', trim((string) $postcode), $matches);
             }
         }
-
-        return false;
+        return (bool) count($matches);
     }
 
     /**


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Closes #322 

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
- Trim address postal code values in `SmartCalcs::_validatePostcode`

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Fixes bug

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
Tested Smartcalcs functionality via admin sales order input.
- Without `trim()`, the string "94080" will pass while "94080 " will not.
- With `trim()`, both strings "94080" and "94080 " pass regex validation..

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [X] PHP 7.x
