### PR TITLE
fix: Plugin compatibility with CartManagementInterface

### DIFF
--- a/Plugin/Quote/Model/QuoteManagement.php
+++ b/Plugin/Quote/Model/QuoteManagement.php
@@ -17,7 +17,7 @@
 
 namespace Taxjar\SalesTax\Plugin\Quote\Model;
 
-use Magento\Quote\Model\QuoteManagement as QuoteManagementEntity;
+use Magento\Quote\Api\CartManagementInterface;
 use Magento\Sales\Api\Data\OrderExtensionInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Taxjar\SalesTax\Api\Data\Sales\MetadataRepositoryInterface;
@@ -58,13 +58,13 @@ class QuoteManagement
     /**
      * Parse order extension data and persist metadata entity
      *
-     * @param QuoteManagementEntity $subject
+     * @param CartManagementInterface $subject
      * @param OrderInterface $order
      * @return OrderInterface
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
     public function afterSubmit(
-        QuoteManagementEntity $subject,
+        CartManagementInterface $subject,
         OrderInterface $order
     ): OrderInterface {
         /** @var OrderExtensionInterface $extensionAttributes */

--- a/Test/Unit/Plugin/Quote/Model/QuoteManagementTest.php
+++ b/Test/Unit/Plugin/Quote/Model/QuoteManagementTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Taxjar\SalesTax\Test\Unit\Plugin\Quote\Model;
 
-use Magento\Quote\Model\QuoteManagement as QuoteManagementEntity;
+use Magento\Quote\Api\CartManagementInterface;
 use Magento\Sales\Api\Data\OrderExtensionInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Taxjar\SalesTax\Api\Data\Sales\MetadataRepositoryInterface;
@@ -58,7 +58,7 @@ class QuoteManagementTest extends UnitTestCase
 
     public function testAfterSubmit()
     {
-        $subjectMock = $this->getMockBuilder(QuoteManagementEntity::class)
+        $subjectMock = $this->getMockBuilder(CartManagementInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -52,9 +52,6 @@
     <type name="Magento\Sales\Api\OrderRepositoryInterface">
         <plugin name="taxjar_order_repository" type="Taxjar\SalesTax\Plugin\Sales\Model\OrderRepository" />
     </type>
-    <type name="Magento\Quote\Model\QuoteManagement">
-        <plugin name="taxjar_quote_management_after_submit" type="Taxjar\SalesTax\Plugin\Quote\Model\QuoteManagement" />
-    </type>
     <type name="Taxjar\SalesTax\Console\Command\SyncProductCategoriesCommand">
         <arguments>
             <argument name="state" xsi:type="object">Magento\Framework\App\State\Proxy</argument>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Because some stores might use a custom implementation of the `CartManagementInterface`.
We are one of these stores.

Closes #326 

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Changes the expected class type in the signature to use the interface.
Removes duplicated plugin declaration

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
There should not be any impact other that increasing the compatibility of the module with stores that might use a custom implementation of the `CartManagementInterface`

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Updated `Test/Unit/Plugin/Quote/Model/QuoteManagementTest.php` subject mock from concrete class `\Magento\Quote\Model\QuoteManagement` to interface `\Magento\Quote\Api\CartManagementInterface`.

#### Versions
<!-- What version(s) did you test this change on? -->
- [x] Magento 2.4
- [x] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [x] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [x] PHP 7.4
- [x] PHP 7.3
