### PR TITLE
Fix postcode validation logic

### DIFF
--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -432,17 +432,15 @@ class Smartcalcs
      */
     private function _validatePostcode($postcode, $countryId)
     {
-        $matches = [];
         $postCodes = $this->postCodesConfig->getPostCodes();
         if (isset($postCodes[$countryId]) && is_array($postCodes[$countryId])) {
             foreach ($postCodes[$countryId] as $pattern) {
-                preg_match('/' . $pattern['pattern'] . '/', trim((string) $postcode), $matches);
-                if (count($matches)) {
+                if (preg_match("/{$pattern['pattern']}/", trim((string) $postcode))) {
                     return true;
                 }
             }
         }
-        return (bool) count($matches);
+        return false;
     }
 
     /**

--- a/Model/Smartcalcs.php
+++ b/Model/Smartcalcs.php
@@ -437,6 +437,9 @@ class Smartcalcs
         if (isset($postCodes[$countryId]) && is_array($postCodes[$countryId])) {
             foreach ($postCodes[$countryId] as $pattern) {
                 preg_match('/' . $pattern['pattern'] . '/', trim((string) $postcode), $matches);
+                if (count($matches)) {
+                    return true;
+                }
             }
         }
         return (bool) count($matches);


### PR DESCRIPTION
If a customer enters a postcode in format 12345-6789, postcode validation fails. Need to return as soon as the pattern matches.

### Context
Postcode validation fails when user enters postcode in format 12345-6789

### Description
Fixes the postcode validation logic.

### Performance
N/A

### Testing
- Add product to cart
- In the address select country US
- Add postcode in format 12345-6789
- There will be no tax calculated as the posycode validation fails

#### Versions
<!-- What version(s) did you test this change on? -->
- [x] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [ ] Magento Open Source (formerly Magento 2 Community Edition)
- [x] Adobe Commerce (formerly Magento 2 Enterprise Edition)
<!-- What version of PHP did you test this change on? -->
- [ ] PHP 8.2
- [x] PHP 8.1
- [x] PHP 7.4
- [ ] PHP 7.3
