### PR TITLE
Fix nullable order type in quote management plugin

### DIFF
--- a/Plugin/Quote/Model/QuoteManagement.php
+++ b/Plugin/Quote/Model/QuoteManagement.php
@@ -59,27 +59,29 @@ class QuoteManagement
      * Parse order extension data and persist metadata entity
      *
      * @param CartManagementInterface $subject
-     * @param OrderInterface $order
+     * @param OrderInterface|null $order
      * @return OrderInterface
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
     public function afterSubmit(
         CartManagementInterface $subject,
-        OrderInterface $order
+        ?OrderInterface $order
     ): OrderInterface {
-        /** @var OrderExtensionInterface $extensionAttributes */
-        $extensionAttributes = $order->getExtensionAttributes();
-        if ($extensionAttributes) {
-            if ($extensionAttributes->getTjTaxCalculationStatus()) {
-                $this->metadata->setOrderId($order->getEntityId());
-                $this->metadata->setTaxCalculationStatus($extensionAttributes->getTjTaxCalculationStatus());
-            }
-            if ($extensionAttributes->getTjTaxCalculationMessage()) {
-                $this->metadata->setOrderId($order->getEntityId());
-                $this->metadata->setTaxCalculationMessage($extensionAttributes->getTjTaxCalculationMessage());
-            }
-            if ($this->metadata->getOrderId() !== null) {
-                $this->metadataRepository->save($this->metadata);
+        if ($order instanceof OrderInterface) {
+            /** @var OrderExtensionInterface $extensionAttributes */
+            $extensionAttributes = $order->getExtensionAttributes();
+            if ($extensionAttributes) {
+                if ($extensionAttributes->getTjTaxCalculationStatus()) {
+                    $this->metadata->setOrderId($order->getEntityId());
+                    $this->metadata->setTaxCalculationStatus($extensionAttributes->getTjTaxCalculationStatus());
+                }
+                if ($extensionAttributes->getTjTaxCalculationMessage()) {
+                    $this->metadata->setOrderId($order->getEntityId());
+                    $this->metadata->setTaxCalculationMessage($extensionAttributes->getTjTaxCalculationMessage());
+                }
+                if ($this->metadata->getOrderId() !== null) {
+                    $this->metadataRepository->save($this->metadata);
+                }
             }
         }
         return $order;

--- a/Plugin/Quote/Model/QuoteManagement.php
+++ b/Plugin/Quote/Model/QuoteManagement.php
@@ -66,7 +66,7 @@ class QuoteManagement
     public function afterSubmit(
         CartManagementInterface $subject,
         ?OrderInterface $order
-    ): OrderInterface {
+    ): ?OrderInterface {
         if ($order instanceof OrderInterface) {
             /** @var OrderExtensionInterface $extensionAttributes */
             $extensionAttributes = $order->getExtensionAttributes();

--- a/Plugin/Quote/Model/QuoteManagement.php
+++ b/Plugin/Quote/Model/QuoteManagement.php
@@ -60,7 +60,7 @@ class QuoteManagement
      *
      * @param CartManagementInterface $subject
      * @param OrderInterface|null $order
-     * @return OrderInterface
+     * @return OrderInterface|null
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
     public function afterSubmit(

--- a/Test/Unit/Model/Tax/NexusSyncTest.php
+++ b/Test/Unit/Model/Tax/NexusSyncTest.php
@@ -263,7 +263,7 @@ class NexusSyncTest extends UnitTestCase
             ->method('loadByCode')
             ->withConsecutive(['TX', 'US'], ['', 'GB'])
             ->willReturnSelf();
-        $regionMock->expects(static::once())->method('getId')->willReturn(99);
+        $regionMock->expects(static::atLeast(2))->method('getId')->willReturn(99);
         $this->regionFactoryMock->expects(static::atLeast(2))->method('create')->willReturn($regionMock);
 
         $countryMock = $this->getMockBuilder(Country::class)->disableOriginalConstructor()->getMock();
@@ -271,26 +271,26 @@ class NexusSyncTest extends UnitTestCase
             ->method('loadByCode')
             ->withConsecutive(['US'], ['GB'])
             ->willReturnSelf();
-        $countryMock->expects(static::once())->method('getId')->willReturn(77);
+        $countryMock->expects(static::atLeast(2))->method('getId')->willReturn(77);
         $this->countryFactoryMock->expects(static::atLeast(2))->method('create')->willReturn($countryMock);
         $this->nexusResourceMock->expects(static::any())->method('getIdFieldName')->willReturn('id');
 
         $nexusResult = $this->getMockBuilder(Nexus::class)->disableOriginalConstructor()->getMock();
         $nexusResult->expects(static::any())->method('getIdFieldName')->willReturn('id');
-        $nexusResult->expects(static::atLeast(2))->method('getId')->willReturn(55);
-        $nexusResult->expects(static::atLeastOnce())->method('setData')->willReturnSelf();
-        $nexusResult->expects(static::atLeastOnce())->method('save')->willReturnSelf();
+        $nexusResult->expects(static::any())->method('getId')->willReturn(55);
+        $nexusResult->expects(static::any())->method('setData')->willReturnSelf();
+        $nexusResult->expects(static::any())->method('save')->willReturnSelf();
 
         $nexusCollectionMock = $this->getMockBuilder(Collection::class)->disableOriginalConstructor()->getMock();
-        $nexusCollectionMock->expects(static::once())->method('addRegionFilter')->willReturnSelf();
-        $nexusCollectionMock->expects(static::once())->method('addCountryFilter')->willReturnSelf();
-        $nexusCollectionMock->expects(static::atLeast(2))->method('getFirstItem')->willReturn($nexusResult);
+        $nexusCollectionMock->expects(static::once())->method('addFieldToFilter')->willReturnSelf();
+        $nexusCollectionMock->expects(static::once())->method('each')->willReturnSelf();
+        $nexusCollectionMock->expects(static::any())->method('getFirstItem')->willReturn($nexusResult);
 
         $nexusMock = $this->getMockBuilder(Nexus::class)->disableOriginalConstructor()->getMock();
         $nexusMock->expects(static::any())->method('getIdFieldName')->willReturn('id');
-        $nexusMock->expects(static::exactly(2))->method('getCollection')->willReturn($nexusCollectionMock);
+        $nexusMock->expects(static::exactly(1))->method('getCollection')->willReturn($nexusCollectionMock);
 
-        $this->nexusFactoryMock->expects(static::exactly(2))->method('create')->willReturn($nexusMock);
+        $this->nexusFactoryMock->expects(static::exactly(3))->method('create')->willReturn($nexusMock);
 
         $this->setExpectations();
         $this->sut->syncCollection();

--- a/Test/Unit/Plugin/Quote/Model/QuoteManagementTest.php
+++ b/Test/Unit/Plugin/Quote/Model/QuoteManagementTest.php
@@ -108,6 +108,19 @@ class QuoteManagementTest extends UnitTestCase
         static::assertSame($orderMock, $this->sut->afterSubmit($subjectMock, $orderMock));
     }
 
+    public function testAfterSubmitHandlesNullOrder()
+    {
+        $subjectMock = $this->getMockBuilder(CartManagementInterface::class)
+                            ->disableOriginalConstructor()
+                            ->getMock();
+
+        $orderMock = null;
+
+        $this->setExpectations();
+
+        static::assertNull($this->sut->afterSubmit($subjectMock, $orderMock));
+    }
+
     protected function setExpectations()
     {
         $this->sut = new QuoteManagement(


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Customer reported error with quote management plugin due to non nullable type hint.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Accounts for scenarios where we are unable to create an order either due to invalid cart data or other server issue.