### PR TITLE
Fix rendering of JS for syncable but not-yet-synced orders

### DIFF
--- a/view/adminhtml/templates/order/view/synced.phtml
+++ b/view/adminhtml/templates/order/view/synced.phtml
@@ -31,6 +31,7 @@ if ($synced) {
     <th><?= $block->escapeHtml(__('Synced to TaxJar')) ?></th>
     <td><?= $block->escapeHtml($orderSyncDate) ?></td>
 </tr>
+<?php endif; ?>
 <script>
     require([
         'jquery',
@@ -56,4 +57,3 @@ if ($synced) {
         };
     });
 </script>
-<?php endif; ?>


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Identified bug in phtml logic where a Sales Order that has yet to be synced or fails to sync, but has reached a syncable status will not render the necessary JS to manual sync order to TaxJar

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Moves PHP `endif` before JS script tag open so JS will render whether order has been synced or not.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
Break/fix

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Create sales order with TJ module disabled
2. Enable TJ module
3. Navigate to sales order
4. Click "Sync to TaxJar" button in actions panel, order is synced

#### Versions
<!-- What version(s) did you test this change on? -->
- [x] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (formerly Magento 2 Community Edition)
- [ ] Adobe Commerce (formerly Magento 2 Enterprise Edition)
<!-- What version of PHP did you test this change on? -->
- [ ] PHP 8.2
- [X] PHP 8.1
- [ ] PHP 7.4
- [ ] PHP 7.3
