### PR TITLE
Refactor access modifier to allow plugin-method support for…

### DIFF
--- a/Model/Transaction.php
+++ b/Model/Transaction.php
@@ -305,7 +305,7 @@ class Transaction
      * @param OrderInterface $order
      * @return string
      */
-    protected function getProvider($order): string
+    public function getProvider($order): string
     {
         $provider = 'api';
 


### PR DESCRIPTION
…Transaction::getProvider method

### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
When using 3P services to route external transactions through an M2 environment and into TaxJar, ii is sometimes necessary to override the API's transaction provider value.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Exposes Transaction::getProvider method as public to allow method override via plugin methods.

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (formerly Magento 2 Community Edition)
- [ ] Adobe Commerce (formerly Magento 2 Enterprise Edition)
<!-- What version of PHP did you test this change on? -->
- [ ] PHP 8.2
- [X] PHP 8.1
- [ ] PHP 7.4
- [ ] PHP 7.3
