### PR TITLE
Fix logging of failure on Customer removal

### DIFF
--- a/Plugin/Customer/Model/ResourceModel/CustomerRepository.php
+++ b/Plugin/Customer/Model/ResourceModel/CustomerRepository.php
@@ -6,6 +6,8 @@ use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Taxjar\SalesTax\Model\Client;
 use Taxjar\SalesTax\Model\ClientFactory;
+use Taxjar\SalesTax\Model\Configuration;
+use Taxjar\SalesTax\Model\Logger;
 
 class CustomerRepository
 {
@@ -15,11 +17,18 @@ class CustomerRepository
     private $clientFactory;
 
     /**
-     * @param ClientFactory $clientFactory
+     * @var Logger $logger
      */
-    public function __construct(ClientFactory $clientFactory)
+    protected $logger;
+
+    /**
+     * @param ClientFactory $clientFactory
+     * @param Logger $logger
+     */
+    public function __construct(ClientFactory $clientFactory, Logger $logger)
     {
         $this->clientFactory = $clientFactory;
+        $this->logger = $logger;
     }
 
     /**
@@ -38,7 +47,7 @@ class CustomerRepository
             $this->getClient()->deleteResource('customers', $customerId);
         } catch (LocalizedException $e) {
             $message = 'Could not delete customer #' . $customerId . ": " . $e->getMessage();
-            $this->logger->log($message, 'error');
+            $this->getLogger()->log($message, 'error');
         }
 
         return $customerId;
@@ -54,5 +63,17 @@ class CustomerRepository
         $client = $this->clientFactory->create();
         $client->showResponseErrors(true);
         return $client;
+    }
+
+    /**
+     * Returns our Logger instance configured to write to the TaxJar customer log.
+     *
+     * @return Logger
+     */
+    private function getLogger(): Logger
+    {
+        $logger = $this->logger;
+        $logger->setFilename(Configuration::TAXJAR_CUSTOMER_LOG);
+        return $logger;
     }
 }

--- a/Test/Unit/Plugin/Customer/Model/ResourceModel/CustomerRepositoryInterfaceTest.php
+++ b/Test/Unit/Plugin/Customer/Model/ResourceModel/CustomerRepositoryInterfaceTest.php
@@ -3,9 +3,12 @@
 namespace Taxjar\SalesTax\Test\Unit\Plugin\Customer\Model\ResourceModel;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\Exception\LocalizedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Taxjar\SalesTax\Model\Client;
 use Taxjar\SalesTax\Model\ClientFactory;
+use Taxjar\SalesTax\Model\Configuration;
+use Taxjar\SalesTax\Model\Logger;
 use Taxjar\SalesTax\Plugin\Customer\Model\ResourceModel\CustomerRepository;
 use Taxjar\SalesTax\Test\Unit\UnitTestCase;
 
@@ -21,11 +24,20 @@ class CustomerRepositoryInterfaceTest extends UnitTestCase
      */
     private $clientFactoryMock;
 
+    /**
+     * @var MockObject|Logger
+     */
+    private $loggerMock;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->clientFactoryMock = $this->getMockBuilder(ClientFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->loggerMock = $this->getMockBuilder(Logger::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -54,10 +66,37 @@ class CustomerRepositoryInterfaceTest extends UnitTestCase
         static::assertSame(123, $this->sut->beforeDeleteById($subjectMock, 123));
     }
 
+    public function testBeforeDeleteByIdFailureLogsError() {
+        $expectedMessage = 'Could not delete customer #123: Failed to initialize client';
+
+        $mockException = new LocalizedException(__('Failed to initialize client'));
+
+        $subjectMock = $this->getMockBuilder(CustomerRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->clientFactoryMock->expects(static::once())
+            ->method('create')
+            ->willThrowException($mockException);
+
+        $this->loggerMock->expects(static::once())
+            ->method('setFilename')
+            ->with(Configuration::TAXJAR_CUSTOMER_LOG);
+
+        $this->loggerMock->expects(static::once())
+            ->method('log')
+            ->with($expectedMessage);
+
+        $this->setExpectations();
+
+        static::assertSame(123, $this->sut->beforeDeleteById($subjectMock, 123));
+    }
+
     protected function setExpectations()
     {
         $this->sut = new CustomerRepository(
-            $this->clientFactoryMock
+            $this->clientFactoryMock,
+            $this->loggerMock
         );
     }
 }

--- a/Test/Unit/Plugin/Customer/Model/ResourceModel/CustomerRepositoryInterfaceTest.php
+++ b/Test/Unit/Plugin/Customer/Model/ResourceModel/CustomerRepositoryInterfaceTest.php
@@ -66,7 +66,8 @@ class CustomerRepositoryInterfaceTest extends UnitTestCase
         static::assertSame(123, $this->sut->beforeDeleteById($subjectMock, 123));
     }
 
-    public function testBeforeDeleteByIdFailureLogsError() {
+    public function testBeforeDeleteByIdFailureLogsError()
+    {
         $expectedMessage = 'Could not delete customer #123: Failed to initialize client';
 
         $mockException = new LocalizedException(__('Failed to initialize client'));


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Closes #353 

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Pre v2, TJ  interaction w/ Customer object used Observer classes which extended an abstract class where this logger was originally included. With changes to core code and deprecation of previously observed events, these interactions were migrated to use Plugins instead.

Although the happy-path was not affected by this bug, if TaxJar fails to delete a customer for some reason, the absence of a Logger in the CustomerRepository Plugin would not be able to log the error and would also cause the Magento customer deletion process to fail.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
N/A - bug fix

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
Added unit test coverage for changes

#### Versions
<!-- What version(s) did you test this change on? -->
- [X] Magento 2.4
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [X] Magento Open Source (formerly Magento 2 Community Edition)
- [ ] Adobe Commerce (formerly Magento 2 Enterprise Edition)
<!-- What version of PHP did you test this change on? -->
- [ ] PHP 8.2
- [X] PHP 8.1
- [ ] PHP 7.4
- [ ] PHP 7.3
