### PR TITLE
Replace dependency on Zend Client with Laminas Client

### DIFF
--- a/Model/Tax/Nexus/Repository.php
+++ b/Model/Tax/Nexus/Repository.php
@@ -183,12 +183,13 @@ class Repository implements \Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface
         $exception = new InputException();
         // @codingStandardsIgnoreEnd
 
-        if (!\Zend_Validate::is(trim((string) $nexus->getCountryId()), 'NotEmpty')) {
+        $validator = new \Laminas\Validator\NotEmpty();
+        if (!$validator->isValid(trim((string) $nexus->getCountryId()))) {
             $exception->addError(__('%fieldName is a required field.', ['fieldName' => Nexus::KEY_COUNTRY_ID]));
         }
 
         if (($nexus->getCountryId() == 'US' || $nexus->getCountryId() == 'CA') &&
-            !\Zend_Validate::is($nexus->getRegionId(), 'NotEmpty')) {
+            !$validator->isValid($nexus->getRegionId())) {
             $exception->addError(__('State can\'t be empty if country is US/Canada'));
         }
 

--- a/Setup/Patch/Data/AddExtensionAttributesPatch.php
+++ b/Setup/Patch/Data/AddExtensionAttributesPatch.php
@@ -116,7 +116,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface, PatchRevertable
 
     /**
      * @param \Magento\Eav\Setup\EavSetup $eavSetup
-     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Zend_Validate_Exception
+     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Laminas\Validator\Exception\RuntimeException
      */
     protected function createTjExemptionTypeAttribute($eavSetup)
     {
@@ -197,7 +197,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface, PatchRevertable
 
     /**
      * @param \Magento\Eav\Setup\EavSetup $eavSetup
-     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Zend_Validate_Exception
+     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Laminas\Validator\Exception\RuntimeException
      */
     protected function createTjRegionsAttribute($eavSetup)
     {
@@ -278,7 +278,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface, PatchRevertable
 
     /**
      * @param \Magento\Eav\Setup\EavSetup $eavSetup
-     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Zend_Validate_Exception
+     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Laminas\Validator\Exception\RuntimeException
      */
     protected function createTjLastSyncAttribute($eavSetup)
     {


### PR DESCRIPTION
### Context

The Zend Framework components are deprecated and should be removed from Magento extensions. The replacement library is the Laminas Framework.

Closes #358

### Description

These commits are direct line-for-line replacements of the deprecated Zend Framework components in exchange for their Laminas Framework counterparts. No additional logic or syntax has been altered. The included changes allow the extension to be used on Magento v2.4.6.

### Performance

N/A - deprecated code replacement

### Testing

N/A - no impact on the test suite

#### Versions

- [x] Magento 2.4
- [ ] Magento 2.3

- [x] Magento Open Source (formerly Magento 2 Community Edition)
- [ ] Adobe Commerce (formerly Magento 2 Enterprise Edition)

- [ ] PHP 8.2
- [x] PHP 8.1
- [ ] PHP 7.4
- [ ] PHP 7.3
