### PR TITLE
Remove Zend_Framework1

### DIFF
--- a/Model/Tax/Nexus/Repository.php
+++ b/Model/Tax/Nexus/Repository.php
@@ -24,10 +24,10 @@ use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException as ModelException;
-use Taxjar\SalesTax\Model\Tax\Nexus;
-use Taxjar\SalesTax\Model\Tax\NexusRegistry;
 use Taxjar\SalesTax\Model\ResourceModel\Tax\Nexus\Collection as NexusCollection;
 use Taxjar\SalesTax\Model\ResourceModel\Tax\Nexus\CollectionFactory as NexusCollectionFactory;
+use Taxjar\SalesTax\Model\Tax\Nexus;
+use Taxjar\SalesTax\Model\Tax\NexusRegistry;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -183,12 +183,16 @@ class Repository implements \Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface
         $exception = new InputException();
         // @codingStandardsIgnoreEnd
 
-        if (!\Zend_Validate::is(trim((string) $nexus->getCountryId()), 'NotEmpty')) {
+        // Create a validator chain and add validators to it
+        $validatorChain = new \Magento\Framework\Validator\ValidatorChain();
+        $validatorChain->attach(new \Magento\Framework\Validator\NotEmpty, true);
+
+        if (!$validatorChain->isValid(trim((string) $nexus->getCountryId()))) {
             $exception->addError(__('%fieldName is a required field.', ['fieldName' => Nexus::KEY_COUNTRY_ID]));
         }
 
         if (($nexus->getCountryId() == 'US' || $nexus->getCountryId() == 'CA') &&
-            !\Zend_Validate::is($nexus->getRegionId(), 'NotEmpty')) {
+            !$validatorChain->isValid($nexus->getRegionId())) {
             $exception->addError(__('State can\'t be empty if country is US/Canada'));
         }
 


### PR DESCRIPTION
* Replace all usage of deprecated `Zend_HTTP`
* Replace all usage of deprecated `Zend_Validator`

### Context
Make module compatible with Magento 2.4.6

### Description
Replace usages of `\Zend_*` classes with modern approaches

### Performance
Not tested

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Open Magento back-office
2. Start creating new order
3. Choose any customer
4. Add any product
5. Enter shipping address data
6. Click the link "Get available payment methods"

Expected Result: Payment methods loaded
Actual Result: No changes in view. XHR returns:
> Exception #0 (Exception): User Deprecated Functionality: Class is deprecated in /var/www/html/vendor/magento/framework/HTTP/ZendClient.php on line 27


#### Versions
<!-- What version(s) did you test this change on? -->
- [x] Magento 2.4.6
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [x] Magento Open Source (formerly Magento 2 Community Edition)
- [ ] Adobe Commerce (formerly Magento 2 Enterprise Edition)
<!-- What version of PHP did you test this change on? -->
- [ ] PHP 8.2
- [x] PHP 8.1
- [ ] PHP 7.4
- [ ] PHP 7.3
