### PR TITLE
Remove Zend for Magento 2.4.6

### DIFF
--- a/Model/Tax/Nexus/Repository.php
+++ b/Model/Tax/Nexus/Repository.php
@@ -24,6 +24,8 @@ use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException as ModelException;
+use Magento\Framework\Validator\NotEmpty;
+use Magento\Framework\Validator\ValidatorChain;
 use Taxjar\SalesTax\Model\Tax\Nexus;
 use Taxjar\SalesTax\Model\Tax\NexusRegistry;
 use Taxjar\SalesTax\Model\ResourceModel\Tax\Nexus\Collection as NexusCollection;
@@ -183,12 +185,12 @@ class Repository implements \Taxjar\SalesTax\Api\Tax\NexusRepositoryInterface
         $exception = new InputException();
         // @codingStandardsIgnoreEnd
 
-        if (!\Zend_Validate::is(trim((string) $nexus->getCountryId()), 'NotEmpty')) {
+        if (!ValidatorChain::is(trim((string)$nexus->getCountryId()), NotEmpty::class)) {
             $exception->addError(__('%fieldName is a required field.', ['fieldName' => Nexus::KEY_COUNTRY_ID]));
         }
 
-        if (($nexus->getCountryId() == 'US' || $nexus->getCountryId() == 'CA') &&
-            !\Zend_Validate::is($nexus->getRegionId(), 'NotEmpty')) {
+        if (in_array($nexus->getCountryId(), ['US', 'CA']) &&
+            !ValidatorChain::is($nexus->getRegionId(), NotEmpty::class)) {
             $exception->addError(__('State can\'t be empty if country is US/Canada'));
         }
 

--- a/Setup/Patch/Data/AddExtensionAttributesPatch.php
+++ b/Setup/Patch/Data/AddExtensionAttributesPatch.php
@@ -116,7 +116,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface, PatchRevertable
 
     /**
      * @param \Magento\Eav\Setup\EavSetup $eavSetup
-     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Zend_Validate_Exception
+     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Laminas\Validator\Exception\RuntimeException
      */
     protected function createTjExemptionTypeAttribute($eavSetup)
     {
@@ -197,7 +197,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface, PatchRevertable
 
     /**
      * @param \Magento\Eav\Setup\EavSetup $eavSetup
-     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Zend_Validate_Exception
+     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Laminas\Validator\Exception\RuntimeException
      */
     protected function createTjRegionsAttribute($eavSetup)
     {
@@ -278,7 +278,7 @@ class AddExtensionAttributesPatch implements DataPatchInterface, PatchRevertable
 
     /**
      * @param \Magento\Eav\Setup\EavSetup $eavSetup
-     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Zend_Validate_Exception
+     * @throws \Magento\Framework\Exception\AlreadyExistsException|\Magento\Framework\Exception\LocalizedException|\Laminas\Validator\Exception\RuntimeException
      */
     protected function createTjLastSyncAttribute($eavSetup)
     {


### PR DESCRIPTION
### Context
Because https://github.com/taxjar/taxjar-magento2-extension/issues/358 and https://github.com/taxjar/taxjar-magento2-extension/pull/360 still not update.

### Description
- Use `Magento\Framework\HTTP\LaminasClient` (Magento 2.4.6 and above) to replace `Zend_Http_Client` 
- In my dev env, set the adapter to `Laminas\Http\Client\Adapter\Socket` is necessary, and the default adapter is `Magento\Framework\HTTP\Adapter\Curl` that is missing pass some header (include `Authorization`). So I got the 401 for Unauthorized

```php
# My test code for debug
$om = \Magento\Framework\App\ObjectManager::getInstance();
$clientFactory = $om->get(\Magento\Framework\HTTP\LaminasClientFactory::class);
$client = $clientFactory->create();

$method = 'POST';
$apiKey = 'fake_key';
$url = 'https://httpbin.org/post';
$data = [
  'city' => 'Irving',
  'country' => 'US',
  'state' => 'TX',
  'street' => '101 No Steet',
  'zip' => '77777',
];

$client->setUri($url);
$client->setMethod($method);
$client->setHeaders([
    'Authorization' => 'Bearer ' . $apiKey,
    'x-api-version' => 'FAKE_VERSION',
    'Referer' => 'https://www.taxjar.com/'
]);
$client->setOptions([
  'timeout' => 30,
  'useragent' => 'my UA'
]);
$client->setRawBody(json_encode($data));
$client->setEncType('application/json');

echo $client->send();

$output = <<<OUTPUT
{
  "args": {},
  "data": "",
  "files": {},
  "form": {
    "{\"city\":\"Irving\",\"country\":\"US\",\"state\":\"TX\",\"street\":\"101 No Steet\",\"zip\":\"77777\"}": ""
  },
  "headers": {
    "Accept": "*/*",
    "Content-Length": "83",
    "Content-Type": "application/x-www-form-urlencoded",
    "Host": "httpbin.org",
    "Https": "//www.taxjar.com/",
    "User-Agent": "my UA",
    "X-Amzn-Trace-Id": "Root=1-647a40aa-44948c4f575e30814c965143"
  },
  "json": null,
  "origin": "MY_IP_ADDRESS",
  "url": "https://httpbin.org/post"
}
OUTPUT;

# Set Adapter for Authorization header
$client->setAdapter(\Laminas\Http\Client\Adapter\Socket::class);
echo $client->send();

$output = <<<OUTPUT
{
  "args": {},
  "data": "{\"city\":\"Irving\",\"country\":\"US\",\"state\":\"TX\",\"street\":\"101 No Steet\",\"zip\":\"77777\"}",
  "files": {},
  "form": {},
  "headers": {
    "Accept-Encoding": "gzip, deflate",
    "Authorization": "Bearer fake_key",
    "Content-Length": "83",
    "Content-Type": "application/json",
    "Host": "httpbin.org",
    "Referer": "https://www.taxjar.com/",
    "User-Agent": "my UA",
    "X-Amzn-Trace-Id": "Root=1-647a40c7-346b48df0919db53041d4158",
    "X-Api-Version": "FAKE_VERSION"
  },
  "json": {
    "city": "Irving",
    "country": "US",
    "state": "TX",
    "street": "101 No Steet",
    "zip": "77777"
  },
  "origin": "MY_IP_ADDRESS",
  "url": "https://httpbin.org/post"
}
OUTPUT;
```


- BTW, the best practice is using `Magento\Framework\HTTP\ClientInterface`, but it does not provide `PUT` and `DELETE` method interfaces. 🙁


### Performance
N/A

### Testing
N/A

#### Versions
<!-- What version(s) did you test this change on? -->
- [x] Magento 2.4.6
- [ ] Magento 2.3
<!-- What edition(s) of Magento did you test this change on? -->
- [x] Magento Open Source (formerly Magento 2 Community Edition)
- [x] Adobe Commerce (formerly Magento 2 Enterprise Edition)
<!-- What version of PHP did you test this change on? -->
- [x] PHP 8.2
- [x] PHP 8.1
- [ ] PHP 7.4
- [ ] PHP 7.3
