### PR TITLE
Version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.0.0] - 2025-08-25
+- Add support for Magento 2.4.8 with framework ^103.0.8
+- Add PHP 8.3 compatibility (drops PHP 8.2 support)
+- Add PHPUnit 10.* compatibility
+- Fix Braintree module double-prefixing bug in sales grid filters
+
 ## [3.0.0] - 2025-04-24
 - Fix issue with uncreated customer attributes
 
@@ -313,7 +319,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Initial release of our Magento 2 extension.** Sales tax calculations at checkout with backup zip-based rates powered by TaxJar. Supports product exemptions, shipping taxability, sourcing logic, and international calculations in more than 30 countries.
 - **Special promo sales tax calculations for Magento merchants.** Existing M2 beta users must upgrade to this version to receive special promo calculations at checkout using our new API endpoint.
 
-[Unreleased]: https://github.com/taxjar/taxjar-magento2-extension/compare/v2.2.0..HEAD
+[Unreleased]: https://github.com/taxjar/taxjar-magento2-extension/compare/v4.0.0..HEAD
+[4.0.0]: https://github.com/taxjar/taxjar-magento2-extension/compare/v3.0.0...v4.0.0
 [3.0.0]: https://github.com/taxjar/taxjar-magento2-extension/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/taxjar/taxjar-magento2-extension/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/taxjar/taxjar-magento2-extension/compare/v2.0.0...v2.1.0

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -24,7 +24,7 @@ use Magento\Tax\Model\Config as MagentoTaxConfig;
 
 class Configuration
 {
-    const TAXJAR_VERSION                    = '3.0.0';
+    const TAXJAR_VERSION                    = '4.0.0';
     const TAXJAR_AUTH_URL                   = 'https://app.taxjar.com';
     const TAXJAR_API_URL                    = 'https://api.taxjar.com/v2';
     const TAXJAR_SANDBOX_API_URL            = 'https://api.sandbox.taxjar.com/v2';

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "taxjar/module-taxjar",
     "description": "TaxJar Sales Tax Module for Magento 2",
     "type": "magento2-module",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "license": "OSL-3.0",
     "require": {
         "magento/framework": "^103.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "module-taxjar",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "TaxJar Sales Tax Module for Magento 2",
   "scripts": {
     "build": "zip -r Taxjar_SalesTax-${npm_package_version}.zip ./ -x \"package.json\" \".git/*\" \".github/*\" \".gitignore\" \"vendor/*\" \"Test/Integration/credentials.php\" \".travis.yml\" \".vscode/*\" \".DS_Store\" \".idea\" \".editorconfig\""


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->

Version bump after the magento 2.4.8 and php8.3 upgrade. Related PR is here: https://github.com/taxjar/taxjar-magento2-extension/pull/384. This upgrade is not compatible with php8.2 and thus with lower versions of the magento as well. Thus is a major release.